### PR TITLE
New NETCoreCheck package for nuget.org release - port of PR #63

### DIFF
--- a/src/clickonce/pkg/projects/NetCoreCheck/Directory.Build.props
+++ b/src/clickonce/pkg/projects/NetCoreCheck/Directory.Build.props
@@ -1,4 +1,5 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
     <Title>NetCoreCheck</Title>

--- a/src/clickonce/pkg/projects/NetCoreCheck/Directory.Build.props
+++ b/src/clickonce/pkg/projects/NetCoreCheck/Directory.Build.props
@@ -5,8 +5,6 @@
     <Title>NetCoreCheck</Title>
     <Description>Provides NetCoreCheck tool, used for detection of .NET Core runtime.</Description>
     <PackageTags>dotnet;deployment-tools;netcorecheck</PackageTags>
-    <PackageId>VS.Redist.Common.NETCoreCheck.$(TargetArchitecture)</PackageId>
-    <IsShippingPackage>false</IsShippingPackage>
     <ContentTargetFolders>$(PackageTargetRid)</ContentTargetFolders>
   </PropertyGroup>
 

--- a/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck-NonShipping.pkgproj
+++ b/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck-NonShipping.pkgproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    This package is shipping to VS Feed only. It will always have a unique version, that includes
+    pre-release or release suffixes and build number, even when built in release branches.
+
+    Release to VS Feed is automatic, as part of the build - not having a unique version would have
+    caused feed publishing, and build, failure.
+  -->
+
+  <PropertyGroup>
+    <PackageId>VS.Redist.Common.NETCoreCheck.$(TargetArchitecture)</PackageId>
+    <IsShippingPackage>false</IsShippingPackage>
+  </PropertyGroup>
+
+</Project>

--- a/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck-Shipping.pkgproj
+++ b/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck-Shipping.pkgproj
@@ -8,7 +8,7 @@
   -->
 
   <PropertyGroup>
-    <PackageId>Microsoft.Net.NETCoreCheck.$(TargetArchitecture)</PackageId>
+    <PackageId>Microsoft.NET.Tools.NETCoreCheck.$(TargetArchitecture)</PackageId>
     <IsShipping>true</IsShipping>
     <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>

--- a/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck-Shipping.pkgproj
+++ b/src/clickonce/pkg/projects/NetCoreCheck/NetCoreCheck-Shipping.pkgproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    This package is shipping to nuget.org. It will have a stable version, without pre-release
+    or release suffixes, when built in release branches.
+
+    Release to nuget.org is on-demand. Stable versions are expected for product releases.
+  -->
+
+  <PropertyGroup>
+    <PackageId>Microsoft.Net.NETCoreCheck.$(TargetArchitecture)</PackageId>
+    <IsShipping>true</IsShipping>
+    <IsShippingPackage>true</IsShippingPackage>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Port of https://github.com/dotnet/deployment-tools/pull/63

Introducing another NETCoreCheck package, for nuget.org release.

- Stable versioning (when building in release branches)
- New name: Microsoft.NET.Tools.NETCoreCheck
