### PR TITLE
Add ClickOnce Launcher

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -6,3 +6,4 @@
 ;; Examples:
 ;;  *apphost.exe;;Template, https://github.com/dotnet/core-setup/pull/7549
 ;;  *apphosttemplateapphostexe.exe;;Template, https://github.com/dotnet/core-setup/pull/7549
+*launcher.exe;;Template

--- a/src/clickonce/launcher/Constants.cs
+++ b/src/clickonce/launcher/Constants.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Deployment.Launcher
+{
+    public static class Constants
+    {
+        // Logging - registry keys/values
+        public static readonly string ClickOnceDeploymentSubkeyName = @"SOFTWARE\Classes\Software\Microsoft\Windows\CurrentVersion\Deployment";
+        public static readonly string LauncherLogFilePathRegistryString = "LauncherLogFilePath";
+
+        // Error messages
+        public static readonly string ErrorApplicationFilenameCannotBeEmpty = "Filenname cannot be empty.";
+        public static readonly string ErrorApplicationFilenameCannotIncludeAPath = "Filename cannot include a path.";
+        public static readonly string ErrorApplicationAssemblyIdentity = "Cannot obtain assembly identity from application binary: {0}";
+        public static readonly string ErrorInvalidStartProcessWithRetryParameters = "Invalid StartProcessWithRetry() parameters.";
+        public static readonly string ErrorNotAClickOnceDeployment = "Launcher cannot be run outside of a ClickOnce deployment.";
+        public static readonly string ErrorProcessFailedToLaunch = "Failed to launch \"{0}\" {1}";
+        public static readonly string ErrorProcessStart = "Failed to start the process with error: {0}";
+        public static readonly string ErrorProcessNotStarted = "Process did not start.";
+        public static readonly string ErrorResourceMissing = "Resource does not exist: {0}";
+        public static readonly string ErrorResourceFailedToLoad = "LoadResource() failed to read the resource: {0}";
+        public static readonly string ErrorResourceFailedToLock = "LockResource() failed to lock the resource for reading: {0}";
+        public static readonly string ErrorUnsupportedExtension = "Filename has unsupported extension: {0}";
+
+        // Info/status messages
+        public static readonly string InfoLauncherPath = "Launcher path: {0}";
+        public static readonly string InfoProcessStartWaitRetry = "Waiting {0} miliseconds before retrying...";
+        public static readonly string InfoProcessToLaunch = "Launching: \"{0}\" {1}";
+
+        // Various constants
+
+        // We do not currently retry - this matches the ClickOnce model of launching apps.
+        // If this decision changes, the number of attempts and delay should be modified accordingly.
+        public static readonly int NumberOfProcessStartAttempts = 1; 
+        public static readonly int DelayBeforeRetryMiliseconds = 1000;
+    }
+}

--- a/src/clickonce/launcher/Constants.cs
+++ b/src/clickonce/launcher/Constants.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Deployment.Launcher
         public static readonly string LauncherLogFilePathRegistryString = "LauncherLogFilePath";
 
         // Error messages
-        public static readonly string ErrorApplicationFilenameCannotBeEmpty = "Filenname cannot be empty.";
+        public static readonly string ErrorApplicationFilenameCannotBeEmpty = "Filename cannot be empty.";
         public static readonly string ErrorApplicationFilenameCannotIncludeAPath = "Filename cannot include a path.";
         public static readonly string ErrorApplicationAssemblyIdentity = "Cannot obtain assembly identity from application binary: {0}";
         public static readonly string ErrorInvalidStartProcessWithRetryParameters = "Invalid StartProcessWithRetry() parameters.";

--- a/src/clickonce/launcher/HostFinder.cs
+++ b/src/clickonce/launcher/HostFinder.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Deployment.Utilities;
+
+namespace Microsoft.Deployment.Launcher
+{
+    internal static class HostFinder
+    {
+        /// <summary>
+        /// Gets full path to .NET host appropriate for activating the application.
+        /// 
+        /// .NET host'slocation can be obtained from multiple locations.
+        ///
+        /// Current code searches in default, global shared runtime, location only:
+        /// %ProgramFiles%\dotnet and %ProgramFiles(x86)%\dotnet
+        /// 
+        /// Consider adding support for other non-standard registrations of host location.
+        /// 1) Environment variables: DOTNET_ROOT or DOTNET_ROOT(x86)
+        /// 2) Registry: HKLM\SOFTWARE\dotnet\Setup\InstalledVersions\{arch}\[InstallLocation]
+        /// 
+        /// Order of search should eventually be:
+        /// 1) Environment variables
+        /// 2) Registry
+        /// 3) Global location
+        /// </summary>
+        /// <param name="applicationFilePath">Full path to application</param>
+        /// <returns></returns>
+        internal static string GetHost(string applicationFilePath)
+        {
+            string arch = GetProcessorArchitectureFromAssembly(applicationFilePath);
+
+            if (arch == "x86")
+            {
+                return GetX86Host();
+            }
+            else if (arch == "amd64" || arch == "arm64")
+            {
+                return Get64bitHost();
+            }
+            else if (arch == "msil")
+            {
+                string host = Get64bitHost();
+                return string.IsNullOrEmpty(host) ? GetX86Host() : host;
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Gets ProgramFiles folder for the specified bitness.
+        /// </summary>
+        /// <param name="is64bit">If 64-bit bitness is required</param>
+        /// <returns></returns>
+        private static string GetProgramFilesFolder(bool is64bit = false)
+        {
+            return is64bit ?
+                (Environment.Is64BitProcess ?
+                    Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles) :
+                    Environment.GetEnvironmentVariable("ProgramW6432")) :
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+        }
+
+        /// <summary>
+        /// Get global host if it exists, for the specified bitness.
+        /// </summary>
+        /// <param name="is64bit">If 64-bit bitness is required</param>
+        /// <returns></returns>
+        private static string GetGlobalHost(bool is64bit = false)
+        {
+            string folder = GetProgramFilesFolder(is64bit);
+            string host = !string.IsNullOrEmpty(folder) ? Path.Combine(folder, "dotnet\\dotnet.exe") : string.Empty;
+            return File.Exists(host) ? host : string.Empty;
+        }
+
+        /// <summary>
+        /// Gets full path to x86 .NET host.
+        /// </summary>
+        /// <returns>X86 host</returns>
+        private static string GetX86Host()
+        {
+            return GetGlobalHost();
+        }
+
+        /// <summary>
+        /// Gets full path to 64-bit .NET host.
+        /// </summary>
+        /// <returns>64-bit host</returns>
+        private static string Get64bitHost()
+        {
+            return Environment.Is64BitOperatingSystem ? GetGlobalHost(true) : string.Empty;
+        }
+
+        /// <summary>
+        /// Gets processor architecture from assembly metadata. Throws for non-managed binaries.
+        /// </summary>
+        /// <param name="path">Assembly path</param>
+        /// <returns></returns>
+        private static string GetProcessorArchitectureFromAssembly(string path)
+        {
+            Guid riid = GetGuidOfType(typeof(NativeMethods.IReferenceIdentity));
+            NativeMethods.IReferenceIdentity refid = (NativeMethods.IReferenceIdentity)NativeMethods.GetAssemblyIdentityFromFile(path, ref riid);
+            if (refid == null)
+            {
+                throw new LauncherException(Constants.ErrorApplicationAssemblyIdentity, path);
+            }
+
+            string processorArchitecture = refid.GetAttribute(null, "processorArchitecture");
+            processorArchitecture =
+                !string.IsNullOrEmpty(processorArchitecture) ?
+                processorArchitecture.ToLowerInvariant() :
+                "msil";
+
+            return processorArchitecture;
+        }
+
+        private static Guid GetGuidOfType(Type type)
+        {
+            var guidAttr = (GuidAttribute)Attribute.GetCustomAttribute(type, typeof(GuidAttribute), false);
+            return new Guid(guidAttr.Value);
+        }
+    }
+}

--- a/src/clickonce/launcher/HostFinder.cs
+++ b/src/clickonce/launcher/HostFinder.cs
@@ -101,8 +101,8 @@ namespace Microsoft.Deployment.Launcher
         /// <returns></returns>
         private static string GetProcessorArchitectureFromAssembly(string path)
         {
-            Guid riid = GetGuidOfType(typeof(NativeMethods.IReferenceIdentity));
-            NativeMethods.IReferenceIdentity refid = (NativeMethods.IReferenceIdentity)NativeMethods.GetAssemblyIdentityFromFile(path, ref riid);
+            Guid riid = GetGuidOfType(typeof(NativeMethods.Clr.IReferenceIdentity));
+            NativeMethods.Clr.IReferenceIdentity refid = (NativeMethods.Clr.IReferenceIdentity)NativeMethods.Clr.GetAssemblyIdentityFromFile(path, ref riid);
             if (refid == null)
             {
                 throw new LauncherException(Constants.ErrorApplicationAssemblyIdentity, path);

--- a/src/clickonce/launcher/Launcher.csproj
+++ b/src/clickonce/launcher/Launcher.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Launcher</AssemblyName>
+    <OutputType>WinExe</OutputType>
+    <TargetFrameworks>net45</TargetFrameworks>
+    <NoWin32Manifest>true</NoWin32Manifest>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System.Deployment" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Shared\NativeMethods.cs" />
+  </ItemGroup>
+</Project>

--- a/src/clickonce/launcher/LauncherException.cs
+++ b/src/clickonce/launcher/LauncherException.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Deployment.Launcher
+{
+    [Serializable]
+    public class LauncherException : Exception
+    {
+        public LauncherException()
+        {
+        }
+
+        public LauncherException(string message)
+            : base(message)
+        {
+        }
+
+        public LauncherException(string format, params object[] args)
+            : base(string.Format(format, args))
+        {
+        }
+
+        public LauncherException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected LauncherException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/clickonce/launcher/Logger.cs
+++ b/src/clickonce/launcher/Logger.cs
@@ -1,0 +1,154 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Deployment.Launcher
+{
+    internal class Logger
+    {
+        private static bool AppendToExistingLog = true;
+        private static Logger Instance = new Logger();
+
+        internal StreamWriter Writer { get; private set; }
+
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        private Logger()
+        {
+            Writer = null;
+        }
+
+        /// <summary>
+        /// Constructor that instantiates a new object with provided StreamWriter.
+        /// </summary>
+        /// <param name="sw">StreaWriter object</param>
+        private Logger(StreamWriter sw)
+        {
+            Writer = sw;
+        }
+
+        /// <summary>
+        /// Writes text message to log file.
+        /// </summary>
+        /// <param name="message">Text message</param>
+        private void WriteLine(string message)
+        {
+            if (Writer != null)
+            {
+                Writer.WriteLine(message);
+            }
+        }
+
+        /// <summary>
+        /// Logs header text of new Launcher instance.
+        /// </summary>
+        internal void LogInstanceHeader()
+        {
+            LogInfo(DateTime.Now.ToString());
+        }
+
+        /// <summary>
+        /// Logs footer text.
+        /// </summary>
+        private static void LogInstanceFooter()
+        {
+            LogInfo("");
+        }
+
+        /// <summary>
+        /// Closes logger, which closes StreamWriter if it exists.
+        /// </summary>
+        private void Close()
+        {
+            if (Writer != null)
+            {
+                LogInstanceFooter();
+                Writer.Close();
+                Writer = null;
+            }
+        }
+
+        /// <summary>
+        /// Starts logging, using new StreamReader, and updates the Instance object.
+        /// </summary>
+        /// <param name="path"></param>
+        internal static void StartLogging(string path)
+        {
+            if (Instance.Writer != null || string.IsNullOrEmpty(path))
+            {
+                return;
+            }
+
+            try
+            {
+                StreamWriter sw = new StreamWriter(path, AppendToExistingLog);
+                Instance = new Logger(sw);
+                Instance.LogInstanceHeader();
+            }
+            catch (Exception)
+            {
+                // Failed to open the log file.
+                // Logging is optional, do not fail the Launcher.
+            }
+        }
+
+        /// <summary>
+        /// Stops logging.
+        /// </summary>
+        internal static void StopLogging()
+        {
+            Instance.Close();
+        }
+
+        /// <summary>
+        /// Logs an info message with specified string format and optional arguments.
+        /// </summary>
+        /// <param name="format">String format</param>
+        /// <param name="args">Arguments</param>
+        internal static void LogInfo(string format, params object[] args)
+        {
+            LogInfo(string.Format(format, args));
+        }
+
+        /// <summary>
+        /// Logs an info message.
+        /// </summary>
+        /// <param name="info"></param>
+        internal static void LogInfo(string info)
+        {
+            string[] ss = info.Split('\n');
+
+            foreach (string line in ss)
+            {
+                Instance.WriteLine(line);
+            }
+        }
+
+        /// <summary>
+        /// Logs an error message with specified string format and optional arguments.
+        /// </summary>
+        /// <param name="format">String format</param>
+        /// <param name="args">Arguments</param>
+        internal static void LogError(string format, params object[] args)
+        {
+            LogError(string.Format(format, args));
+        }
+
+        /// <summary>
+        /// Logs an error message.
+        /// </summary>
+        /// <param name="error">Error message</param>
+        internal static void LogError(string error)
+        {
+            string[] ss = error.Split('\n');
+
+            foreach (string line in ss)
+            {
+                Instance.WriteLine("*** Error: " + line);
+            }
+        }
+    }
+}

--- a/src/clickonce/launcher/ProcessHelper.cs
+++ b/src/clickonce/launcher/ProcessHelper.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.Deployment.Launcher
+{
+    internal class ProcessHelper
+    {
+        private readonly ProcessStartInfo psi;
+
+        /// <summary>
+        /// ProcessHelper constructor
+        /// </summary>
+        /// <param name="exe">Executable name</param>
+        /// <param name="args">Arguments</param>
+        public ProcessHelper(string exe, string args)
+        {
+            psi = new ProcessStartInfo(exe, args)
+            {
+                UseShellExecute = false
+            };
+        }
+
+        /// <summary>
+        /// Starts the process, with retries.
+        /// Number of attempts and delay are specified in Constants class.
+        /// </summary>
+        public void StartProcessWithRetries()
+        {
+            Logger.LogInfo(Constants.InfoProcessToLaunch, psi.FileName, psi.Arguments);
+            int count = 1;
+            while (true)
+            {
+                try
+                {
+                    StartProcess();
+                    return;
+                }
+                catch (Exception e)
+                {
+                    // Log each failure attempt
+                    Logger.LogError(Constants.ErrorProcessStart, e.Message);
+
+                    if (count++ < Constants.NumberOfProcessStartAttempts)
+                    {
+                        Logger.LogInfo(Constants.InfoProcessStartWaitRetry, Constants.DelayBeforeRetryMiliseconds);
+                        Thread.Sleep(Constants.DelayBeforeRetryMiliseconds);
+                        continue;
+                    }
+                    else
+                    {
+                        Logger.LogError(Constants.ErrorProcessFailedToLaunch, psi.FileName, psi.Arguments);
+                        throw;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Starts the process.
+        /// </summary>
+        private void StartProcess()
+        {
+            if (null == Process.Start(psi))
+            {
+                throw new LauncherException(Constants.ErrorProcessNotStarted);
+            }
+        }
+    }
+}

--- a/src/clickonce/launcher/Program.cs
+++ b/src/clickonce/launcher/Program.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Win32;
+using System;
+using System.Deployment.Application;
+using System.IO;
+
+namespace Microsoft.Deployment.Launcher
+{
+    static class Program
+    {
+        /// <summary>
+        /// The main entry point for the application.
+        /// </summary>
+        [STAThread]
+        static void Main()
+        {
+            try
+            {
+                StartLoggingIfConfigured();
+
+                // Allow running as a ClickOnce app only.
+                if (false == ApplicationDeployment.IsNetworkDeployed)
+                {
+                    throw new LauncherException(Constants.ErrorNotAClickOnceDeployment);
+                }
+
+                Launch(GetApplicationPath());
+
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e.Message);
+            }
+            finally
+            {
+                Logger.StopLogging();
+            }
+        }
+
+        /// <summary>
+        /// Launches .NET (Core) application.
+        /// </summary>
+        /// <param name="appToLaunchFullPath">Full path to application binary</param>
+        private static void Launch(string appToLaunchFullPath)
+        {
+            string exe;
+            string args;
+
+            string extension = Path.GetExtension(appToLaunchFullPath).ToLower();
+            if (extension == ".dll")
+            {
+                exe = HostFinder.GetHost(appToLaunchFullPath);
+                args = appToLaunchFullPath.DoubleQuoted();
+            }
+            else if (extension == ".exe")
+            {
+                exe = appToLaunchFullPath;
+                args = string.Empty;
+            }
+            else
+            {
+                // Desktop .NET (Core) applications on Windows can only be EXEs or DLLs.
+                throw new LauncherException(Constants.ErrorUnsupportedExtension, appToLaunchFullPath);
+            }
+
+            ProcessHelper ph = new ProcessHelper(exe, args);
+            ph.StartProcessWithRetries();
+        }
+
+        /// <summary>
+        /// Gets the full path to the application from Launcher resources.
+        /// Validates application filename value.
+        /// </summary>
+        /// <returns>Full path of app to launch.</returns>
+        private static string GetApplicationPath()
+        {
+            string launcherPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            Logger.LogInfo(Constants.InfoLauncherPath, launcherPath);
+
+            string applicationFilename = ResourceReader.GetApplicationFilename(launcherPath);
+            if (string.IsNullOrEmpty(applicationFilename))
+            {
+                throw new LauncherException(Constants.ErrorApplicationFilenameCannotBeEmpty);
+            }
+
+            // Application filename cannot include paths, it has to be in the same folder as Launcher.
+            // We prohibit launching anything outside of app's ClickOnce folder.
+            if (string.Compare(applicationFilename, Path.GetFileName(applicationFilename), StringComparison.InvariantCultureIgnoreCase) != 0)
+            {
+                throw new LauncherException(Constants.ErrorApplicationFilenameCannotIncludeAPath);
+            }
+
+            return Path.Combine(Path.GetDirectoryName(launcherPath), applicationFilename);
+        }
+
+        /// <summary>
+        /// Starts logging if configured in registry.
+        /// User sets the log file path, which enables logging.
+        /// This model follows the existing ClickOnce runtime logging.
+        /// </summary>
+        private static void StartLoggingIfConfigured()
+        {
+            string path = null;
+
+            try
+            {
+                using (RegistryKey deploymentKey = Registry.CurrentUser.OpenSubKey(Constants.ClickOnceDeploymentSubkeyName))
+                {
+                    /// Deployment key may not be present.
+                    if (deploymentKey != null)
+                    {
+                        path = deploymentKey.GetValue(Constants.LauncherLogFilePathRegistryString) as string;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Logging is optional, do not fail the Launcher.
+            }
+
+            if (!string.IsNullOrEmpty(path))
+            {
+                Logger.StartLogging(path);
+            }
+        }
+
+        /// <summary>
+        /// Gets the text enclosed in double quotes.
+        /// </summary>
+        /// <param name="text">Text</param>
+        /// <returns></returns>
+        private static string DoubleQuoted(this string text)
+        {
+            return "\"" + text + "\"";
+        }
+    }
+}

--- a/src/clickonce/launcher/Program.cs
+++ b/src/clickonce/launcher/Program.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Deployment.Launcher
         [STAThread]
         static void Main()
         {
+            StartLoggingIfConfigured();
+
             try
             {
-                StartLoggingIfConfigured();
-
                 // Allow running as a ClickOnce app only.
                 if (false == ApplicationDeployment.IsNetworkDeployed)
                 {

--- a/src/clickonce/launcher/ResourceReader.cs
+++ b/src/clickonce/launcher/ResourceReader.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Deployment.Utilities;
+
+namespace Microsoft.Deployment.Launcher
+{
+    internal static class ResourceReader
+    {
+        /// <summary>
+        /// Gets the name of the application, from the custom resource.
+        /// </summary>
+        /// <param name="path">Path to file from which to read the resource.</param>
+        /// <returns>Application filename</returns>
+        public static string GetApplicationFilename(string path)
+        {
+            return ReadString(path, NativeMethods.Launcher_CustomResourceTypePtr, NativeMethods.Launcher_ResourceName);
+        }
+
+        /// <summary>
+        /// Reads resource string from a resource type.
+        /// </summary>
+        /// <param name="path">Path to file from which to read the resource</param>
+        /// <param name="type">Resource type</param>
+        /// <param name="name">Resource name</param>
+        /// <returns>Resource value</returns>
+        private static string ReadString(string path, IntPtr type, string name)
+        {
+            IntPtr hModule = IntPtr.Zero;
+            string binaryToLaunch = string.Empty;
+
+            try
+            {
+                hModule = NativeMethods.LoadLibraryExW(path, IntPtr.Zero, NativeMethods.LOAD_LIBRARY_AS_DATAFILE);
+                if (hModule != IntPtr.Zero)
+                {
+                    binaryToLaunch = GetResourceString(hModule, type, name);
+                }
+            }
+            finally
+            {
+                if (hModule != IntPtr.Zero)
+                {
+                    NativeMethods.FreeLibrary(hModule);
+                }
+            }
+
+            return binaryToLaunch;
+        }
+
+        /// <summary>
+        /// Gets the value of a resource string from module.
+        /// </summary>
+        /// <param name="hModule">Module handle</param>
+        /// <param name="pType">Resource type</param>
+        /// <param name="pName">Resource name</param>
+        /// <returns>Resource value</returns>
+        private static string GetResourceString(IntPtr hModule, IntPtr pType, string pName)
+        {
+            string value = string.Empty;
+            IntPtr hResInfo = NativeMethods.FindResource(hModule, pName, pType);
+            if (hResInfo == IntPtr.Zero)
+            {
+                throw new LauncherException(Constants.ErrorResourceMissing, pName);
+            }
+
+            IntPtr hResource = NativeMethods.LoadResource(hModule, hResInfo);
+            if (hResource == IntPtr.Zero)
+            {
+                throw new LauncherException(Constants.ErrorResourceFailedToLoad, pName);
+            }
+
+            IntPtr hResLock = NativeMethods.LockResource(hResource);
+            if (hResLock == IntPtr.Zero)
+            {
+                throw new LauncherException(Constants.ErrorResourceFailedToLock, pName);
+            }
+
+            uint bufsize = NativeMethods.SizeofResource(hModule, hResInfo);
+            byte[] buffer = new byte[bufsize];
+
+            Marshal.Copy(hResource, buffer, 0, buffer.Length);
+            value = Encoding.Unicode.GetString(buffer, 0, buffer.Length);
+
+
+            // Strip all leading or trailing '\0' characters.
+            // Trailing '\0' is always added by Visual Studio and Mage tool.
+
+            return value.Trim('\0');
+        }
+    }
+}

--- a/src/clickonce/launcher/ResourceReader.cs
+++ b/src/clickonce/launcher/ResourceReader.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Deployment.Launcher
 
             try
             {
-                hModule = NativeMethods.LoadLibraryExW(path, IntPtr.Zero, NativeMethods.LOAD_LIBRARY_AS_DATAFILE);
+                hModule = NativeMethods.Kernel32.LoadLibraryExW(path, IntPtr.Zero, NativeMethods.Kernel32.LOAD_LIBRARY_AS_DATAFILE);
                 if (hModule != IntPtr.Zero)
                 {
                     binaryToLaunch = GetResourceString(hModule, type, name);
@@ -44,7 +44,7 @@ namespace Microsoft.Deployment.Launcher
             {
                 if (hModule != IntPtr.Zero)
                 {
-                    NativeMethods.FreeLibrary(hModule);
+                    NativeMethods.Kernel32.FreeLibrary(hModule);
                 }
             }
 
@@ -61,25 +61,25 @@ namespace Microsoft.Deployment.Launcher
         private static string GetResourceString(IntPtr hModule, IntPtr pType, string pName)
         {
             string value = string.Empty;
-            IntPtr hResInfo = NativeMethods.FindResource(hModule, pName, pType);
+            IntPtr hResInfo = NativeMethods.Kernel32.FindResource(hModule, pName, pType);
             if (hResInfo == IntPtr.Zero)
             {
                 throw new LauncherException(Constants.ErrorResourceMissing, pName);
             }
 
-            IntPtr hResource = NativeMethods.LoadResource(hModule, hResInfo);
+            IntPtr hResource = NativeMethods.Kernel32.LoadResource(hModule, hResInfo);
             if (hResource == IntPtr.Zero)
             {
                 throw new LauncherException(Constants.ErrorResourceFailedToLoad, pName);
             }
 
-            IntPtr hResLock = NativeMethods.LockResource(hResource);
+            IntPtr hResLock = NativeMethods.Kernel32.LockResource(hResource);
             if (hResLock == IntPtr.Zero)
             {
                 throw new LauncherException(Constants.ErrorResourceFailedToLock, pName);
             }
 
-            uint bufsize = NativeMethods.SizeofResource(hModule, hResInfo);
+            uint bufsize = NativeMethods.Kernel32.SizeofResource(hModule, hResInfo);
             byte[] buffer = new byte[bufsize];
 
             Marshal.Copy(hResource, buffer, 0, buffer.Length);

--- a/src/clickonce/shared/NativeMethods.cs
+++ b/src/clickonce/shared/NativeMethods.cs
@@ -12,52 +12,58 @@ namespace Microsoft.Deployment.Utilities
         public static readonly IntPtr Launcher_CustomResourceTypePtr = new IntPtr(50);
         public const string Launcher_ResourceName = "FILENAME";
 
-        public const UInt32 LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern IntPtr BeginUpdateResourceW(String fileName, bool deleteExistingResource);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern bool UpdateResourceW(IntPtr hUpdate, IntPtr lpType, String lpName, short wLanguage, byte[] data, int cbData);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        internal static extern bool EndUpdateResource(IntPtr hUpdate, bool fDiscard);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-        internal static extern IntPtr GetModuleHandle(string moduleName);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern IntPtr FindResource(IntPtr hModule, string lpName, IntPtr lpType);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint SizeofResource(IntPtr hModule, IntPtr hResInfo);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern IntPtr LoadResource(IntPtr hModule, IntPtr hResInfo);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern IntPtr LockResource(IntPtr hResData);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern bool FreeLibrary(IntPtr hModule);
-
-        [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr LoadLibraryExW(string strFileName, IntPtr hFile, UInt32 ulFlags);
-
-        [DllImport("clr.dll", CharSet = CharSet.Unicode, ExactSpelling = true, PreserveSig = false)]
-        [return: MarshalAs(UnmanagedType.IUnknown)]
-        public static extern object GetAssemblyIdentityFromFile([In, MarshalAs(UnmanagedType.LPWStr)] string filePath, [In] ref Guid riid);
-
-        [ComImport]
-        [Guid("6eaf5ace-7917-4f3c-b129-e046a9704766")]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IReferenceIdentity
+        internal static class Kernel32
         {
-            [return: MarshalAs(UnmanagedType.LPWStr)]
-            string GetAttribute([In, MarshalAs(UnmanagedType.LPWStr)] string Namespace, [In, MarshalAs(UnmanagedType.LPWStr)] string Name);
-            void SetAttribute();
-            void EnumAttributes();
-            void Clone();
+            public const UInt32 LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
+
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern IntPtr BeginUpdateResourceW(String fileName, bool deleteExistingResource);
+
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern bool UpdateResourceW(IntPtr hUpdate, IntPtr lpType, String lpName, short wLanguage, byte[] data, int cbData);
+
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Auto, SetLastError = true)]
+            public static extern bool EndUpdateResource(IntPtr hUpdate, bool fDiscard);
+
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode)]
+            public static extern IntPtr GetModuleHandle(string moduleName);
+
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern IntPtr FindResource(IntPtr hModule, string lpName, IntPtr lpType);
+
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern uint SizeofResource(IntPtr hModule, IntPtr hResInfo);
+
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern IntPtr LoadResource(IntPtr hModule, IntPtr hResInfo);
+
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern IntPtr LockResource(IntPtr hResData);
+
+            [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern bool FreeLibrary(IntPtr hModule);
+
+            [DllImport(nameof(Kernel32), SetLastError = true, CharSet = CharSet.Unicode)]
+            public static extern IntPtr LoadLibraryExW(string strFileName, IntPtr hFile, UInt32 ulFlags);
+        }
+
+        internal static class Clr
+        {
+            [DllImport(nameof(Clr), CharSet = CharSet.Unicode, ExactSpelling = true, PreserveSig = false)]
+            [return: MarshalAs(UnmanagedType.IUnknown)]
+            public static extern object GetAssemblyIdentityFromFile([In, MarshalAs(UnmanagedType.LPWStr)] string filePath, [In] ref Guid riid);
+
+            [ComImport]
+            [Guid("6eaf5ace-7917-4f3c-b129-e046a9704766")]
+            [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+            public interface IReferenceIdentity
+            {
+                [return: MarshalAs(UnmanagedType.LPWStr)]
+                string GetAttribute([In, MarshalAs(UnmanagedType.LPWStr)] string Namespace, [In, MarshalAs(UnmanagedType.LPWStr)] string Name);
+                void SetAttribute();
+                void EnumAttributes();
+                void Clone();
+            }
         }
     }
 }

--- a/src/clickonce/shared/NativeMethods.cs
+++ b/src/clickonce/shared/NativeMethods.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Deployment.Utilities
+{
+    internal static class NativeMethods
+    {
+        // Warning - Launcher resource type and name should never be changed
+        public static readonly IntPtr Launcher_CustomResourceTypePtr = new IntPtr(50);
+        public const string Launcher_ResourceName = "FILENAME";
+
+        public const UInt32 LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr BeginUpdateResourceW(String fileName, bool deleteExistingResource);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern bool UpdateResourceW(IntPtr hUpdate, IntPtr lpType, String lpName, short wLanguage, byte[] data, int cbData);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern bool EndUpdateResource(IntPtr hUpdate, bool fDiscard);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        internal static extern IntPtr GetModuleHandle(string moduleName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr FindResource(IntPtr hModule, string lpName, IntPtr lpType);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern uint SizeofResource(IntPtr hModule, IntPtr hResInfo);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr LoadResource(IntPtr hModule, IntPtr hResInfo);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr LockResource(IntPtr hResData);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool FreeLibrary(IntPtr hModule);
+
+        [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern IntPtr LoadLibraryExW(string strFileName, IntPtr hFile, UInt32 ulFlags);
+
+        [DllImport("clr.dll", CharSet = CharSet.Unicode, ExactSpelling = true, PreserveSig = false)]
+        [return: MarshalAs(UnmanagedType.IUnknown)]
+        public static extern object GetAssemblyIdentityFromFile([In, MarshalAs(UnmanagedType.LPWStr)] string filePath, [In] ref Guid riid);
+
+        [ComImport]
+        [Guid("6eaf5ace-7917-4f3c-b129-e046a9704766")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public interface IReferenceIdentity
+        {
+            [return: MarshalAs(UnmanagedType.LPWStr)]
+            string GetAttribute([In, MarshalAs(UnmanagedType.LPWStr)] string Namespace, [In, MarshalAs(UnmanagedType.LPWStr)] string Name);
+            void SetAttribute();
+            void EnumAttributes();
+            void Clone();
+        }
+    }
+}


### PR DESCRIPTION
Add ClickOnce Launcher

Launcher will be used to activate .NET (Core) apps, directly (if they are EXEs) or using a host discovered on user's machine. Initially, only default global shared host location is checked - others will be added at later time.

Logging is optional, and can be configured by user with a registry key/value that will be documented in existing ClickOnce documentation.
