### PR TITLE
Marking non-shipping packages accordingly

### DIFF
--- a/src/clickonce/launcher/Launcher.csproj
+++ b/src/clickonce/launcher/Launcher.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable Condition="'$(TargetArchitecture)' == 'x86'">true</IsPackable>
-    <IsShipping>true</IsShipping>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShipping>false</IsShipping>
+    <IsShippingPackage>false</IsShippingPackage>
     <PackageId>VS.Redist.Common.NetCore.Launcher</PackageId>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!--

--- a/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck.pkgproj
+++ b/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck.pkgproj
@@ -5,8 +5,7 @@
     <Description>Provides NetCoreCheck tool, used for detection of .NET Core runtime.</Description>
     <PackageTags>dotnet;deployment-tools;netcorecheck</PackageTags>
     <PackageId>VS.Redist.Common.NETCoreCheck.$(TargetArchitecture)</PackageId>
-    <IsShipping>true</IsShipping>
-    <IsShippingPackage>true</IsShippingPackage>
+    <IsShippingPackage>false</IsShippingPackage>
     <ContentTargetFolders>$(PackageTargetRid)</ContentTargetFolders>
   </PropertyGroup>
 


### PR DESCRIPTION
VS.* packages should not use stable versions - reverting partial change in PR: https://github.com/dotnet/deployment-tools/pull/59