### PR TITLE
Update Arcade tooling

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -66,6 +66,11 @@
     <_subset>+$(_subset.Trim('+'))+</_subset>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Temporarily disable ClickOnce native build due to compiler mismatch issue with libnethost.lib -->
+    <DisableClickOnceNativeBuild>true</DisableClickOnceNativeBuild>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- ClickOnce -->
     <SubsetName Include="ClickOnce" Description="ClickOnce tools" />
@@ -90,8 +95,8 @@
   <ItemGroup Condition="$(_subset.Contains('+clickonce+'))">
     <ClickOnceProjectToBuild Include="$(ClickOnceProjectRoot)**\*.csproj" Pack="true" SignPhase="Binaries" />
     <ClickOnceProjectToBuild Include="$(ClickOnceProjectRoot)**\*.vcxproj" SignPhase="Binaries" />
-    <ClickOnceProjectToBuild Include="$(ClickOnceProjectRoot)**\*.proj" SignPhase="Binaries" />
-    <ClickOncePkgprojProjectToBuild Include="$(ClickOnceProjectRoot)pkg\projects\**\*.pkgproj" SignPhase="MsiFiles" BuildInParallel="false" />
+    <ClickOnceProjectToBuild Include="$(ClickOnceProjectRoot)**\*.proj" SignPhase="Binaries" Condition="'$(DisableClickOnceNativeBuild)' != 'true'" />
+    <ClickOncePkgprojProjectToBuild Include="$(ClickOnceProjectRoot)pkg\projects\**\*.pkgproj" SignPhase="MsiFiles" BuildInParallel="false" Condition="'$(DisableClickOnceNativeBuild)' != 'true'" />
     <ProjectToBuild Include="@(ClickOnceProjectToBuild)" BuildInParallel="true" Category="clickonce" />
     <ProjectToBuild Include="@(ClickOncePkgprojProjectToBuild)" Pack="true" Category="clickonce" />
   </ItemGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -142,33 +142,33 @@
       <Uri>https://github.com/dotnet/llvm-project</Uri>
       <Sha>214f08d74f9266a03e5836fe08855e6cd8b03b87</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-preview.4.20202.18">
+    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-preview.6.20264.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0375524a91a47ca4db3ee1be548f74bab7e26e76</Sha>
+      <Sha>bdd7235c43d762cea051cfc2071e14de48175f0c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="5.0.0-preview.4.20202.18">
+    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="5.0.0-preview.6.20264.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0375524a91a47ca4db3ee1be548f74bab7e26e76</Sha>
+      <Sha>bdd7235c43d762cea051cfc2071e14de48175f0c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="5.0.0-preview.4.20202.18">
+    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="5.0.0-preview.6.20264.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0375524a91a47ca4db3ee1be548f74bab7e26e76</Sha>
+      <Sha>bdd7235c43d762cea051cfc2071e14de48175f0c</Sha>
     </Dependency>
     <Dependency Name="runtime.native.System.IO.Ports" Version="5.0.0-alpha.1.19563.3">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cf64918877d98577363bb40d5eafac52beb80a79</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20202.18">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.6.20264.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0375524a91a47ca4db3ee1be548f74bab7e26e76</Sha>
+      <Sha>bdd7235c43d762cea051cfc2071e14de48175f0c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-preview.4.20202.18">
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="5.0.0-preview.6.20264.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0375524a91a47ca4db3ee1be548f74bab7e26e76</Sha>
+      <Sha>bdd7235c43d762cea051cfc2071e14de48175f0c</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="5.0.0-preview.4.20202.18">
+    <Dependency Name="System.Text.Json" Version="5.0.0-preview.6.20264.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>0375524a91a47ca4db3ee1be548f74bab7e26e76</Sha>
+      <Sha>bdd7235c43d762cea051cfc2071e14de48175f0c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="5.0.0-preview.3.20306.1">
       <Uri>https://github.com/mono/linker</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,61 +6,61 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.20529.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.20569.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ac072862d7613005f6f9849af8ba2c211098be6e</Sha>
+      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.IBC.CoreFx" Version="99.99.99-master-20190716.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,15 +62,15 @@
     <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20569.13</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20569.13</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- Installer dependencies -->
-    <MicrosoftNETCoreAppVersion>5.0.0-preview.4.20202.18</MicrosoftNETCoreAppVersion>
-    <MicrosoftNETCoreDotNetHostVersion>5.0.0-preview.4.20202.18</MicrosoftNETCoreDotNetHostVersion>
-    <MicrosoftNETCoreDotNetHostPolicyVersion>5.0.0-preview.4.20202.18</MicrosoftNETCoreDotNetHostPolicyVersion>
+    <MicrosoftNETCoreAppVersion>5.0.0-preview.6.20264.1</MicrosoftNETCoreAppVersion>
+    <MicrosoftNETCoreDotNetHostVersion>5.0.0-preview.6.20264.1</MicrosoftNETCoreDotNetHostVersion>
+    <MicrosoftNETCoreDotNetHostPolicyVersion>5.0.0-preview.6.20264.1</MicrosoftNETCoreDotNetHostPolicyVersion>
     <MicrosoftExtensionsDependencyModelVersion>3.1.0</MicrosoftExtensionsDependencyModelVersion>
     <!-- CoreClr dependencies -->
-    <MicrosoftNETCoreILAsmVersion>5.0.0-preview.4.20202.18</MicrosoftNETCoreILAsmVersion>
-    <MicrosoftNETSdkILVersion>5.0.0-preview.4.20202.18</MicrosoftNETSdkILVersion>
+    <MicrosoftNETCoreILAsmVersion>5.0.0-preview.6.20264.1</MicrosoftNETCoreILAsmVersion>
+    <MicrosoftNETSdkILVersion>5.0.0-preview.6.20264.1</MicrosoftNETSdkILVersion>
     <!-- Libraries dependencies -->
-    <SystemTextJsonVersion>5.0.0-preview.4.20202.18</SystemTextJsonVersion>
+    <SystemTextJsonVersion>5.0.0-preview.6.20264.1</SystemTextJsonVersion>
     <runtimenativeSystemIOPortsVersion>5.0.0-alpha.1.19563.3</runtimenativeSystemIOPortsVersion>
     <!-- Runtime-Assets dependencies -->
     <SystemComponentModelTypeConverterTestDataVersion>5.0.0-beta.20258.1</SystemComponentModelTypeConverterTestDataVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,16 +51,16 @@
   </ItemGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20529.3</MicrosoftDotNetApiCompatVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.20529.3</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.20529.3</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20529.3</MicrosoftDotNetGenAPIVersion>
-    <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.20529.3</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20529.3</MicrosoftDotNetXUnitExtensionsVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20529.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20529.3</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20529.3</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20529.3</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20569.13</MicrosoftDotNetApiCompatVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.20569.13</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.20569.13</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20569.13</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.20569.13</MicrosoftDotNetGenFacadesVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20569.13</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20569.13</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20569.13</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20569.13</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20569.13</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- Installer dependencies -->
     <MicrosoftNETCoreAppVersion>5.0.0-preview.4.20202.18</MicrosoftNETCoreAppVersion>
     <MicrosoftNETCoreDotNetHostVersion>5.0.0-preview.4.20202.18</MicrosoftNETCoreDotNetHostVersion>

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -99,8 +99,9 @@ function InsertMaestroPrivateFeedCredentials($Sources, $Creds, $Username, $Passw
 function EnablePrivatePackageSources($DisabledPackageSources) {
     $maestroPrivateSources = $DisabledPackageSources.SelectNodes("add[contains(@key,'darc-int')]")
     ForEach ($DisabledPackageSource in $maestroPrivateSources) {
-        Write-Host "`tEnsuring private source '$($DisabledPackageSource.key)' is enabled"
-        $DisabledPackageSource.SetAttribute("value", "false")
+        Write-Host "`tEnsuring private source '$($DisabledPackageSource.key)' is enabled by deleting it from disabledPackageSource"
+        # Due to https://github.com/NuGet/Home/issues/10291, we must actually remove the disabled entries
+        $DisabledPackageSources.RemoveChild($DisabledPackageSource)
     }
 }
 

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -158,8 +158,8 @@ if [ "$?" == "0" ]; then
     for DisabledSourceName in ${DisabledDarcIntSources[@]} ; do
         if [[ $DisabledSourceName == darc-int* ]]
             then
-                OldDisableValue="add key=\"$DisabledSourceName\" value=\"true\""
-                NewDisableValue="add key=\"$DisabledSourceName\" value=\"false\""
+                OldDisableValue="<add key=\"$DisabledSourceName\" value=\"true\" />"
+                NewDisableValue="<!-- Reenabled for build : $DisabledSourceName -->"
                 sed -i.bak "s|$OldDisableValue|$NewDisableValue|" $ConfigFile
                 echo "Neutralized disablePackageSources entry for '$DisabledSourceName'"
         fi

--- a/eng/jobs/steps/upload-job-artifacts.yml
+++ b/eng/jobs/steps/upload-job-artifacts.yml
@@ -4,6 +4,11 @@ parameters:
 steps:
 # Upload build outputs as build artifacts only if internal and not PR, to save storage space.
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - powershell: |
+     $ArtifactsFolderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
+     Write-Output "##vso[task.setvariable variable=FileExists]$ArtifactsFolderExists"
+    displayName: Detect Artifacts subdirectory
+
   - task: CopyFiles@2
     displayName: Prepare job-specific Artifacts subdirectory
     inputs:
@@ -13,7 +18,7 @@ steps:
         NonShipping/**/*
       TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
       CleanTargetFolder: true
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsFolderExists'], True))
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Artifacts

--- a/eng/jobs/steps/upload-job-artifacts.yml
+++ b/eng/jobs/steps/upload-job-artifacts.yml
@@ -5,9 +5,9 @@ steps:
 # Upload build outputs as build artifacts only if internal and not PR, to save storage space.
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - powershell: |
-     $ArtifactsFolderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
-     Write-Output "##vso[task.setvariable variable=FileExists]$ArtifactsFolderExists"
-    displayName: Detect Artifacts subdirectory
+     $folderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
+     Write-Output "##vso[task.setvariable variable=ArtifactsPackagesFolderExists]$folderExists"
+    displayName: Detect Packages subdirectory
 
   - task: CopyFiles@2
     displayName: Prepare job-specific Artifacts subdirectory
@@ -18,7 +18,12 @@ steps:
         NonShipping/**/*
       TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
       CleanTargetFolder: true
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsFolderExists'], True))
+    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsPackagesFolderExists'], True))
+
+  - powershell: |
+     $folderExists = Test-Path -Path "$(Build.StagingDirectory)/Artifacts"
+     Write-Output "##vso[task.setvariable variable=StagingArtifactsFolderExist]$folderExists"
+    displayName: Detect Staged Artifacts subdirectory
 
   - task: PublishBuildArtifacts@1
     displayName: Publish Artifacts
@@ -26,7 +31,7 @@ steps:
       pathToPublish: '$(Build.StagingDirectory)/Artifacts'
       artifactName: IntermediateUnsignedArtifacts
       artifactType: container
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
 
 # Upload build outputs as build artifacts only if internal and not PR, to save storage space.
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/global.json
+++ b/global.json
@@ -12,10 +12,10 @@
     "python3": "3.7.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20529.3",
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20529.3",
-    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20529.3",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20529.3",
+    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20569.13",
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20569.13",
+    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20569.13",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20569.13",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.4.20202.18",
     "Microsoft.Build.NoTargets": "1.0.53",


### PR DESCRIPTION
This PR includes several changes:

- Updates Arcade tooling with fixes for NuGet signing validation
- Temporarily disables build and packaging of native projects - see issue https://github.com/dotnet/deployment-tools/issues/77
- Fixes YAMLs to skip publishing steps for builds that do not produce any packages or other artifacts
