### PR TITLE
Check for updates before starting the app

### DIFF
--- a/src/clickonce/MageCLI/Mage.cs
+++ b/src/clickonce/MageCLI/Mage.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Deployment.MageCLI
             {
                 manifest.Install = true;
                 manifest.UpdateEnabled = true;
-                manifest.UpdateMode = UpdateMode.Background;
+                manifest.UpdateMode = UpdateMode.Foreground;
             }
             else
             {
@@ -331,7 +331,7 @@ namespace Microsoft.Deployment.MageCLI
                 {
                     manifest.Install = true;
                     manifest.UpdateEnabled = true;
-                    manifest.UpdateMode = UpdateMode.Background;
+                    manifest.UpdateMode = UpdateMode.Foreground;
 
                     // We need to activate the set method on these fields since the XML
                     // representation might not be in sync with the propery value.


### PR DESCRIPTION
This change modifies the default update behavior in Mage generated manifests to match default Visual Studio experience.

In Visual Studio, when developer enables ClickOnce updates, default option is for updates to happen before the application starts. This enables end-user to install the update as soon as it's available.

Mage default was to check for update after app was launched, and offer it on next app launch.

I believe these two experiences should match and provide end-user with update sooner.

Developers can still modify their deployment manifest to get the old behavior, if desired.