### PR TITLE
Fixing debug build errors caused by NetCoreCheck dependency

### DIFF
--- a/src/clickonce/native/projects/NetCoreCheck/CMakeLists.txt
+++ b/src/clickonce/native/projects/NetCoreCheck/CMakeLists.txt
@@ -22,6 +22,7 @@ add_definitions(-DUNICODE)
 add_definitions(-D_UNICODE)
 add_definitions(-DFEATURE_APPHOST=1)
 add_definitions(-DNETHOST_USE_AS_STATIC)
+remove_definitions(-D_DEBUG)
 
 target_link_libraries(NetCoreCheck
         shlwapi.lib

--- a/src/clickonce/native/projects/common.cmake
+++ b/src/clickonce/native/projects/common.cmake
@@ -5,9 +5,7 @@
 project(${DOTNET_PROJECT_NAME})
 
 if(CLR_CMAKE_HOST_WIN32)
-    add_compile_options($<$<CONFIG:RelWithDebInfo>:/MT>)
-    add_compile_options($<$<CONFIG:Release>:/MT>)
-    add_compile_options($<$<CONFIG:Debug>:/MTd>)
+    add_compile_options(/MT)
 else()
     add_compile_options(-fvisibility=hidden)
 endif()


### PR DESCRIPTION
- Using compile option MT instead of MTd for debug
- Disabling _DEBUG during NetCoreCheck build