### PR TITLE
Updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ all supported platforms, as well as the sources to .NET deployment tools.
 
 ## Tools documentation
 
-* [dotnet-mage](Documentation/dotnet-mage/README.md) usage patterns for dotnet-mage tool (currently called Mage.NET)
+* [dotnet-mage](Documentation/dotnet-mage/README.md) usage patterns for dotnet-mage tool (formerly Mage.NET)
 
 ## What is .NET?
 


### PR DESCRIPTION
Changing `currently called Mage.NET` to `formerly Mage.NET`