### PR TITLE
Enable packaging of Launcher nuget package for VS

### DIFF
--- a/src/clickonce/Directory.Build.props
+++ b/src/clickonce/Directory.Build.props
@@ -264,4 +264,27 @@
     <StaticLibSuffix Condition="'$(TargetOS)' == 'Windows_NT'">.lib</StaticLibSuffix>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Disable NuGet static graph evaluation as pkgprojs do their own restore.  -->
+    <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RequireLicenseAcceptance Condition="'$(RequireLicenseAcceptance)' == ''">false</RequireLicenseAcceptance>
+    <PackageRequireLicenseAcceptance>$(RequireLicenseAcceptance)</PackageRequireLicenseAcceptance>
+    <!-- This link should be updated for each release milestone, currently this points to 1.0.0 -->
+    <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799417</ReleaseNotes>
+    <ProjectUrl>https://github.com/dotnet/deployment-tools</ProjectUrl>
+    <PackagePlatform Condition="'$(PackagePlatform)' == ''">$(Platform)</PackagePlatform>
+    <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>
+
+    <!-- this repo doesn't currently use the index so don't force it to be in sync -->
+    <SkipIndexCheck>true</SkipIndexCheck>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackagesIntermediateDir>$(IntermediateOutputRootPath)packages/</PackagesIntermediateDir>
+  </PropertyGroup>
+
 </Project>

--- a/src/clickonce/launcher/Launcher.csproj
+++ b/src/clickonce/launcher/Launcher.csproj
@@ -1,11 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <IsPackable Condition="'$(TargetArchitecture)' == 'x86'">true</IsPackable>
+    <IsShipping>false</IsShipping>
+    <IsShippingPackage>false</IsShippingPackage>
+    <PackageId>VS.Redist.Common.NetCore.Launcher</PackageId>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <AssemblyName>Launcher</AssemblyName>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFramework>net45</TargetFramework>
     <NoWin32Manifest>true</NoWin32Manifest>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System.Deployment" />
   </ItemGroup>

--- a/src/clickonce/launcher/Launcher.csproj
+++ b/src/clickonce/launcher/Launcher.csproj
@@ -5,6 +5,11 @@
     <IsShippingPackage>false</IsShippingPackage>
     <PackageId>VS.Redist.Common.NetCore.Launcher</PackageId>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <!--
+      Suppress warnings/errors about missing dependencies. Launcher is a template binary
+      and never used during build.
+    -->
+    <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/clickonce/pkg/Directory.Build.props
+++ b/src/clickonce/pkg/Directory.Build.props
@@ -5,26 +5,4 @@
     <Platform>$(TargetArchitecture)</Platform>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Disable NuGet static graph evaluation as pkgprojs do their own restore.  -->
-    <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageRequireLicenseAcceptance>$(RequireLicenseAcceptance)</PackageRequireLicenseAcceptance>
-    <!-- This link should be updated for each release milestone, currently this points to 1.0.0 -->
-    <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799417</ReleaseNotes>
-    <ProjectUrl>https://github.com/dotnet/deployment-tools</ProjectUrl>
-    <PackagePlatform Condition="'$(PackagePlatform)' == ''">$(Platform)</PackagePlatform>
-    <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>
-
-    <!-- this repo doesn't currently use the index so don't force it to be in sync -->
-    <SkipIndexCheck>true</SkipIndexCheck>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <PackagesIntermediateDir>$(IntermediateOutputRootPath)packages/</PackagesIntermediateDir>
-  </PropertyGroup>
-
 </Project>

--- a/src/clickonce/pkg/projects/Directory.Build.props
+++ b/src/clickonce/pkg/projects/Directory.Build.props
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <RequireLicenseAcceptance Condition="'$(RequireLicenseAcceptance)' == ''">false</RequireLicenseAcceptance>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Simple change to enable building launcher package - a single one as Launcher is an MSIL binary.

Majority of changes are about shared packaging infra being moved 1 or 2 levels up the tree.