### PR TITLE
Rename Mage.NET to dotnet-mage

### DIFF
--- a/src/clickonce/MageCLI/MageCLI.csproj
+++ b/src/clickonce/MageCLI/MageCLI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <BinplaceSymbols>true</BinplaceSymbols>
-    <AssemblyName>Mage.NET</AssemblyName>
+    <AssemblyName>dotnet-mage</AssemblyName>
     <OutputType>EXE</OutputType>
     <SignAssemblyAttribute>true</SignAssemblyAttribute>
     <RCSuppressManifest>true</RCSuppressManifest>


### PR DESCRIPTION
As previously planned, final name of Mage CLI tool will be "dotnet-mage".

Deployed as a .NET Global tool would allow usage as "dotnet-mage" and "dotnet mage" which fits the existing naming model for Microsoft's .NET Global tools.