### PR TITLE
New features in Mage.NET tool

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,11 @@
     <ArtifactsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts'))</ArtifactsDir>
     <ArtifactsBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'bin'))</ArtifactsBinDir>
     <ArtifactsObjDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'obj'))</ArtifactsObjDir>
+
+    <!-- Create English satellite assemblies (which shouldn't be required, but preserves previous build behavior) -->
+    <XlfLanguages>en;cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant</XlfLanguages>
+
+    <ErrorOnOutOfDateXlf>true</ErrorOnOutOfDateXlf>
   </PropertyGroup>
 
   <!-- Configuration properties which are needed in both the (isolated) restore and build phases. -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -83,6 +83,8 @@
     <SystemWindowsExtensionsTestDataVersion>5.0.0-beta.20258.1</SystemWindowsExtensionsTestDataVersion>
     <!-- Standard dependencies -->
     <NETStandardLibraryVersion>2.2.0-prerelease.19564.1</NETStandardLibraryVersion>
+    <!-- MSBuild dependencies -->
+    <MicrosoftBuildTasksCoreVersion>16.8.0-preview-20453-01</MicrosoftBuildTasksCoreVersion>
     <!-- dotnet-optimization dependencies -->
     <optimizationwindows_ntx64IBCCoreFxVersion>99.99.99-master-20200228.3</optimizationwindows_ntx64IBCCoreFxVersion>
     <optimizationlinuxx64IBCCoreFxVersion>99.99.99-master-20200228.3</optimizationlinuxx64IBCCoreFxVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <!-- Opt-in/out repo features -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
-    <UsingToolXliff>false</UsingToolXliff>
+    <UsingToolXliff>true</UsingToolXliff>
     <!-- Blob storage container that has the "Latest" channel to publish to. -->
     <ContainerName>dotnet</ContainerName>
     <ChecksumContainerName>$(ContainerName)</ChecksumContainerName>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -12,7 +12,7 @@ Param(
   [string]$testscope,
   [switch]$testnobuild,
   [ValidateSet("x86","x64","arm","arm64","wasm")][string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
-  [Parameter(Position=0)][string][Alias('s')]$subset,
+  [string][Alias('s')]$subset,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -31,7 +31,6 @@ function Get-Help() {
   Write-Host "  -os                            Target operating system: Windows_NT, Linux, OSX, or Browser."
   Write-Host "                                 [Default: Your machine's OS.]"
   Write-Host "  -subset (-s)                   Build a subset, print available subsets with -subset help."
-  Write-Host "                                 '-subset' can be omitted if the subset is given as the first argument."
   Write-Host "                                 [Default: Builds the entire repo.]"
   Write-Host "  -verbosity (-v)                MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
   Write-Host "                                 [Default: Minimal]"
@@ -71,10 +70,10 @@ function Get-Help() {
   Write-Host "Here are some quick examples. These assume you are on a Windows x64 machine:"
   Write-Host ""
   Write-Host "* Build ClickOnce tools for Windows x64 on Release configuration:"
-  Write-Host ".\build.cmd clickonce -c release"
+  Write-Host ".\build.cmd -subset clickonce -c release"
   Write-Host ""
   Write-Host "* Build ClickOnce tools and installers for Windows x64 on Release configuration:"
-  Write-Host ".\build.cmd clickonce+installer -c release"
+  Write-Host ".\build.cmd -subset clickonce+installer -c release"
   Write-Host ""
   Write-Host "For more information, check out https://github.com/dotnet/runtime/blob/master/docs/workflow/README.md"
 }
@@ -146,6 +145,7 @@ foreach ($argument in $PSBoundParameters.Keys)
 {
   switch($argument)
   {
+    "subset"                 { $arguments += " /p:Subset=$($PSBoundParameters[$argument].ToLowerInvariant())" }
     "framework"              { $arguments += " /p:BuildTargetFramework=$($PSBoundParameters[$argument].ToLowerInvariant())" }
     "os"                     { $arguments += " /p:TargetOS=$($PSBoundParameters[$argument])" }
     "allconfigurations"      { $arguments += " /p:BuildAllConfigurations=true" }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -31,7 +31,6 @@ usage()
   echo "                                  [Default: Your machine's OS.]"
   echo "  --projects <value>              Project or solution file(s) to build."
   echo "  --subset (-s)                   Build a subset, print available subsets with -subset help."
-  echo "                                 '--subset' can be omitted if the subset is given as the first argument."
   echo "                                  [Default: Builds the entire repo.]"
   echo "  --verbosity (-v)                MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
   echo "                                  [Default: Minimal]"
@@ -79,7 +78,7 @@ usage()
   echo "There are no projects that build for Linux at the moment - these are just examples."
   echo ""
   echo "* Build ClickOnce for Linux x64 on Release configuration:"
-  echo "./build.sh clickonce -c release"
+  echo "./build.sh -subset clickonce -c release"
   echo ""
   echo "For more general information, check out https://github.com/dotnet/runtime/blob/master/docs/workflow/README.md"
 }

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -74,6 +74,7 @@ jobs:
           $(CommonMSBuildArgs)
           $(MsbuildSigningArguments)
           /p:Sign=true /p:SignBinaries=true
+          /p:LocalizedBuild=true
         displayName: Build and Sign Binaries
 
     - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -81,6 +82,7 @@ jobs:
           build.cmd -subset clickonce+installer -ci -test
           $(CommonMSBuildArgs)
           $(MsbuildSigningArguments)
+          /p:LocalizedBuild=true
         displayName: Build
 
     - script: >-

--- a/src/clickonce/MageCLI/Application.resx
+++ b/src/clickonce/MageCLI/Application.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationManifestMissingHostInBrowserTag" xml:space="preserve">
-    <value>The application manifest specified does not include the HostInBrowser tag required for a Windows Presentation Foundation Browser Application.</value>
+  <data name="ApplicationManifestCannotHaveHostInBrowserTag" xml:space="preserve">
+    <value>The specified application manifest includes unsupported HostInBrowser tag.</value>
   </data>
   <data name="DeployManifestNotSigned" xml:space="preserve">
     <value>Deployment manifest is not signed - "{0}"</value>
@@ -139,12 +139,13 @@
   -Sign &lt;file_name&gt;	          -s
   -ClearApplicationCache	  -cc
   -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
   -Help [verbose]		  -h -?
 
 
 
 Options
-  -Algorithm &lt;sha256RSA|sha1RSA&gt;    -a
+  -Algorithm &lt;sha256RSA&gt;           -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -162,12 +163,12 @@ Options
   -ProviderURL &lt;url&gt; 	            -pu
   -Publisher &lt;publisher_name&gt;       -pub
   -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
-  -WPFBrowserApp &lt;true|false&gt;       -wpf
 
 Use "mage -help verbose" for more detailed help</value>
   </data>
@@ -199,6 +200,11 @@ Use "mage -help verbose" for more detailed help</value>
       Example:
         -Verify MyApp.manifest
   
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
   -ClearApplicationCache  -cc
       Clear the downloaded application cache of all online-only applications. 
 
@@ -210,10 +216,10 @@ Use "mage -help verbose" for more detailed help</value>
 
 Options:
 
-  -Algorithm &lt;sha256RSA|sha1RSA&gt;  -a
+  -Algorithm &lt;sha256RSA&gt;      -a
       Specifies the algorithm to generate digests.
       Example:
-         -Algorithm sha1RSA
+         -Algorithm sha256RSA
 
   -AppCodeBase &lt;path&gt;     -appc
       Specifies the code base of the app manifest to be placed in the
@@ -317,6 +323,11 @@ Options:
       Example:
         -SupportURL http://www.whatever.net/application/support
 
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
   -ToFile &lt;file_name&gt;     -t
       Specifies the name of the file to save the output of a sign, new, or 
       update command.
@@ -341,17 +352,14 @@ Options:
       Specifies the version of the application whose manifest is being 
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
-        -Version 1.2.3.2112
-
-  -WPFBrowserApp &lt;true|false&gt;       -wpf
-      Specifies whether the application is a Windows Presentation Foundation Browser Application or not.</value>
+        -Version 1.2.3.2112</value>
   </data>
   <data name="InternalError" xml:space="preserve">
     <value>Internal error, please try again.</value>
     <comment>trailing space is added at run-time</comment>
   </data>
   <data name="InvalidAlgorithmValue" xml:space="preserve">
-    <value>Algorithm has to be sha1RSA or sha256RSA. Specified - "{0}".</value>
+    <value>Algorithm has to be sha256RSA. Specified - "{0}".</value>
   </data>
   <data name="InvalidCertFile" xml:space="preserve">
     <value>Cert file is not of proper format - "{0}"</value>
@@ -364,6 +372,9 @@ Options:
   </data>
   <data name="VerifyIsExclusive" xml:space="preserve">
     <value>'verify' command can't be combined with any other command.</value>
+  </data>
+  <data name="AddLauncherIsExclusive" xml:space="preserve">
+    <value>'addlauncher' command can't be combined with any other command.</value>
   </data>
   <data name="InvalidCertUsage" xml:space="preserve">
     <value>This certificate cannot be used for signing - "{0}"</value>
@@ -392,13 +403,8 @@ Options:
   <data name="InvalidKeyFile" xml:space="preserve">
     <value>Key file is not of proper format - "{0}"</value>
   </data>
-  <data name="InvalidOption" xml:space="preserve">
-    <value>The "{0}" option can only be used with the following types of files:</value>
-    <comment>trailing space is added at run-time</comment>
-  </data>
-  <data name="InvalidOptionConjuction" xml:space="preserve">
-    <value> ,</value>
-    <comment>If two types are allowed, this will be inserted between the first and second type</comment>
+  <data name="FileTypeSpecificOption" xml:space="preserve">
+    <value>The "{0}" option can only be used with the following type of files: "{1}"</value>
   </data>
   <data name="InvalidPassword" xml:space="preserve">
     <value>Cert password is incorrect - "{0}"</value>
@@ -413,11 +419,20 @@ Options:
   <data name="InvalidRequiredUpdate" xml:space="preserve">
     <value>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</value>
   </data>
-  <data name="InvalidSignOption" xml:space="preserve">
+  <data name="InvalidNonManifestOption" xml:space="preserve">
     <value>The "{0}" option can only be used with the -Update or -New commands.</value>
+  </data>
+  <data name="InvalidAddLauncherOption" xml:space="preserve">
+    <value>The "{0}" option can not be used with -AddLauncher command.</value>
+  </data>
+  <data name="InvalidNonAddLauncherOption" xml:space="preserve">
+    <value>The "{0}" option can only be used with -AddLauncher command.</value>
   </data>
   <data name="InvalidTrustLevel" xml:space="preserve">
     <value>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</value>
+  </data>
+  <data name="TrustLevelsNotSupportedOnNETCore" xml:space="preserve">
+    <value>Setting trust level is not supported on .NET Core</value>
   </data>
   <data name="InvalidUrl" xml:space="preserve">
     <value>The URL is not of the proper format - "{0}"</value>
@@ -427,12 +442,6 @@ Options:
   </data>
   <data name="InvalidVersion" xml:space="preserve">
     <value>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</value>
-  </data>
-  <data name="InvalidWPFBrowserApp" xml:space="preserve">
-    <value>The -WPFBrowserApp option must be "true", "false", "t", or "f" - "{0}"</value>
-  </data>
-  <data name="InvalidWPFBrowserAppInstallCombination" xml:space="preserve">
-    <value>The WPFBrowserApp and Install options cannot be set to true at the same time</value>
   </data>
   <data name="LockedFile" xml:space="preserve">
     <value>Not including locked file {0}</value>
@@ -445,6 +454,9 @@ Options:
   </data>
   <data name="MissingPassword" xml:space="preserve">
     <value>Missing Password option, this is required when using the CertFile option.</value>
+  </data>
+  <data name="MissingAddLauncherOption" xml:space="preserve">
+    <value>Missing {0} option, it is required with AddLauncher command.</value>
   </data>
   <data name="MissingUseApplicationManifestForTrustInfo" xml:space="preserve">
     <value>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</value>
@@ -463,8 +475,8 @@ Options:
     <value>No output file was specified.  Please use -ToFile &lt;filename&gt;.</value>
   </data>
   <data name="NoVerb" xml:space="preserve">
-    <value>The first argument must be one of the following: -New, -Update, -Sign, -Verify</value>
-    <comment>"-New, -Update, -Sign, -Verify" are command names and should not be translated</comment>
+    <value>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</value>
+    <comment>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</comment>
  </data>
   <data name="TooManyKeysSpecified" xml:space="preserve">
     <value>Only one of -KeyFile, -CertFile, or -CertHash can be used.</value>
@@ -534,5 +546,23 @@ Options:
   </data>
   <data name="SignatureValidatedSuccessfully" xml:space="preserve">
     <value>Manifest has a valid signature.</value>
+  </data>
+  <data name="MissingLauncherTemplate" xml:space="preserve">
+    <value>Launcher template "{0}" does not exist.</value>
+  </data>
+  <data name="FailedToUpdateLauncherResources" xml:space="preserve">
+    <value>Failed to update Launcher resources.</value>
+  </data>
+  <data name="FailedToAddLauncher" xml:space="preserve">
+    <value>Failed to add Launcher.</value>
+  </data>
+  <data name="InvalidBinaryToLaunch" xml:space="preserve">
+    <value>Binary to launch cannot include a path, it can only be a filename - {0}.</value>
+  </data>
+  <data name="MissingBinaryToLaunch" xml:space="preserve">
+    <value>Binary to launch cannot be empty.</value>
+  </data>
+  <data name="LauncherSuccessfullyAdded" xml:space="preserve">
+    <value>Launcher successfully added.</value>
   </data>
 </root>

--- a/src/clickonce/MageCLI/CommandLineArguments.cs
+++ b/src/clickonce/MageCLI/CommandLineArguments.cs
@@ -1,16 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace CommandLineParser
-{
-    using System;
-    using System.Diagnostics;
-    using System.Reflection;
-    using System.Collections;
-    using System.Globalization;
-    using System.IO;
-    using System.Text;
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Collections;
+using System.Globalization;
+using System.IO;
+using System.Text;
 
+namespace Microsoft.Deployment.CommandLineParser
+{
     /// <summary>
     /// A delegate used in error reporting.
     /// </summary>

--- a/src/clickonce/MageCLI/CryptoApi.cs
+++ b/src/clickonce/MageCLI/CryptoApi.cs
@@ -1,18 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Mage
-{
-    using System;
-    using System.Runtime.ConstrainedExecution;
-    using System.Runtime.InteropServices;
-    using System.Security;
-    using System.Security.Cryptography;
-    using System.Security.Permissions;
-    using System.Text;
-    using Microsoft.Win32.SafeHandles;
-    using _FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
+using System;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.Cryptography;
+using System.Security.Permissions;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+using _FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
+namespace Microsoft.Deployment.Utilities
+{
     internal abstract class CAPIBase
     {
         //
@@ -39,7 +39,6 @@ namespace Mage
         internal const int S_OK        = 0;
         internal const int S_FALSE     = 1;
         internal const string szOID_RSA_SHA256RSA   = "1.2.840.113549.1.1.11";
-        internal const string szOID_RSA_SHA1RSA = "1.2.840.113549.1.1.5";
 
         // dwFlags definitions for CryptAcquireContext
         internal const uint CRYPT_VERIFYCONTEXT     = 0xF0000000;

--- a/src/clickonce/MageCLI/LauncherUtil.cs
+++ b/src/clickonce/MageCLI/LauncherUtil.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Deployment.Utilities
                     Application.PrintErrorMessage(ErrorMessages.FailedToUpdateLauncherResources, "");
                     return false;
                 }
-
             }
             catch (Exception)
             {

--- a/src/clickonce/MageCLI/LauncherUtil.cs
+++ b/src/clickonce/MageCLI/LauncherUtil.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Deployment.MageCLI;
+
+namespace Microsoft.Deployment.Utilities
+{
+    public sealed class LauncherUtil
+    {
+        /// <summary>
+        /// Launcher binary filename.
+        /// </summary>
+        public static string LauncherFilename = @"Launcher.exe";
+
+        /// <summary>
+        /// Launcher binary template filename.
+        /// </summary>
+        public static string LauncherTemplate = @"Launcher.exe";
+
+        /// <summary>
+        /// Adds Launcher binary to specified directory and updates resource with target binary name
+        /// </summary>
+        /// <param name="dir">Directory in which to add Launcher</param>
+        /// <param name="binaryToLaunch">Name of binary to be launched by Launcher</param>
+        /// <returns>Success or failure</returns>
+        public static bool AddLauncher(string dir, string binaryToLaunch)
+        {
+            try
+            {
+                if (string.Compare(binaryToLaunch, Path.GetFileName(binaryToLaunch), true) != 0)
+                {
+                    Application.PrintErrorMessage(ErrorMessages.InvalidBinaryToLaunch, binaryToLaunch);
+                    return false;
+                }
+
+                if (!Directory.Exists(dir))
+                {
+                    Application.PrintErrorMessage(ErrorMessages.InvalidDirectory, dir);
+                    return false;
+                }
+
+                string launcherTemplatePath = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), LauncherTemplate);
+                if (!File.Exists(launcherTemplatePath))
+                {
+                    Application.PrintErrorMessage(ErrorMessages.MissingLauncherTemplate, launcherTemplatePath);
+                    return false;
+                }
+
+                // Copy template binary
+                string targetFilePath = Path.Combine(dir, LauncherFilename);
+                File.Copy(launcherTemplatePath, targetFilePath, true);
+
+                if (false == ResourceUpdater.SetApplicationFilename(targetFilePath, binaryToLaunch))
+                {
+                    Application.PrintErrorMessage(ErrorMessages.FailedToUpdateLauncherResources, "");
+                    return false;
+                }
+
+            }
+            catch (Exception)
+            {
+                Application.PrintErrorMessage(ErrorMessages.FailedToAddLauncher, "");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}
+

--- a/src/clickonce/MageCLI/MageCLI.csproj
+++ b/src/clickonce/MageCLI/MageCLI.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Application.resx">
-      <LogicalName>$(AssemblyName).Application.resources</LogicalName>
+      <LogicalName>Microsoft.Deployment.MageCLI.Application.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Condition="$(TargetFramework.StartsWith('net4'))" Include="$(IntermediateOutputPath)\MageCLI.Application.resources">

--- a/src/clickonce/MageCLI/MageCLI.csproj
+++ b/src/clickonce/MageCLI/MageCLI.csproj
@@ -6,11 +6,29 @@
     <SignAssemblyAttribute>true</SignAssemblyAttribute>
     <RCSuppressManifest>true</RCSuppressManifest>
     <AssemblyAttributeClsCompliant>false</AssemblyAttributeClsCompliant>
-    <TargetFramework>net4.8</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <PlatformSpecificBuild>true</PlatformSpecificBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+  </PropertyGroup>
+  <PropertyGroup Condition="!$(TargetFramework.StartsWith('net4'))">
+    <DefineConstants>$(DefineConstants);RUNTIME_TYPE_NETCORE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.6.0" />
+    <Compile Include="..\Shared\NativeMethods.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Application.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Condition="$(TargetFramework.StartsWith('net4'))" Include="$(IntermediateOutputPath)\MageCLI.Application.resources">
+      <LogicalName>Microsoft.Deployment.MageCLI.Application.resources</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/src/clickonce/MageCLI/MageCLI.csproj
+++ b/src/clickonce/MageCLI/MageCLI.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Application.resx">
+      <LogicalName>$(AssemblyName).Application.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Condition="$(TargetFramework.StartsWith('net4'))" Include="$(IntermediateOutputPath)\MageCLI.Application.resources">

--- a/src/clickonce/MageCLI/Misc.cs
+++ b/src/clickonce/MageCLI/Misc.cs
@@ -4,11 +4,9 @@
 using System;
 using System.IO;
 using System.Xml;
-using System.Reflection;
-using System.Text.RegularExpressions;
 using Microsoft.Win32;
 
-namespace Utilities
+namespace Microsoft.Deployment.Utilities
 {
     /// <summary>
     /// Constants
@@ -43,7 +41,7 @@ namespace Utilities
         /// </summary>
         /// <param name="codebase"></param>
         /// <returns></returns>
-        public static void ValidateCodebase(string codebase)
+        private static void ValidateCodebase(string codebase)
         {
             try
             {
@@ -60,7 +58,7 @@ namespace Utilities
         /// Validates the URL.
         /// </summary>
         /// <param name="url"></param>
-        public static void ValidateUrl(string url)
+        private static void ValidateUrl(string url)
         {
             // This will throw if codebase isn't a legal URI
             Uri uri = new Uri(url);
@@ -152,7 +150,7 @@ namespace Utilities
         /// <returns>Publisher name</returns>
         internal static string GetRegisteredOrganization()
         {
-            string result = "";
+            string result = string.Empty;
 
             using (RegistryKey key = Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", false))
             {
@@ -161,7 +159,7 @@ namespace Utilities
                     result = key.GetValue("RegisteredOrganization") as string;
                     if (result == null)
                     {
-                        result = "";
+                        result = string.Empty;
                     }
                 }
             }

--- a/src/clickonce/MageCLI/ResourceUpdater.cs
+++ b/src/clickonce/MageCLI/ResourceUpdater.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Microsoft.Deployment.Utilities
+{
+    internal static class ResourceUpdater
+    {
+        /// <summary>
+        /// Sets the filename of application to launch, in the custom resource.
+        /// </summary>
+        /// <param name="path">Path to the file in which to set the resource.</param>
+        /// <param name="filename">Filename of application to launch.</param>
+        /// <returns>Success or failure</returns>
+        public static bool SetApplicationFilename(string path, string filename)
+        {
+            return WriteString(path, NativeMethods.Launcher_CustomResourceTypePtr, NativeMethods.Launcher_ResourceName, filename);
+        }
+
+        /// <summary>
+        /// Writes resource string with specific resource type and value.
+        /// </summary>
+        /// <param name="path">Path to a file in which to write the resource</param>
+        /// <param name="type">Resource type</param>
+        /// <param name="name">Resource name</param>
+        /// <param name="value">Resource value</param>
+        /// <returns>Success or failure</returns>
+        private static bool WriteString(string path, IntPtr type, string name, string value)
+        {
+            bool returnValue = true;
+            int beginUpdateRetries = 20;
+            const int beginUpdateRetryInterval = 100; // In milliseconds
+            bool endUpdate = false;
+
+            IntPtr hUpdate = IntPtr.Zero;
+
+            try
+            {
+                hUpdate = NativeMethods.Kernel32.BeginUpdateResourceW(path, false);
+                while (IntPtr.Zero == hUpdate &&
+                       Marshal.GetHRForLastWin32Error() == NativeMethods.Kernel32.ERROR_SHARING_VIOLATION &&
+                       beginUpdateRetries > 0)
+                {
+                    hUpdate = NativeMethods.Kernel32.BeginUpdateResourceW(path, false);
+                    beginUpdateRetries--;
+                    Thread.Sleep(beginUpdateRetryInterval);
+                }
+
+                if (IntPtr.Zero == hUpdate)
+                {
+                    return false;
+                }
+
+                endUpdate = true;
+
+                if (hUpdate != IntPtr.Zero)
+                {
+                    byte[] dataBytes = GetZeroTerminatedByteArray(value);
+
+                    if (!NativeMethods.Kernel32.UpdateResourceW(hUpdate, type, name, 0, dataBytes, dataBytes.Length))
+                    {
+                        return false;
+                    }
+                }
+            }
+            finally
+            {
+                if (endUpdate && !NativeMethods.Kernel32.EndUpdateResource(hUpdate, false))
+                {
+                    returnValue = false;
+                }
+            }
+
+            return returnValue;
+        }
+
+        /// <summary>
+        /// Gets a zero-terminated byte array from the input string.
+        /// </summary>
+        /// <param name="str">String</param>
+        /// <returns>Byte array</returns>
+        private static byte[] GetZeroTerminatedByteArray(string str)
+        {
+            // Append zero-termination to match MSBuild code.
+
+            byte[] strBytes = System.Text.Encoding.Unicode.GetBytes(str);
+            byte[] data = new byte[strBytes.Length + 2];
+            strBytes.CopyTo(data, 0);
+            data[data.Length - 2] = 0;
+            data[data.Length - 1] = 0;
+            return data;
+        }
+    }
+}

--- a/src/clickonce/MageCLI/xlf/Application.cs.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.cs.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.de.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.de.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.es.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.es.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.fr.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.fr.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.it.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.it.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.ja.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ja.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.ko.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ko.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.pl.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.pl.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.pt-BR.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.pt-BR.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.ru.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ru.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.tr.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.tr.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.zh-Hans.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.zh-Hans.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/MageCLI/xlf/Application.zh-Hant.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.zh-Hant.xlf
@@ -1,0 +1,819 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Application.resx">
+    <body>
+      <trans-unit id="AddLauncherIsExclusive">
+        <source>'addlauncher' command can't be combined with any other command.</source>
+        <target state="new">'addlauncher' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationCacheCleared">
+        <source>Application cache cleared.</source>
+        <target state="new">Application cache cleared.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ApplicationManifestCannotHaveHostInBrowserTag">
+        <source>The specified application manifest includes unsupported HostInBrowser tag.</source>
+        <target state="new">The specified application manifest includes unsupported HostInBrowser tag.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DefaultAppName">
+        <source>New Application</source>
+        <target state="new">New Application</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestNotSigned">
+        <source>Deployment manifest is not signed - "{0}"</source>
+        <target state="new">Deployment manifest is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeployManifestSignatureInvalid">
+        <source>Deployment manifest contains invalid signature - "{0}"</source>
+        <target state="new">Deployment manifest contains invalid signature - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorApplicactionCachedCleared">
+        <source>Failed to clear application cache.</source>
+        <target state="new">Failed to clear application cache.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidSignature">
+        <source>Manifest does not have a valid signature.</source>
+        <target state="new">Manifest does not have a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorInvalidTimestampFormat">
+        <source>Timestamp is not encoded as a base64 string.</source>
+        <target state="new">Timestamp is not encoded as a base64 string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMessage">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorMissingSignatureNode">
+        <source>Signature node is missing.</source>
+        <target state="new">Signature node is missing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingOutputFile">
+        <source>Error writing output file "{0}".</source>
+        <target state="new">Error writing output file "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddLauncher">
+        <source>Failed to add Launcher.</source>
+        <target state="new">Failed to add Launcher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToUpdateLauncherResources">
+        <source>Failed to update Launcher resources.</source>
+        <target state="new">Failed to update Launcher resources.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileNotWriteable">
+        <source>Cannot write to file "{0}"</source>
+        <target state="new">Cannot write to file "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileTypeSpecificOption">
+        <source>The "{0}" option can only be used with the following type of files: "{1}"</source>
+        <target state="new">The "{0}" option can only be used with the following type of files: "{1}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpTerse">
+        <source>Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</source>
+        <target state="new">Commands
+  -New &lt;file_type&gt;	          -n
+  -Update &lt;file_name&gt;	          -u
+  -Sign &lt;file_name&gt;	          -s
+  -ClearApplicationCache	  -cc
+  -Verify &lt;manifest_file_name&gt;    -ver
+  -AddLauncher &lt;binary_to_launch&gt; -al
+  -Help [verbose]		  -h -?
+
+
+
+Options
+  -Algorithm &lt;sha256RSA&gt;           -a
+  -AppCodeBase &lt;path&gt;	            -appc
+  -AppManifest &lt;path&gt;	            -appm
+  -CertFile &lt;file_name&gt;	            -cf
+  -CertHash &lt;hash&gt;                  -ch
+  -CryptoProvider &lt;name&gt;            -csp
+  -FromDirectory &lt;path&gt;	            -fd
+  -IconFile &lt;file_path&gt;             -if
+  -IncludeProviderURL &lt;true|false&gt;  -ip
+  -Install &lt;true|false&gt;             -i 
+  -KeyContainer &lt;name&gt;              -kc
+  -MinVersion &lt;version #|none&gt;      -mv
+  -Name &lt;name&gt;		            -n
+  -Password &lt;password&gt;	            -pwd
+  -Processor &lt;processor&gt;	    -p
+  -ProviderURL &lt;url&gt; 	            -pu
+  -Publisher &lt;publisher_name&gt;       -pub
+  -SupportURL &lt;support_url&gt;         -s
+  -TargetDirectory &lt;path&gt;	    -td
+  -TimeStampUri &lt;uri&gt;               -ti
+  -ToFile	&lt;file_name&gt;	    -t
+  -TrustLevel &lt;level&gt;	            -tr
+  -UseManifestForTrust &lt;true|false&gt; -um
+  -Version &lt;version&gt;	            -v
+
+Use "mage -help verbose" for more detailed help</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpVerbose">
+        <source>Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</source>
+        <target state="new">Commands:
+
+  -New &lt;file_type&gt;        -n
+      Generate a new application manifest, deployment manifest, or trust
+      license, using the options listed below.
+      Examples:
+        -New Application -ToFile MyApp.manifest -Name MyApp -Processor X86
+        -New Deployment -ToFile MyApp.application -Name MyApp -Version 1.0.0.0
+    
+  -Update &lt;file_name&gt;     -u
+      Update an existing application manifest, deployment manifest, or trust
+      License, updating it as specified by the options listed below.
+      Examples:
+        -Update MyApp.manifest -FromDirectory bin/release
+        -Update MyApp.application -Version 2.1.0.123 -ToFile MyApp21.application 
+          
+  -Sign &lt;file_name&gt;       -s
+      Sign an existing manifest or license with a keypair or an X509
+      certificate.
+      Examples:
+        -Sign MyApp.manifest -CertFile MyCert.pfx -Password mycertpassword
+    
+  -Verify &lt;manifest_file_name&gt;       -ver
+      Verify if the manifest is signed correctly. Cannot be combined with other commands.
+      Example:
+        -Verify MyApp.manifest
+  
+  -AddLauncher &lt;binary_to_launch&gt;    -al
+      Adds Launcher to target directory and sets its binary to launch.
+      Example:
+        -AddLauncher myapp.dll -TargetDirectory bin/release
+
+  -ClearApplicationCache  -cc
+      Clear the downloaded application cache of all online-only applications. 
+
+  -Help [verbose]         -h -?
+      Print usage instructions.
+      Examples:
+        -Help
+        -Help Verbose
+
+Options:
+
+  -Algorithm &lt;sha256RSA&gt;      -a
+      Specifies the algorithm to generate digests.
+      Example:
+         -Algorithm sha256RSA
+
+  -AppCodeBase &lt;path&gt;     -appc
+      Specifies the code base of the app manifest to be placed in the
+      deployment manifest being generated or updated.
+      Example:
+         -AppCodeBase 1.0.0.0/myapp.manifest
+      
+  -AppManifest &lt;path&gt;     -appm
+      Specifies the local path to an application manifest that is being
+      referenced from the deployment manifest being generated or updated.
+      Example:
+        -AppManifest MyApp.manifest
+
+  -CertFile &lt;file_name&gt;   -cf
+      Specifies the name of an X509 certificate file with which to sign a
+      manifest or license file.  This option can be used in conjunction 
+      with the -Password option, if the certificate requires a password
+      for Personal Information Exchange (PFX) files. If the file does not 
+      contain private key a combination of -CryptoProvider and 
+      -KeyContainer options is required.
+      Example:
+        -CertFile MyCert.pfx
+        -CertFile MyCert.pfx -Password mycertpassword
+        -CertFile PublicKey.cer -KeyContainer name -CryptoProvider MyCspName
+
+  -CertHash &lt;hash&gt;        -ch
+      Specifies the hash of an X509 certificate in your local cert store.
+      Example:
+        -CertHash a1b2c3d4e5f6g7h8i9j0
+
+  -CryptoProvider &lt;name&gt;  -csp
+      Specifies the name of cryptographic service provider (CSP) that contains
+      the private key container.  This option requires the -KeyContainer option.
+      Example:
+        -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0" -KeyContainer name
+
+  -FromDirectory &lt;path&gt;   -fd
+      Specifies the directory to recursively search for files to include in
+      an application manifest.  
+      Example:
+        -FromDirectory bin/release
+        
+  -IconFile &lt;file_path&gt;   -if
+      Specifies relative path and filename for the application icon.
+        
+  -IncludeProviderURL &lt;true|false&gt; -ip
+      Specifies if the deployment manifest will include the deployment 
+      provider URL.
+      
+  -Install &lt;true|false&gt;   -i
+      Specifies if the application will be an installed or an online only 
+      application.
+
+  -KeyContainer &lt;name&gt;    -kc
+      Specifies the key container that contains the name of the private key.
+      This option requires the -CryptoProvider option.
+      Example:
+        -KeyContainer name -CryptoProvider "Microsoft Enhanced Cryptographic Provider v1.0"
+
+  -MinVersion &lt;version #|none&gt;   -mv
+      Specifies whether the manifest being generated specifies a minimum version.
+      Must be of the form "0.0.0.0".  Specifying "none" removes this from the manifest.
+      Example:
+        -MinVersion 1.2.3.4
+        -MinVersion none
+
+  -Name &lt;name&gt;            -n
+      Specifies the name of the application whose manifest is being 
+      generated or updated.  Names which include spaces should be enclosed
+      in quotes.
+      Examples:
+        -Name MyApp
+        -Name "My Application"
+        
+  -Password &lt;password&gt;    -pwd
+      Specifies the password to use with an X509 certificate when signing
+      a manifest or license file.  See example above.
+
+  -Processor &lt;processor&gt;  -p
+      Specifies the processor architecture of the application whose manifest
+      is being generated or updated.
+      Examples:
+        -Processor MSIL
+        -Processor i386
+
+  -ProviderURL &lt;url&gt;      -pu
+      Specifies the provider URL to be use in the deployment manifest being
+      generated or updated.
+      Example:
+        -ProviderURL http://www.whatever.net/application
+
+  -Publisher &lt;publisher_name&gt;    -pub
+      Specifies the name of the publisher.  Names which include spaces should 
+      be enclosed in quotes.
+      Examples:
+        -Publisher MyCompany
+        -Publisher "My Company"
+
+  -SupportURL &lt;url&gt;       -s
+      Specifies the support URL for the application.
+      Example:
+        -SupportURL http://www.whatever.net/application/support
+
+  -TargetDirectory &lt;path&gt;	  -td
+      Specifies the directory to which to add the Launcher.
+      Example:
+        -TargetDirectory bin/release
+
+  -ToFile &lt;file_name&gt;     -t
+      Specifies the name of the file to save the output of a sign, new, or 
+      update command.
+      Example:
+        -ToFile MyApp.manifest
+
+  -TimeStampUri &lt;uri&gt;     -ti
+      Specifies the URI to use for timestamping during signing.
+
+  -TrustLevel &lt;level&gt;     -tr
+      Specifies the trust level to be included in the application manifest
+      being generated or updated. Valid values are: "Internet", "LocalIntranet",
+      and "FullTrust".
+      Example:
+        -TrustLevel FullTrust
+
+  -UseManifestForTrust &lt;true|false&gt; -um
+      Specifies if the application manifest will be used for certification and
+      branding information.
+            
+  -Version &lt;version&gt;                -v
+      Specifies the version of the application whose manifest is being 
+      generated or updated.  Must be of the form "0.0.0.0".
+      Example:
+        -Version 1.2.3.2112</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InfoMessage">
+        <source>Info</source>
+        <target state="new">Info</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InternalError">
+        <source>Internal error, please try again.</source>
+        <target state="new">Internal error, please try again.</target>
+        <note>trailing space is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidAddLauncherOption">
+        <source>The "{0}" option can not be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can not be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidAlgorithmValue">
+        <source>Algorithm has to be sha256RSA. Specified - "{0}".</source>
+        <target state="new">Algorithm has to be sha256RSA. Specified - "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBinaryToLaunch">
+        <source>Binary to launch cannot include a path, it can only be a filename - {0}.</source>
+        <target state="new">Binary to launch cannot include a path, it can only be a filename - {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertFile">
+        <source>Cert file is not of proper format - "{0}"</source>
+        <target state="new">Cert file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertNoPrivateKey">
+        <source>This certificate does not contain a private key - "{0}"</source>
+        <target state="new">This certificate does not contain a private key - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertUsage">
+        <source>This certificate cannot be used for signing - "{0}"</source>
+        <target state="new">This certificate cannot be used for signing - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCodebase">
+        <source>The codebase is invalid - "{0}"</source>
+        <target state="new">The codebase is invalid - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidDirectory">
+        <source>Directory not found - "{0}"</source>
+        <target state="new">Directory not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidFileType">
+        <source>Invalid file type, must be "Application", or "Deployment"</source>
+        <target state="new">Invalid file type, must be "Application", or "Deployment"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHash">
+        <source>No cert found matching specified hash - "{0}"</source>
+        <target state="new">No cert found matching specified hash - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidIncludeProviderURL">
+        <source>The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -IncludeProviderURL option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInputFile">
+        <source>Unrecognized file type - "{0}"</source>
+        <target state="new">Unrecognized file type - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidInstall">
+        <source>The -Install option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -Install option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidKeyFile">
+        <source>Key file is not of proper format - "{0}"</source>
+        <target state="new">Key file is not of proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidMinVersion">
+        <source>The minimum version specified is not valid.</source>
+        <target state="new">The minimum version specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonAddLauncherOption">
+        <source>The "{0}" option can only be used with -AddLauncher command.</source>
+        <target state="new">The "{0}" option can only be used with -AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidNonManifestOption">
+        <source>The "{0}" option can only be used with the -Update or -New commands.</source>
+        <target state="new">The "{0}" option can only be used with the -Update or -New commands.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPassword">
+        <source>Cert password is incorrect - "{0}"</source>
+        <target state="new">Cert password is incorrect - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidPath">
+        <source>File not found - "{0}"</source>
+        <target state="new">File not found - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidProcessor">
+        <source>Unknown processor type "{0}".  Supported processor types are:</source>
+        <target state="new">Unknown processor type "{0}".  Supported processor types are:</target>
+        <note>Will be followed by a list of processor types, after a newline is added at run-time</note>
+      </trans-unit>
+      <trans-unit id="InvalidRequiredUpdate">
+        <source>The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -RequiredUpdate option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTimestamp">
+        <source>The timestamp URI specified is not valid.</source>
+        <target state="new">The timestamp URI specified is not valid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustLevel">
+        <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
+        <target state="new">Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUrl">
+        <source>The URL is not of the proper format - "{0}"</source>
+        <target state="new">The URL is not of the proper format - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUseManifestForTrust">
+        <source>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidVersion">
+        <source>Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</source>
+        <target state="new">Version must be of format X.X.X.X (ex 1.0.0.0) - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LauncherSuccessfullyAdded">
+        <source>Launcher successfully added.</source>
+        <target state="new">Launcher successfully added.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LockedFile">
+        <source>Not including locked file {0}</source>
+        <target state="new">Not including locked file {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingAddLauncherOption">
+        <source>Missing {0} option, it is required with AddLauncher command.</source>
+        <target state="new">Missing {0} option, it is required with AddLauncher command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingArgument">
+        <source>Missing value following the "{0}" option</source>
+        <target state="new">Missing value following the "{0}" option</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingBinaryToLaunch">
+        <source>Binary to launch cannot be empty.</source>
+        <target state="new">Binary to launch cannot be empty.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingCspOrContainer">
+        <source>This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</source>
+        <target state="new">This certificate does not contain a private key - "{0}", if this is a public key certificate, please provide valid cryptographic service provider and key container names</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingDeploymentProviderUrl">
+        <source>The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</source>
+        <target state="new">The IncludeProviderURL option is set to true, but no deployment provider Url is provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingLauncherTemplate">
+        <source>Launcher template "{0}" does not exist.</source>
+        <target state="new">Launcher template "{0}" does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingPassword">
+        <source>Missing Password option, this is required when using the CertFile option.</source>
+        <target state="new">Missing Password option, this is required when using the CertFile option.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingUseApplicationManifestForTrustInfo">
+        <source>When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</source>
+        <target state="new">When generating or updating an application manifest, the {0} option can only be used when the UseManifestForTrust option is set to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MultipleKeys">
+        <source>Only one type of signing method may be specified.</source>
+        <target state="new">Only one type of signing method may be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewLicense">
+        <source>New License</source>
+        <target state="new">New License</target>
+        <note>This is the title string for new licenses.  See Mage.cs:432</note>
+      </trans-unit>
+      <trans-unit id="NoKeySpecified">
+        <source>The -Sign command requires one of -CertFile, or -CertHash.</source>
+        <target state="new">The -Sign command requires one of -CertFile, or -CertHash.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoOutputFileSpecified">
+        <source>No output file was specified.  Please use -ToFile &lt;filename&gt;.</source>
+        <target state="new">No output file was specified.  Please use -ToFile &lt;filename&gt;.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoVerb">
+        <source>The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</source>
+        <target state="new">The first argument must be one of the following: -New, -Update, -Sign, -Verify, -AddLauncher</target>
+        <note>"-New, -Update, -Sign, -Verify, -AddLauncher" are command names and should not be translated</note>
+      </trans-unit>
+      <trans-unit id="NotAllowedCleanCache">
+        <source>ClearApplicationCache should not be used with any other switch.</source>
+        <target state="new">ClearApplicationCache should not be used with any other switch.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSomeErrorsEncountered">
+        <source>However, some errors were encountered.</source>
+        <target state="new">However, some errors were encountered.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyCreated">
+        <source>successfully created</source>
+        <target state="new">successfully created</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullySigned">
+        <source>successfully signed</source>
+        <target state="new">successfully signed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ResultSuccessfullyUpdated">
+        <source>successfully updated</source>
+        <target state="new">successfully updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SecurityMessage">
+        <source>Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</source>
+        <target state="new">Mage does not have the security permissions necessary to run.  Ensure that mage is not running from an untrusted source such as a network share or web site.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SignatureValidatedSuccessfully">
+        <source>Manifest has a valid signature.</source>
+        <target state="new">Manifest has a valid signature.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TooManyKeysSpecified">
+        <source>Only one of -KeyFile, -CertFile, or -CertHash can be used.</source>
+        <target state="new">Only one of -KeyFile, -CertFile, or -CertHash can be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLevelsNotSupportedOnNETCore">
+        <source>Setting trust level is not supported on .NET Core</source>
+        <target state="new">Setting trust level is not supported on .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TrustLicenseNotSigned">
+        <source>Trust license is not signed - "{0}"</source>
+        <target state="new">Trust license is not signed - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToOpenCertificate">
+        <source>Unable to open certificate "{0}":</source>
+        <target state="new">Unable to open certificate "{0}":</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnableToStartGUI">
+        <source>Unable to locate Mage UI - "{0}"</source>
+        <target state="new">Unable to locate Mage UI - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedParameter">
+        <source>Parameter not recognized - "{0}"</source>
+        <target state="new">Parameter not recognized - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerifyIsExclusive">
+        <source>'verify' command can't be combined with any other command.</source>
+        <target state="new">'verify' command can't be combined with any other command.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WarningMessage">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/clickonce/shared/NativeMethods.cs
+++ b/src/clickonce/shared/NativeMethods.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Deployment.Utilities
         internal static class Kernel32
         {
             public const UInt32 LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
+            public const int ERROR_SHARING_VIOLATION = -2147024864;
 
             [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
             public static extern IntPtr BeginUpdateResourceW(String fileName, bool deleteExistingResource);


### PR DESCRIPTION
This PR includes most of the planned features for the tool:
- Enable adding launcher to be deployed with .NET (Core) app
- Enable proper manifest dependencies for Core deployment, with Launcher, i.e CLR version, supported runtime, etc.
- Enable proper payload dependencies for Launcher-based deployments, i.e. all assemblies as simple files, etc.
- Remove support for sha1 and ia64
- Disable custom trust-levels except FullTrust - .NET (Core) does not support partial trust
- Remove wpfbrowser app support - not supported in .NET (Core)
- Clean up error handling classes
- Refactor some parts of command parsing code
- Enable Xliff generation and localization builds