### PR TITLE
Launcher should not be signed

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -25,8 +25,8 @@
       <BundleInstallerEngineArtifact Include="$(ArtifactsPackagesDir)**/*engine.exe" />
       <BundleInstallerExeArtifact Include="$(ArtifactsPackagesDir)**/*.exe" />
 
-      <!-- launcher is not signed, by design. -->
-      <FileSignInfo Include="launcher.exe" CertificateName="None" />
+      <!-- Launcher is not signed, by design. -->
+      <FileSignInfo Include="Launcher.exe" CertificateName="None" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(SignBinaries)' == 'true'">


### PR DESCRIPTION
FileSignInfo@Include value is case-sensitive - update the value for Launcher binary signing exclusion.

Launcher is a template binary, that should not be signed.