### PR TITLE
Updating package versioning for RTM build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,13 +6,12 @@
     <MajorVersion>5</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <!-- Set assembly version to align with major and minor version,
          as for the patches and revisions should be manually updated per assembly if it is serviced. -->
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <!-- Enable to remove prerelease label. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <!-- Opt-in/out repo features -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>

--- a/src/clickonce/launcher/Launcher.csproj
+++ b/src/clickonce/launcher/Launcher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable Condition="'$(TargetArchitecture)' == 'x86'">true</IsPackable>
-    <IsShipping>false</IsShipping>
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsShipping>true</IsShipping>
+    <IsShippingPackage>true</IsShippingPackage>
     <PackageId>VS.Redist.Common.NetCore.Launcher</PackageId>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!--

--- a/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck.pkgproj
+++ b/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck.pkgproj
@@ -5,7 +5,8 @@
     <Description>Provides NetCoreCheck tool, used for detection of .NET Core runtime.</Description>
     <PackageTags>dotnet;deployment-tools;netcorecheck</PackageTags>
     <PackageId>VS.Redist.Common.NETCoreCheck.$(TargetArchitecture)</PackageId>
-    <IsShippingPackage>false</IsShippingPackage>
+    <IsShipping>true</IsShipping>
+    <IsShippingPackage>true</IsShippingPackage>
     <ContentTargetFolders>$(PackageTargetRid)</ContentTargetFolders>
   </PropertyGroup>
 


### PR DESCRIPTION
Updating package versioning - removing pre-release labels.

Had to update IsShipping and IsShippingPackage to 'true' to get versioning tasks to work on VS packaging. While the packages are now binplaced under 'Shipping' folder, they will still get automatically published to VS Feed.