### PR TITLE
Updating name of NETCoreCheck nuget package to follow naming convention

### DIFF
--- a/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck.pkgproj
+++ b/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck.pkgproj
@@ -4,7 +4,7 @@
     <Title>NetCoreCheck</Title>
     <Description>Provides NetCoreCheck tool, used for detection of .NET Core runtime.</Description>
     <PackageTags>dotnet;deployment-tools;netcorecheck</PackageTags>
-    <PackageId>VS.Redist.Common.NetCoreCheck.$(TargetArchitecture)</PackageId>
+    <PackageId>VS.Redist.Common.NETCoreCheck.$(TargetArchitecture)</PackageId>
     <IsShippingPackage>false</IsShippingPackage>
     <ContentTargetFolders>$(PackageTargetRid)</ContentTargetFolders>
   </PropertyGroup>


### PR DESCRIPTION
Fixing https://github.com/dotnet/deployment-tools/issues/18

VS.Redist.Common.NetCoreCheck -> VS.Redist.Common.NETCoreCheck