### PR TITLE
Arcade update January 2021

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,61 +6,61 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.20569.13">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.21064.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>772260960df1337d7448bcc97af1fced236eff63</Sha>
+      <Sha>2882fdde84f3f70fd74f9e408cc961dc07384d69</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.IBC.CoreFx" Version="99.99.99-master-20190716.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,16 +51,16 @@
   </ItemGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20569.13</MicrosoftDotNetApiCompatVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.20569.13</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.20569.13</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20569.13</MicrosoftDotNetGenAPIVersion>
-    <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.20569.13</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20569.13</MicrosoftDotNetXUnitExtensionsVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20569.13</MicrosoftDotNetXUnitConsoleRunnerVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20569.13</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20569.13</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20569.13</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.21064.2</MicrosoftDotNetApiCompatVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.21064.2</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.21064.2</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.21064.2</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.21064.2</MicrosoftDotNetGenFacadesVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.21064.2</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.21064.2</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.21064.2</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.21064.2</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.21064.2</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- Installer dependencies -->
     <MicrosoftNETCoreAppVersion>5.0.0-preview.6.20264.1</MicrosoftNETCoreAppVersion>
     <MicrosoftNETCoreDotNetHostVersion>5.0.0-preview.6.20264.1</MicrosoftNETCoreDotNetHostVersion>

--- a/global.json
+++ b/global.json
@@ -12,10 +12,10 @@
     "python3": "3.7.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20569.13",
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20569.13",
-    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20569.13",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20569.13",
+    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.21064.2",
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.21064.2",
+    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.21064.2",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.21064.2",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.4.20202.18",
     "Microsoft.Build.NoTargets": "1.0.53",


### PR DESCRIPTION
Update Arcade toolset with latest - this fixes the issue with symbol publishing due to some missing nuget feeds.