### PR TITLE
Update toolset to 5.0.2

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -68,7 +68,7 @@
 
   <PropertyGroup>
     <!-- Temporarily disable ClickOnce native build due to compiler mismatch issue with libnethost.lib -->
-    <DisableClickOnceNativeBuild>true</DisableClickOnceNativeBuild>
+    <DisableClickOnceNativeBuild>false</DisableClickOnceNativeBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.5.20251.2",
+    "version": "5.0.102",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "5.0.100-preview.6.20266.3"
+    "dotnet": "5.0.102"
   },
   "native-tools": {
     "cmake": "3.14.5",

--- a/src/clickonce/MageCLI/Application.cs
+++ b/src/clickonce/MageCLI/Application.cs
@@ -502,6 +502,11 @@ namespace Microsoft.Deployment.MageCLI
         MissingBinaryToLaunch,
 
         /// <summary>
+        /// Current platform cannot be used for signing.
+        /// </summary>
+        InvalidSigningPlatform,
+
+        /// <summary>
         /// The UseManifestForTrust argument needs to be set to true when generating/updating an application manifest
         /// while a Publisher or SupportURL argument is provided.
         /// </summary>

--- a/src/clickonce/MageCLI/Application.resx
+++ b/src/clickonce/MageCLI/Application.resx
@@ -564,4 +564,7 @@ Options:
   <data name="LauncherSuccessfullyAdded" xml:space="preserve">
     <value>Launcher successfully added.</value>
   </data>
+  <data name="InvalidSigningPlatform" xml:space="preserve">
+    <value>Signing is only supported on Windows.</value>
+  </data>
 </root>

--- a/src/clickonce/MageCLI/Certificate.cs
+++ b/src/clickonce/MageCLI/Certificate.cs
@@ -9,6 +9,9 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
 using System.Collections.Generic;
+#if RUNTIME_TYPE_NETCORE
+using System.Runtime.Versioning;
+#endif
 
 namespace Microsoft.Deployment.Utilities
 {
@@ -220,12 +223,19 @@ namespace Microsoft.Deployment.Utilities
         /// If the certificate has private key, this cert can be used for signing, if it does not, 
         /// try to access private key stored in the CSP, if CSP provider or key container name 
         /// is not provided, certificate can't be used for signing.
+        ///
+        /// In .NET 5+, CspParameters type is only available on Windows - this method cannot be used
+        /// on other platforms.
+        /// Signing is only supported on Windows, anyway, due to limitations in signing code in MSBuild.
         /// </summary>
         /// <param name="certificate">Certificate</param>
         /// <param name="cryptoProviderName">Crypto provider name</param>
         /// <param name="keyContainerName">Key container name</param>
         /// <param name="providerType">Provider type</param>
         /// <returns></returns>
+#if RUNTIME_TYPE_NETCORE
+        [SupportedOSPlatform("windows")]
+#endif
         public static bool SetPrivateKeyIfNeeded(X509Certificate2 certificate, string cryptoProviderName, string keyContainerName, int providerType = -1)
         {
             if (Certificate.HasPrivateKey(certificate))

--- a/src/clickonce/MageCLI/Command.cs
+++ b/src/clickonce/MageCLI/Command.cs
@@ -1052,6 +1052,13 @@ namespace Microsoft.Deployment.MageCLI
         {
             bool result = true;
 
+            // Signing is only supported on Windows.
+            if (!OperatingSystem.IsWindows())
+            {
+                Application.PrintErrorMessage(ErrorMessages.InvalidSigningPlatform);
+                return false;
+            }
+
             if (Requested(Operations.GenerateSomething) == false)
             {
                 // Make sure an input file was specified and exists
@@ -1129,7 +1136,12 @@ namespace Microsoft.Deployment.MageCLI
                             {
                                 Application.PrintErrorMessage(ErrorMessages.InvalidCertUsage, certPath);
                             }
+#if RUNTIME_TYPE_NETCORE
+                            // SetPrivateKeyIfNeeded API is only available on Windows
+                            else if (OperatingSystem.IsWindows())
+#else
                             else
+#endif
                             {
                                 result = Utilities.Certificate.SetPrivateKeyIfNeeded(cert, cryptoProviderName, keyContainer);
                                 if (!result)
@@ -1258,7 +1270,9 @@ namespace Microsoft.Deployment.MageCLI
             return result;
         }
 
+#if !RUNTIME_TYPE_NETCORE
         [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.Demand, Name="FullTrust")]
+#endif
         public void ExecuteManifestRelated()
         {
             Manifest manifest = null;

--- a/src/clickonce/MageCLI/CryptoApi.cs
+++ b/src/clickonce/MageCLI/CryptoApi.cs
@@ -155,7 +155,9 @@ namespace Microsoft.Deployment.Utilities
     /// </summary>
     internal sealed class CAPI : CAPIMethods
     {
+#if DEBUG
         private const int ERROR_NO_MORE_ITEMS = 259;
+#endif
         internal const uint PP_ENUMCONTAINERS = 2;
         internal const uint CRYPT_FIRST = 1;
         internal const uint CRYPT_NEXT = 2;

--- a/src/clickonce/MageCLI/CryptoApi.cs
+++ b/src/clickonce/MageCLI/CryptoApi.cs
@@ -180,6 +180,8 @@ namespace Microsoft.Deployment.Utilities
             out int errorCode)
         {
             errorCode = 0;
+
+#if !RUNTIME_TYPE_NETCORE
             CspParameters parameters = new CspParameters();
             parameters.ProviderName = pwszProvider;
             parameters.KeyContainerName = pwszContainer;
@@ -191,6 +193,7 @@ namespace Microsoft.Deployment.Utilities
             KeyContainerPermissionAccessEntry entry = new KeyContainerPermissionAccessEntry(parameters, KeyContainerPermissionFlags.Open);
             kp.AccessEntries.Add(entry);
             kp.Demand();
+#endif
 
             bool rc = CAPIMethods.CryptAcquireContext(ref hCryptProv,
                                                       pwszContainer,
@@ -229,13 +232,15 @@ namespace Microsoft.Deployment.Utilities
 
         internal static bool CertSetKeyProviderInfoProperty(IntPtr pCert, SafeLocalAllocHandle handle)
         {
-            if (pCert == null)
+            if (pCert == IntPtr.Zero)
                 throw new ArgumentNullException(nameof(pCert));
 
             if (handle.IsInvalid)
                 throw new ArgumentException(nameof(handle));
 
+#if !RUNTIME_TYPE_NETCORE
             new PermissionSet(PermissionState.Unrestricted).Demand();
+#endif
 
             return CertSetCertificateContextProperty(pCert, CAPI.CERT_KEY_PROV_INFO_PROP_ID, 0, handle);
         }
@@ -316,8 +321,11 @@ namespace Microsoft.Deployment.Utilities
         }
 
         [DllImport(CAPI.KERNEL32, SetLastError=true),
-         SuppressUnmanagedCodeSecurity,
-         ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+         SuppressUnmanagedCodeSecurity
+#if !RUNTIME_TYPE_NETCORE
+         , ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)
+#endif
+        ]
         private static extern int LocalFree(IntPtr handle);
 
         override protected bool ReleaseHandle()
@@ -340,8 +348,11 @@ namespace Microsoft.Deployment.Utilities
         }
 
         [DllImport(CAPI.ADVAPI32, SetLastError=true),
-         SuppressUnmanagedCodeSecurity,
-         ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+         SuppressUnmanagedCodeSecurity
+#if !RUNTIME_TYPE_NETCORE
+         , ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)
+#endif
+        ]
         private static extern bool CryptReleaseContext(IntPtr hCryptProv, uint dwFlags); 
 
         override protected bool ReleaseHandle()

--- a/src/clickonce/MageCLI/xlf/Application.cs.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.cs.xlf
@@ -639,6 +639,11 @@ Možnosti:
         <target state="translated">Možnost -RequiredUpdate musí mít hodnotu true, false, t nebo f – {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">Zadaný identifikátor URI pro časová razítka není platný.</target>

--- a/src/clickonce/MageCLI/xlf/Application.de.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.de.xlf
@@ -639,6 +639,11 @@ Optionen:
         <target state="translated">Die Option "-RequiredUpdate" muss "true", "false", "t" oder "f" sein: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">Der angegebene URI für den Zeitstempel ist ungültig.</target>

--- a/src/clickonce/MageCLI/xlf/Application.es.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.es.xlf
@@ -639,6 +639,11 @@ Opciones:
         <target state="translated">La opción -RequiredUpdate debe ser "true", "false", "t" o "f" - "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">El URI de marca de tiempo especificado no es válido.</target>

--- a/src/clickonce/MageCLI/xlf/Application.fr.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.fr.xlf
@@ -639,6 +639,11 @@ Options :
         <target state="translated">L'option -RequiredUpdate doit avoir la valeur "true", "false", "t" ou "f" - "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">L'URI d'horodatage spécifiée n'est pas valide.</target>

--- a/src/clickonce/MageCLI/xlf/Application.it.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.it.xlf
@@ -639,6 +639,11 @@ Opzioni:
         <target state="translated">L'opzione -RequiredUpdate deve essere "true", "false", "t" o "f" - "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">L'URI del timestamp specificato non è valido.</target>

--- a/src/clickonce/MageCLI/xlf/Application.ja.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ja.xlf
@@ -639,6 +639,11 @@ Options:
         <target state="translated">-RequiredUpdate オプションは、"true"、"false"、"t"、"f" のいずれかでなければなりません - "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">指定されたタイムスタンプ URI は無効です。</target>

--- a/src/clickonce/MageCLI/xlf/Application.ko.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ko.xlf
@@ -639,6 +639,11 @@ Options:
         <target state="translated">-RequiredUpdate 옵션은 "true", "false", "t" 또는 "f"여야 합니다. "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">지정한 타임스탬프 URI가 잘못되었습니다.</target>

--- a/src/clickonce/MageCLI/xlf/Application.pl.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.pl.xlf
@@ -639,6 +639,11 @@ Opcje:
         <target state="translated">Opcja -RequiredUpdate musi mieć wartość „true”, „false”, „t” lub „f” — „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">Określony identyfikator URI sygnatury czasowej jest nieprawidłowy.</target>

--- a/src/clickonce/MageCLI/xlf/Application.pt-BR.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.pt-BR.xlf
@@ -639,6 +639,11 @@ Opções:
         <target state="translated">A opção -RequiredUpdate precisa ser "true", "false", "t" ou "f" – "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">O URI de carimbo de data/hora especificado não é válido.</target>

--- a/src/clickonce/MageCLI/xlf/Application.ru.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ru.xlf
@@ -639,6 +639,11 @@ Options:
         <target state="translated">Параметр -RequiredUpdate должен принимать значения "true", "false", "t" или "f" - "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">Указана недопустимая отметка времени URI.</target>

--- a/src/clickonce/MageCLI/xlf/Application.tr.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.tr.xlf
@@ -639,6 +639,11 @@ Seçenekler:
         <target state="translated">-RequiredUpdate seçeneği "true", "false", "t" veya "f" olmalıdır: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">Belirtilen zaman damgası URI'si geçerli değil.</target>

--- a/src/clickonce/MageCLI/xlf/Application.zh-Hans.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.zh-Hans.xlf
@@ -639,6 +639,11 @@ Options:
         <target state="translated">-RequiredUpdate 选项必须为“true”、“false”、“t”或“f”-“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">指定的时间戳 URI 无效。</target>

--- a/src/clickonce/MageCLI/xlf/Application.zh-Hant.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.zh-Hant.xlf
@@ -639,6 +639,11 @@ Options:
         <target state="translated">-RequiredUpdate 選項必須是 "true"、"false"、"t" 或 "f" - "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSigningPlatform">
+        <source>Signing is only supported on Windows.</source>
+        <target state="new">Signing is only supported on Windows.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidTimestamp">
         <source>The timestamp URI specified is not valid.</source>
         <target state="translated">指定的時間戳記 URI 無效。</target>

--- a/src/clickonce/native/Windows/gen-buildsys-win.bat
+++ b/src/clickonce/native/Windows/gen-buildsys-win.bat
@@ -5,7 +5,7 @@ rem This file invokes cmake and generates the build system for windows.
 set argC=0
 for %%x in (%*) do Set /A argC+=1
 
-if NOT %argC%==7 GOTO :USAGE
+if NOT %argC%==8 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
 setlocal
@@ -25,10 +25,11 @@ if /i "%__Arch%" == "arm64"   (set cm_BaseRid=win10&&set __ExtraCmakeParams=%__E
 set __LatestCommit=%4
 set __NativeVersion=%5
 set __NetCorePkgVersion=%6
+set __DotnetInstallDir=%~7
 shift
 
 :: Form the base RID to be used if we are doing a portable build
-if /i "%7" == "1"       (set cm_BaseRid=win)
+if /i "%8" == "1"       (set cm_BaseRid=win)
 set cm_BaseRid=%cm_BaseRid%-%__Arch%
 echo "Computed RID for native build is %cm_BaseRid%"
 
@@ -43,7 +44,7 @@ popd
 set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCMAKE_SYSTEM_VERSION=10.0" "-DCLI_CMAKE_NATIVE_VER=%__NativeVersion%"
 set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCLI_CMAKE_PKG_RID=%cm_BaseRid%" "-DCLI_CMAKE_COMMIT_HASH=%__LatestCommit%" "-DCLR_CMAKE_HOST_ARCH=%__Arch%"
 set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DCLI_CMAKE_RESOURCE_DIR=%__ResourcesDir%" "-DCLR_ENG_NATIVE_DIR=%__sourceDir%\..\..\..\eng\native"
-set __ExtraCmakeParams=%__ExtraCmakeParams% "-DNET_CORE_PKG_VER=%__NetCorePkgVersion%" "-DDOTNET_PACKS_DIR="%__sourceDir%\..\..\..\.dotnet\packs"
+set __ExtraCmakeParams=%__ExtraCmakeParams% "-DNET_CORE_PKG_VER=%__NetCorePkgVersion%" "-DDOTNET_PACKS_DIR=%__DotnetInstallDir%\packs"
 
 echo "%CMakePath%" %__sourceDir% -G "Visual Studio %__VSString%" %__ExtraCmakeParams%
 "%CMakePath%" %__sourceDir% -G "Visual Studio %__VSString%" %__ExtraCmakeParams%

--- a/src/clickonce/native/build.cmd
+++ b/src/clickonce/native/build.cmd
@@ -14,6 +14,7 @@ set "__LinkArgs= "
 set "__LinkLibraries= "
 set __PortableBuild=0
 set __IncrementalNativeBuild=0
+set __DotnetInstallDir=%~dp0..\..\..\.dotnet
 
 :Arg_Loop
 if [%1] == [] goto :ToolsVersion
@@ -35,6 +36,7 @@ if /i [%1] == [netcorepkgver]  ( set __NetCorePkgVersion=%2&&shift&&shift&goto A
 if /i [%1] == [commit]         ( set __CommitSha=%2&&shift&&shift&goto Arg_Loop)
 
 if /i [%1] == [incremental-native-build] ( set __IncrementalNativeBuild=1&&shift&goto Arg_Loop)
+if /i [%1] == [dotnetInstallDir]     ( set __DotnetInstallDir=%~2&&shift&&shift&goto Arg_Loop)
 if /i [%1] == [rootDir]        ( set __rootDir=%2&&shift&&shift&goto Arg_Loop)
 
 shift
@@ -125,9 +127,9 @@ exit /b 1
 :GenVSSolution
 :: Regenerate the VS solution
 
-echo Calling "%__nativeWindowsDir%\gen-buildsys-win.bat %~dp0 "%__VSVersion%" %__BuildArch% %__CommitSha% %__NativeVersion% %__NetCorePkgVersion% %__PortableBuild%"
+echo Calling "%__nativeWindowsDir%\gen-buildsys-win.bat %~dp0 "%__VSVersion%" %__BuildArch% %__CommitSha% %__NativeVersion% %__NetCorePkgVersion% "%__DotnetInstallDir%" %__PortableBuild%"
 pushd "%__IntermediatesDir%"
-call "%__nativeWindowsDir%\gen-buildsys-win.bat" %~dp0 "%__VSVersion%" %__BuildArch% %__CommitSha% %__NativeVersion% %__NetCorePkgVersion% %__PortableBuild%
+call "%__nativeWindowsDir%\gen-buildsys-win.bat" %~dp0 "%__VSVersion%" %__BuildArch% %__CommitSha% %__NativeVersion% %__NetCorePkgVersion% "%__DotnetInstallDir%" %__PortableBuild%
 popd
 
 :CheckForProj

--- a/src/clickonce/native/build.proj
+++ b/src/clickonce/native/build.proj
@@ -40,7 +40,7 @@
       <BuildArgs>$(Configuration) $(TargetArchitecture) nativever $(NativeVersion) netcorepkgver $(BundledNETCoreAppPackageVersion) commit $(LatestCommit) rid $(OutputRid)</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' == 'true'">$(BuildArgs) portable</BuildArgs>
       <BuildArgs Condition="'$(IncrementalNativeBuild)' == 'true'">$(BuildArgs) incremental-native-build</BuildArgs>
-      <BuildArgs>$(BuildArgs) rootdir $(RepoRoot)</BuildArgs>
+      <BuildArgs>$(BuildArgs) dotnetInstallDir "$(DOTNET_INSTALL_DIR)" rootdir $(RepoRoot)</BuildArgs>
     </PropertyGroup>
 
     <!--


### PR DESCRIPTION
Besides updating toolset to 5.0.2, this PR includes the following changes:
- re-enable native projects
- enable linking to SDK libraries in both local or global locations
- fix all issues in managed code caused by new strict rules in 5.0.2 - condition APIs and constructs that are obsolete in .NET 5 and add guards for platform-specific APIs
- add condition and error message for signing in dotnet-mage - prevents errors on unsupported platforms