### PR TITLE
Add debugger display bits

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/AspNetCoreReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/AspNetCoreReleaseComponent.cs
@@ -36,9 +36,7 @@ namespace Microsoft.Deployment.DotNet.Releases
 
         internal AspNetCoreReleaseComponent(JToken token, ProductRelease release) : base(token, release)
         {
-#pragma warning disable CA1825 // Avoid zero-length array allocations, Array.Empty<T> is only supported in netstandard2.1
             AspNetCoreModuleVersions = new ReadOnlyCollection<Version>(token["version-aspnetcoremodule"]?.ToObject<Version[]>(Utils.DefaultSerializer) ?? new Version[] { });
-#pragma warning restore CA1825 // Avoid zero-length array allocations
             VisualStudioVersion = (string)token["vs-version"];
         }
     }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Cve.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Cve.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Deployment.DotNet.Releases
     {
         /// <summary>
         /// The identifier of the CVE.
-        /// </summary>        
+        /// </summary>
         public string Id
         {
             get;
@@ -24,7 +24,7 @@ namespace Microsoft.Deployment.DotNet.Releases
 
         /// <summary>
         /// The URI pointing to a description of the vulnerability.
-        /// </summary>        
+        /// </summary>
         public Uri DescriptionLink
         {
             get;
@@ -46,7 +46,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         public bool Equals(Cve other)
         {
             return ReferenceEquals(this, other) ||
-                (Id == other.Id && DescriptionLink == other.DescriptionLink);
+                Id == other.Id && DescriptionLink == other.DescriptionLink;
         }
 
         /// <summary>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/JsonExtensions.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/JsonExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Deployment.DotNet.Releases
     {
         internal static bool IsNullOrEmpty(this JToken token)
         {
-            return (token == null) || (token.Type == JTokenType.Null) || (!token.HasValues);
+            return token is null || token is { Type: JTokenType.Null } || !token.HasValues;
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -3,14 +3,15 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>      
+    <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>
   </PropertyGroup>
-  
-  <PropertyGroup>  
+
+  <PropertyGroup>
     <IsPackable Condition="'$(TargetArchitecture)' == 'x86'">true</IsPackable>
     <IsShipping>true</IsShipping>
     <PackageId>Microsoft.Deployment.DotNet.Releases</PackageId>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <RootNamespace>Microsoft.Deployment.DotNet.Releases</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableXlfLocalization>true</EnableXlfLocalization>
@@ -20,9 +21,10 @@
     </Description>
   </PropertyGroup>
 
-  <ItemGroup>    
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ namespace Microsoft.Deployment.DotNet.Releases
     /// <summary>
     /// Provides an overview of a single product, including information related to its support level and the latest SDK and runtime releases.
     /// </summary>
+    [DebuggerDisplay("{ProductName} {ProductVersion} ({SupportPhase})")]
     public class Product
     {
         /// <summary>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseComponent.cs
@@ -65,12 +65,15 @@ namespace Microsoft.Deployment.DotNet.Releases
             Version = token["version"]?.ToObject<ReleaseVersion>(Utils.DefaultSerializer);
             DisplayVersion = token["version-display"]?.ToString();
             JToken filesToken = token["files"];
-            List<ReleaseFile> fileList = filesToken.IsNullOrEmpty() ? new List<ReleaseFile>() :
-                JsonConvert.DeserializeObject<List<ReleaseFile>>(filesToken.ToString(), Utils.DefaultSerializerSettings);
+            List<ReleaseFile> fileList = filesToken.IsNullOrEmpty()
+                ? new List<ReleaseFile>()
+                : JsonConvert.DeserializeObject<List<ReleaseFile>>(
+                    filesToken.ToString(), Utils.DefaultSerializerSettings);
             Release = release;
 
             // Trim out marketing files. Users should never interact with these
-            Files = new ReadOnlyCollection<ReleaseFile>(fileList.Where(f => !f.Name.Contains("-gs") || !f.Name.Contains("-nj")).ToList());
+            Files = new ReadOnlyCollection<ReleaseFile>(
+                fileList.Where(f => !f.Name.Contains("-gs") || !f.Name.Contains("-nj")).ToList());
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseFile.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseFile.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Deployment.DotNet.Releases
         }
 
         [JsonConstructor]
-        internal ReleaseFile([JsonProperty(PropertyName = "hash")] string hash,
+        internal ReleaseFile(
+            [JsonProperty(PropertyName = "hash")] string hash,
             [JsonProperty(PropertyName = "name")] string name,
             [JsonProperty(PropertyName = "rid")] string rid,
             [JsonProperty(PropertyName = "url")] string address)

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseVersion.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseVersion.cs
@@ -17,17 +17,20 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <summary>
         /// Regular expression for capturing the pre-release part of a semantic version.
         /// </summary>
-        private const string PrereleasePattern = @"(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)";
+        private const string PrereleasePattern =
+            @"(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)";
 
         /// <summary>
         /// Regular expression for capturing the build-metadata part of a semantic version.
         /// </summary>
-        private const string BuildMetadataPattern = @"(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)";
+        private const string BuildMetadataPattern =
+            @"(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)";
 
         /// <summary>
         /// Regular expression for v2 semantic version to capture components into separate groups: major, minor, patch, prerelease and build.
         /// </summary>
-        private static readonly string s_semanticVersion2Pattern = $@"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-{PrereleasePattern})?(?:\+{BuildMetadataPattern})?$";
+        private static readonly string s_semanticVersion2Pattern =
+            $@"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-{PrereleasePattern})?(?:\+{BuildMetadataPattern})?$";
 
         /// <summary>
         /// The build metadata of the version or <see langword="null"/>.
@@ -104,7 +107,6 @@ namespace Microsoft.Deployment.DotNet.Releases
         public ReleaseVersion(string version)
         {
             Match match = Regex.Match(version, s_semanticVersion2Pattern);
-
             if (!match.Success)
             {
                 throw new FormatException(string.Format(ReleasesResources.InvalidVersion, version));
@@ -166,10 +168,9 @@ namespace Microsoft.Deployment.DotNet.Releases
             Minor = minor;
             Patch = patch;
 
-            if (!string.IsNullOrEmpty(prerelease))
+            if (!string.IsNullOrWhiteSpace(prerelease))
             {
                 Match prereleaseMatch = Regex.Match(prerelease, $@"^{PrereleasePattern}$");
-
                 if (!prereleaseMatch.Groups["prerelease"].Success)
                 {
                     throw new FormatException(string.Format(ReleasesResources.InvalidPrerelease, prerelease));
@@ -178,10 +179,9 @@ namespace Microsoft.Deployment.DotNet.Releases
                 Prerelease = prereleaseMatch.Groups["prerelease"].Value;
             }
 
-            if (!string.IsNullOrEmpty(buildMetadata))
+            if (!string.IsNullOrWhiteSpace(buildMetadata))
             {
                 Match buildMetadataMatch = Regex.Match(buildMetadata, $@"^{BuildMetadataPattern}$");
-
                 if (!buildMetadataMatch.Groups["buildmetadata"].Success)
                 {
                     throw new FormatException(string.Format(ReleasesResources.InvalidBuildMetadata, buildMetadata));
@@ -213,21 +213,18 @@ namespace Microsoft.Deployment.DotNet.Releases
             }
 
             int result = Major.CompareTo(value.Major);
-
             if (result != 0)
             {
                 return result;
             }
 
             result = Minor.CompareTo(value.Minor);
-
             if (result != 0)
             {
                 return result;
             }
 
             result = Patch.CompareTo(value.Patch);
-
             if (result != 0)
             {
                 return result;
@@ -245,10 +242,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// Returns a signed integer indicating whether this instance precedes, follows or appears in the same position in 
         /// the sort order as the specified <paramref name="obj"/>.
         /// </returns>
-        public int CompareTo(object obj)
-        {
-            return CompareTo((ReleaseVersion)obj);
-        }
+        public int CompareTo(object obj) => CompareTo((ReleaseVersion)obj);
 
         /// <summary>
         /// Compares this instance to the specified object and returns an indication of their relative values.
@@ -258,7 +252,6 @@ namespace Microsoft.Deployment.DotNet.Releases
         public int CompareTo(ReleaseVersion other)
         {
             int result = ComparePrecedenceTo(other);
-
             if (result != 0)
             {
                 return result;
@@ -274,7 +267,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <returns><see langword="true"/> if the specified object is equal to the current object; <see langword="false"/> otherwise.</returns>
         public override bool Equals(object obj)
         {
-            if ((obj is null) || !(obj is ReleaseVersion))
+            if (obj is null || !(obj is ReleaseVersion releaseVersion))
             {
                 return false;
             }
@@ -284,7 +277,7 @@ namespace Microsoft.Deployment.DotNet.Releases
                 return true;
             }
 
-            ReleaseVersion other = (ReleaseVersion)obj;
+            ReleaseVersion other = releaseVersion;
 
             return Major == other.Major && Minor == other.Minor && Patch == other.Patch &&
                 string.Equals(Prerelease, other.Prerelease, StringComparison.Ordinal) &&
@@ -322,8 +315,8 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode()
         {
-            return Major ^ Minor ^ Patch ^ (!string.IsNullOrEmpty(Prerelease) ? Prerelease.GetHashCode() : 0) ^
-                (!string.IsNullOrEmpty(BuildMetadata) ? BuildMetadata.GetHashCode() : 0);
+            return Major ^ Minor ^ Patch ^ (!string.IsNullOrWhiteSpace(Prerelease) ? Prerelease.GetHashCode() : 0) ^
+                (!string.IsNullOrWhiteSpace(BuildMetadata) ? BuildMetadata.GetHashCode() : 0);
         }
 
         /// <summary>
@@ -332,11 +325,8 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="value">The value to compare.</param>
         /// <returns>
         /// <see langword="true"/> if both values have the same sort order; <see langword="false"/> otherwise.
-        /// </returns>        
-        public bool PrecedenceEquals(ReleaseVersion value)
-        {
-            return ComparePrecedenceTo(value) == 0;
-        }
+        /// </returns>
+        public bool PrecedenceEquals(ReleaseVersion value) => ComparePrecedenceTo(value) == 0;
 
         /// <summary>
         /// Returns a <see cref="string"/> representation of this <see cref="ReleaseVersion"/>.
@@ -345,8 +335,8 @@ namespace Microsoft.Deployment.DotNet.Releases
         public override string ToString()
         {
             string v = $"{Major}.{Minor}.{Patch}";
-            v += !string.IsNullOrEmpty(Prerelease) ? $"-{Prerelease}" : string.Empty;
-            v += !string.IsNullOrEmpty(BuildMetadata) ? $"+{BuildMetadata}" : string.Empty;
+            v += !string.IsNullOrWhiteSpace(Prerelease) ? $"-{Prerelease}" : string.Empty;
+            v += !string.IsNullOrWhiteSpace(BuildMetadata) ? $"+{BuildMetadata}" : string.Empty;
 
             return v;
         }
@@ -366,8 +356,8 @@ namespace Microsoft.Deployment.DotNet.Releases
             }
 
             string value = fieldCount == 1 ? $"{Major}" : fieldCount == 2 ? $"{Major}.{Minor}" : $"{Major}.{Minor}.{Patch}";
-            value += fieldCount >= 4 && !string.IsNullOrEmpty(Prerelease) ? $"-{Prerelease}" : string.Empty;
-            value += fieldCount >= 5 && !string.IsNullOrEmpty(BuildMetadata) ? $"+{BuildMetadata}" : string.Empty;
+            value += fieldCount >= 4 && !string.IsNullOrWhiteSpace(Prerelease) ? $"-{Prerelease}" : string.Empty;
+            value += fieldCount >= 5 && !string.IsNullOrWhiteSpace(BuildMetadata) ? $"+{BuildMetadata}" : string.Empty;
 
             return value;
         }
@@ -420,7 +410,7 @@ namespace Microsoft.Deployment.DotNet.Releases
                 return true;
             }
 
-            if ((a is null) || (b is null))
+            if (a is null || b is null)
             {
                 return false;
             }
@@ -434,10 +424,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="a">The first <see cref="ReleaseVersion"/> object.</param>
         /// <param name="b">The second <see cref="ReleaseVersion"/> object.</param>
         /// <returns><see langword="true"/> if <paramref name="a"/> equals <paramref name="b"/>;otherwise <see langword="false"/>.</returns>
-        public static bool operator ==(ReleaseVersion a, ReleaseVersion b)
-        {
-            return Equals(a, b);
-        }
+        public static bool operator ==(ReleaseVersion a, ReleaseVersion b) => Equals(a, b);
 
         /// <summary>
         /// Determines whether two specified <see cref="ReleaseVersion"/> objects are unequal.
@@ -445,10 +432,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="a">The first <see cref="ReleaseVersion"/> object.</param>
         /// <param name="b">The second <see cref="ReleaseVersion"/> object.</param>
         /// <returns><see langword="true"/> if <paramref name="a"/> does not equal <paramref name="b"/>;otherwise <see langword="false"/>.</returns>
-        public static bool operator !=(ReleaseVersion a, ReleaseVersion b)
-        {
-            return !Equals(a, b);
-        }
+        public static bool operator !=(ReleaseVersion a, ReleaseVersion b) => !Equals(a, b);
 
         /// <summary>
         /// Determines whether the first <see cref="ReleaseVersion"/> object is greater than the 
@@ -457,10 +441,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="a">The first <see cref="ReleaseVersion"/> object.</param>
         /// <param name="b">The second <see cref="ReleaseVersion"/> object.</param>
         /// <returns><see langword="true"/> if <paramref name="a"/> is greater than <paramref name="b"/>;otherwise <see langword="false"/>.</returns>
-        public static bool operator >(ReleaseVersion a, ReleaseVersion b)
-        {
-            return Compare(a, b) > 0;
-        }
+        public static bool operator >(ReleaseVersion a, ReleaseVersion b) => Compare(a, b) > 0;
 
         /// <summary>
         /// Determines whether the first <see cref="ReleaseVersion"/> object is greater than or equal to the 
@@ -469,10 +450,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="a">The first <see cref="ReleaseVersion"/> object.</param>
         /// <param name="b">The second <see cref="ReleaseVersion"/> object.</param>
         /// <returns><see langword="true"/> if <paramref name="a"/> is greater than or equal to <paramref name="b"/>;otherwise <see langword="false"/>.</returns>
-        public static bool operator >=(ReleaseVersion a, ReleaseVersion b)
-        {
-            return Compare(a, b) >= 0;
-        }
+        public static bool operator >=(ReleaseVersion a, ReleaseVersion b) => Compare(a, b) >= 0;
 
         /// <summary>
         /// Determines whether the first <see cref="ReleaseVersion"/> object is less than the 
@@ -481,10 +459,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="a">The first <see cref="ReleaseVersion"/> object.</param>
         /// <param name="b">The second <see cref="ReleaseVersion"/> object.</param>
         /// <returns><see langword="true"/> if <paramref name="a"/> is less than <paramref name="b"/>;otherwise <see langword="false"/>.</returns>
-        public static bool operator <(ReleaseVersion a, ReleaseVersion b)
-        {
-            return Compare(a, b) < 0;
-        }
+        public static bool operator <(ReleaseVersion a, ReleaseVersion b) => Compare(a, b) < 0;
 
         /// <summary>
         /// Determines whether the first <see cref="ReleaseVersion"/> object is less than or equal to the 
@@ -493,22 +468,19 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="a">The first <see cref="ReleaseVersion"/> object.</param>
         /// <param name="b">The second <see cref="ReleaseVersion"/> object.</param>
         /// <returns><see langword="true"/> if <paramref name="a"/> is less than or equal to <paramref name="b"/>;otherwise <see langword="false"/>.</returns>
-        public static bool operator <=(ReleaseVersion a, ReleaseVersion b)
-        {
-            return Compare(a, b) <= 0;
-        }
+        public static bool operator <=(ReleaseVersion a, ReleaseVersion b) => Compare(a, b) <= 0;
         #endregion
 
         internal static int CompareIdentifiers(string identifierA, string identifierB)
         {
             // https://semver.org/#spec-item-11
             // A non-prerelease version has a higher precendence than pre-release, e.g. 1.0.0 and 1.0.0-preview2
-            if (string.IsNullOrEmpty(identifierA))
+            if (string.IsNullOrWhiteSpace(identifierA))
             {
-                return string.IsNullOrEmpty(identifierB) ? 0 : 1;
+                return string.IsNullOrWhiteSpace(identifierB) ? 0 : 1;
             }
 
-            if (string.IsNullOrEmpty(identifierB))
+            if (string.IsNullOrWhiteSpace(identifierB))
             {
                 return -1;
             }
@@ -526,7 +498,6 @@ namespace Microsoft.Deployment.DotNet.Releases
                 bool isNumericIdentifierB = Regex.IsMatch(dotPartsB[i], @"^\d+$");
 
                 int compareResult;
-
                 if (isNumericIdentifierA && isNumericIdentifierB)
                 {
                     // Identifiers consisting of only digits are compared numerically
@@ -552,7 +523,6 @@ namespace Microsoft.Deployment.DotNet.Releases
                     }
 
                     compareResult = string.CompareOrdinal(dotPartsA[i], dotPartsB[i]);
-
                     if (compareResult != 0)
                     {
                         return compareResult;
@@ -587,11 +557,9 @@ namespace Microsoft.Deployment.DotNet.Releases
             // between 1 and -1 depending on the ordinal value
             // of the character at the current index.
             int r = 0;
-
             for (int i = a.Length - 1; i > 0; i--)
             {
                 int r2 = a[i].CompareTo(b[i]);
-
                 if (r2 != 0)
                 {
                     r = r2 / Math.Abs(r2);

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseVersionConverter.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseVersionConverter.cs
@@ -17,10 +17,8 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="writer">The <see cref="JsonWriter"/> to use for writing the value.</param>
         /// <param name="value">The <see cref="ReleaseVersion"/> to write.</param>
         /// <param name="serializer">The calling serializer</param>
-        public override void WriteJson(JsonWriter writer, ReleaseVersion value, JsonSerializer serializer)
-        {
+        public override void WriteJson(JsonWriter writer, ReleaseVersion value, JsonSerializer serializer) =>
             writer.WriteValue(value.ToString());
-        }
 
         /// <summary>
         /// Reads a string value and converts it into a <see cref="ReleaseVersion"/> object.
@@ -31,11 +29,11 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="hasExistingValue">The existing value of the object being read.</param>
         /// <param name="serializer">The calling serializer.</param>
         /// <returns>A <see cref="ReleaseVersion"/> created from the object value.</returns>
-        public override ReleaseVersion ReadJson(JsonReader reader, Type objectType, ReleaseVersion existingValue, bool hasExistingValue, JsonSerializer serializer)
+        public override ReleaseVersion ReadJson(
+            JsonReader reader, Type objectType, ReleaseVersion existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            string s = (string)reader.Value;
-
-            return string.IsNullOrEmpty(s) ? null : new ReleaseVersion(s);
+            var stringValue = (string)reader.Value;
+            return string.IsNullOrWhiteSpace(stringValue) ? null : new ReleaseVersion(stringValue);
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/RuntimeReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/RuntimeReleaseComponent.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Deployment.DotNet.Releases
 
         internal RuntimeReleaseComponent(JToken token, ProductRelease release) : base(token, release)
         {
-
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/SupportPhaseConverter.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/SupportPhaseConverter.cs
@@ -20,15 +20,17 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="hasExistingValue">The existing value of the object being read.</param>
         /// <param name="serializer">The calling serializer.</param>
         /// <returns>A <see cref="SupportPhase"/> created from the object value.</returns>
-        public override SupportPhase ReadJson(JsonReader reader, Type objectType, SupportPhase existingValue, bool hasExistingValue, JsonSerializer serializer)
+        public override SupportPhase ReadJson(
+            JsonReader reader, Type objectType, SupportPhase existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
             if (reader.TokenType == JsonToken.String)
             {
                 var tokenValue = reader.Value.ToString();
-
-                if (!string.IsNullOrEmpty(tokenValue))
+                if (!string.IsNullOrWhiteSpace(tokenValue))
                 {
-                    return Enum.TryParse(tokenValue, ignoreCase: true, out SupportPhase result) ? result : SupportPhase.Unknown;
+                    return Enum.TryParse(tokenValue, ignoreCase: true, out SupportPhase result)
+                        ? result
+                        : SupportPhase.Unknown;
                 }
             }
 
@@ -41,9 +43,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="writer">The <see cref="JsonWriter"/> to use for writing the value.</param>
         /// <param name="value">The <see cref="SupportPhase"/> to write.</param>
         /// <param name="serializer">The calling serializer</param>
-        public override void WriteJson(JsonWriter writer, SupportPhase value, JsonSerializer serializer)
-        {
+        public override void WriteJson(JsonWriter writer, SupportPhase value, JsonSerializer serializer) =>
             throw new NotImplementedException();
-        }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/WindowsDesktopReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/WindowsDesktopReleaseComponent.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Deployment.DotNet.Releases
 
         internal WindowsDesktopReleaseComponent(JToken token, ProductRelease release) : base(token, release)
         {
-
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/Microsoft.Deployment.DotNet.Releases.Tests.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/Microsoft.Deployment.DotNet.Releases.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3"/>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ProductCollectionTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ProductCollectionTests.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
             ProductCollection products = await ProductCollection.GetFromFileAsync(@"data\\releases-index.json", false);
             IEnumerable<SupportPhase> supportPhases = products.GetSupportPhases();
 
-            Assert.Equal(3, supportPhases.Count());
+            Assert.Equal(4, supportPhases.Count());
+            Assert.Contains(SupportPhase.Current, supportPhases);
             Assert.Contains(SupportPhase.EOL, supportPhases);
             Assert.Contains(SupportPhase.LTS, supportPhases);
             Assert.Contains(SupportPhase.Preview, supportPhases);
@@ -29,7 +30,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         {
             Func<Task> f = async () => await ProductCollection.GetFromFileAsync((string)null, false);
 
-            ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(f);
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(f);
         }
 
         [Fact]

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ProductTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ProductTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
             var product = Products.Where(p => p.ProductVersion == "3.1").FirstOrDefault();
 
             Assert.Equal(".NET Core", product.ProductName);
-            Assert.Equal("2020-07-14", product.LatestReleaseDate.ToString("yyyy-MM-dd"));
+            Assert.Equal("2021-02-09", product.LatestReleaseDate.ToString("yyyy-MM-dd"));
             Assert.True(product.LatestReleaseIncludesSecurityUpdate);
         }
     }

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ReleaseVersionTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ReleaseVersionTests.cs
@@ -133,8 +133,8 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [InlineData("1.0.0-beta5", "1.0.0-beta4", -1)]
         public void ComparePrecedenceToReturnsRelativeSortOrder(string version1, string version2, int expectedPrecedence)
         {
-            ReleaseVersion v1 = string.IsNullOrEmpty(version1) ? null : new ReleaseVersion(version1);
-            ReleaseVersion v2 = string.IsNullOrEmpty(version2) ? null : new ReleaseVersion(version2);
+            ReleaseVersion v1 = string.IsNullOrWhiteSpace(version1) ? null : new ReleaseVersion(version1);
+            ReleaseVersion v2 = string.IsNullOrWhiteSpace(version2) ? null : new ReleaseVersion(version2);
 
             if (expectedPrecedence == 1)
             {

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/data/6.0/releases.json
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/data/6.0/releases.json
@@ -1,0 +1,2881 @@
+{
+  "channel-version": "5.0",
+  "latest-release": "5.0.0-preview.7",
+  "latest-release-date": "2020-07-21",
+  "latest-runtime": "5.0.0-preview.7.20364.11",
+  "latest-sdk": "5.0.100-preview.7.20366.6",
+  "support-phase": "preview",
+  "lifecycle-policy": "https://www.microsoft.com/net/support/policy",
+  "releases": [
+    {
+      "release-date": "2020-07-21",
+      "release-version": "5.0.0-preview.7",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.7.md",
+      "runtime": {
+        "version": "5.0.0-preview.7.20364.11",
+        "version-display": "5.0.0-preview.7",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a11aa133-be76-4120-baaa-10be1e7eb4a2/55f000bd8967476e3e7dc24a4ba6c692/dotnet-runtime-5.0.0-preview.7.20364.11-linux-arm.tar.gz",
+            "hash": "1d65f3e708da676c5b9295048af240143c7efdb34dfe616edf50fbcaea3747bb4607afb5af5dfda664a512004ad3c31aeae4c142cda3d06ef51ade1832655bd6"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/79fe08db-0239-49c3-a733-d66a61b90a46/9e20b794946c31f310578d0ffc71c5e0/dotnet-runtime-5.0.0-preview.7.20364.11-linux-arm64.tar.gz",
+            "hash": "ea62c09ce3de2732dc94c3384dc7c6ae580703b671dd2670b53a587603c778ba5d399544d3a5c8cbcaad95f4bdc4cad905776247000265bbc6a6ee647f83a96a"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/174bc11f-ed96-4bc9-9bf0-4ff0a5b95279/1d3cc202997876f2602afad1d9745b18/dotnet-runtime-5.0.0-preview.7.20364.11-linux-musl-arm64.tar.gz",
+            "hash": "813b804b3a88aaee78b887e565b05c34e9c9aa3d2dd99f9265caa10639a3f53c999df0f6e3260ddd8c4784cb9fb8b1f1aa4bd1754978570ffba778108dffd10f"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/887d0415-ea76-4b39-9b9a-1bfd81cd49e4/118d1385ff15daf9644ca3c164de5814/dotnet-runtime-5.0.0-preview.7.20364.11-linux-musl-x64.tar.gz",
+            "hash": "8b68b7601ceddbc513272b3c80ba2439046b397e96ffaa07b24efcc5bb32c7854f5a4f851c4f08cc9201167d07f17427e750a51d7392cf2eb9f6e4d0fbbb41b7"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/50405a40-62b0-496f-a099-a1a4aaf7e8a1/8162d7f1eef3a9100160d2e275fe4363/dotnet-runtime-5.0.0-preview.7.20364.11-linux-x64.tar.gz",
+            "hash": "409802189c72820e67a5b064b8f2997095bc5b0be7a4c6734473c6aa56220ff60c758e4c12d2e99e2cf93cf8510e9bbe66e26e68abbe85085c28c5bc9428e77f"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0c69d2c6-b205-49df-b23a-7bff3843b75f/ab032df86acfdf39ec240a91fb316ce8/dotnet-runtime-5.0.0-preview.7.20364.11-osx-x64.pkg",
+            "hash": "5b28d31df77416b44450dd057aed57e1a6d54ab0504c330608c3c305b100f631aa188636757f054154b1a4d30ad74ee0b7bf514fa95c856d8ab438fda6f26dca"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/54247350-9123-4c9a-86e9-a06c766de011/6a32bb36fa5dfc062fcab8c162c2bcdc/dotnet-runtime-5.0.0-preview.7.20364.11-osx-x64.tar.gz",
+            "hash": "867d9a30010dc8513427b24d50530a26b87ff68db68054cb01181b4d3c46c27479304cdddb005d75c8a998d5bbc7880a06dfc05a1375793ad474df52a614ca2a"
+          },
+          {
+            "name": "dotnet-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1f1d1419-8951-4dc3-ac04-3d06f8a93cc6/c4f7a9f30ec7dfe74b54af1605fc4f95/dotnet-runtime-5.0.0-preview.7.20364.11-win-arm.zip",
+            "hash": "236b429e129cf5f51c2e08168982a764d95aaa63f90285481210063e66f2c677b838798ae8d2a9f345e6964a5952d89b4fdf9de0c5db35d13df6f8564779275f"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f63ca84d-31c8-4b0d-9234-950c8a74f7cc/8f053a507356f3dbde2873c53f6752d0/dotnet-runtime-5.0.0-preview.7.20364.11-win-arm64.zip",
+            "hash": "1dcf95be852426bef33920b6a61052b560a18a229da56e6df8eceec01d41771342ece153d96a07a59cc64f88b566dc4879eab8cb136fcac79f56ba14b8f63960"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/203aff04-57b2-4183-9d24-daf502fb9599/cf85a20cc0de18dd31f199c8f8528601/dotnet-runtime-5.0.0-preview.7.20364.11-win-x64.exe",
+            "hash": "b849e082dbf15ec0c5058e1a2fff96ad825ad60fa35f5fc1c263f63968f739d047e59742086f7c63d3fb83fe56681820cc99689237f13b49d4168b5ed103406d"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1f275906-3b32-4a81-9468-a6b47d846130/5cea07ee6b9dcdf2d753c4a9767b4b95/dotnet-runtime-5.0.0-preview.7.20364.11-win-x64.zip",
+            "hash": "f4769be164dd465b957db9308a5478f5089f8d8736b08940ce9a09c5adcf03734ad5ba8dace9b5ca85604665afa0c20c5563a7ed5fc97bcc7c18971206bbe4c7"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2db260ef-40ba-4cce-8666-7de8b879e9a9/a4f4a0671b4e8899c217354e9d8371a8/dotnet-runtime-5.0.0-preview.7.20364.11-win-x86.exe",
+            "hash": "60c5f049bb444a1f364f03d6d166bbc5a8fe47cfad44bb48b5861c473dc78a9d03ccdcd3fd8b31971a86217d8182b12b094949f2dfe876bd2b087b94cde3e1e1"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0e451052-dc35-4b5f-827c-22bfdaa1897e/be0d5cbf43d0ef055899cfec4082b835/dotnet-runtime-5.0.0-preview.7.20364.11-win-x86.zip",
+            "hash": "963a1728dd579104272d2b0b5bb906fa5252a4c11861cea676c9306661d9a27ec25709a8d8d714bbe0806f344725aa5c9d51dc00dd2d9d8b854a7902e9d52568"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.7.20366.6",
+        "version-display": "5.0.100-preview.7",
+        "runtime-version": "5.0.0-preview.7.20364.11",
+        "vs-version": "",
+        "vs-mac-version": "",
+        "vs-support": "Visual Studio 2019 (v16.7, latest preview)",
+        "vs-mac-support": "Visual Studio 2019 for Mac (v8.7 preview)",
+        "csharp-version": "9.0-preview",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/20349622-b776-4fa0-a981-adacd7d57b9c/174f26a811b61a11a2132613e27f442a/dotnet-sdk-5.0.100-preview.7.20366.6-linux-arm.tar.gz",
+            "hash": "2e473ba7d2ed706313a02438da2b338fa91785cbbd68d1c15268641b3d547b7183e9f5be02df8f6d2af537e02280dae94cee63a4d3dd42bfbfb3cb4ce5fade59"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a7d933ce-5f1d-4c7b-a388-509ee6ee710c/152fa9acb7ee9cf34d7cb0eeeb36d448/dotnet-sdk-5.0.100-preview.7.20366.6-linux-arm64.tar.gz",
+            "hash": "34cc65a879c8dedf854e0bb5b8b3f415c7db1ea9281a868516b6c0fdbb6d356dbd41ca258c10aec0c33339a5bc3be6cdf4e4d96099b6e3f73abb841e9c8d2dae"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/30b3cc30-0985-4b87-a7fc-b285bc7798b7/18c6f1b429f4e315d9ce1839191031be/dotnet-sdk-5.0.100-preview.7.20366.6-linux-musl-x64.tar.gz",
+            "hash": "5dc8a07ed8964ed88588b7310ecaeb75be711604334ce6d06b6a6400a28780cbb92264a5022a7acf4b6dbf18c08110a263309dd3adfef3dd1aa20eebbe9ac959"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6e9bdda1-72b5-4d2e-8908-be9321b8db26/cbc8ab6c3a1aca2a8dd92e272edd3293/dotnet-sdk-5.0.100-preview.7.20366.6-linux-x64.tar.gz",
+            "hash": "a1369d4e9e6281a3656acf6ba8357fbb9b25824fa63b42b55700f4d7ab58b2dc355b91c356a13c7d76da92e30dd3a5ccefd1d3396eacc1ac62cbae608b5eed86"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7a2f569c-f3be-43f7-8f5d-ccc2b62b06ca/a7f72e40a5ee418cd15fa477d30d4b30/dotnet-sdk-5.0.100-preview.7.20366.6-osx-x64.pkg",
+            "hash": "fbfaf8900fa35e4656a92981a2d14a578756a2b6fc6ec747d4460be316c6fe07efffeb1f842126b37111404a70f2c43aa516f97494a66b49801710553a62c917"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/76749af6-cccc-430b-91e6-f2beee11d922/4b4594efa029d19c864187820f0a7f97/dotnet-sdk-5.0.100-preview.7.20366.6-osx-x64.tar.gz",
+            "hash": "eed62702c03a3011ccb534f75d4986d09948cf64d601c083759e6770f549cf159bb9adff9c34865e1caa15179f484d22772a4ca79c591823b1ac26025472bf35"
+          },
+          {
+            "name": "dotnet-sdk-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/78b3bbac-4f7e-4be7-8cc2-e4752372c57e/8c594c83509b555c62556460c056bab7/dotnet-sdk-5.0.100-preview.7.20366.6-win-arm.zip",
+            "hash": "ca26bd148a603a352ddf7f8c058fca6607f5e0fb5d485608600c8ea3e267f1cfa5ed5997ab8e7f36b6fcdd32e4ecf255de736a1caec219ad4478e2b63efdd7da"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7c9db83f-13ea-4246-a69d-a51a4e4113ca/5b3ab7f5667fe5bb7b00c9484cada3e2/dotnet-sdk-5.0.100-preview.7.20366.6-win-arm64.zip",
+            "hash": "2c4bee81067deabb53f37935096e81483584f3b634a176824366a647ed1271b307a11ff34f3b0b280c7e2e19c12c4d1d3a37d19c87a51611348fbb04f48733ae"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/21511476-7a5b-4bfe-b96e-3d9ebc1f01ab/f2cf00c22fcd52e96dfee7d18e47c343/dotnet-sdk-5.0.100-preview.7.20366.6-win-x64.exe",
+            "hash": "93400774be604fa238d86fbbbd52eb8488eab317085c6864cdc730e9ea572be46691fa633c5f46bcbe8f7245c5ca722fe23e5d43f654c6d7781cdd292cd2af97"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2febae4a-9ac0-45ea-bf2f-adbe75492a94/d0bee7791c904c5c33bf25b12556aa34/dotnet-sdk-5.0.100-preview.7.20366.6-win-x64.zip",
+            "hash": "a77458590193d71f4c7f483b765fc16495fbb9a83f79cfb943ce46a67c3e9049eef7da87398d8637a4f547cb57a64857584b2b43009593d24daea9f5af6d31cc"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5d536432-9be1-4193-9fec-9e920663e0d0/4b01d64266b503a320e92072e529033f/dotnet-sdk-5.0.100-preview.7.20366.6-win-x86.exe",
+            "hash": "d505ad12efc18d0a09ccb484136f9aeddde06a85caa37822a81aade1bb8f5b42369cdb4dfe67d62c197cc623383f5566f06be89e06ff5e8e4fdd1db96a4a02b3"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/add0a0a6-088d-4c79-ba7d-199e6fb44f3a/560013573bf4f46bfbdefcb7d770a397/dotnet-sdk-5.0.100-preview.7.20366.6-win-x86.zip",
+            "hash": "eba7c98457d91fecdcd303961866033415631f28088ebd3b43e49c2356aab89b77709c144a8c28939d53edeaab8bf26c9681de79e9df7fb73350f4b92529f497"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.7.20366.6",
+          "version-display": "5.0.100-preview.7",
+          "runtime-version": "5.0.0-preview.7.20364.11",
+          "vs-version": "",
+          "vs-mac-version": "",
+          "vs-support": "Visual Studio 2019 (v16.7, latest preview)",
+          "vs-mac-support": "Visual Studio 2019 for Mac (v8.7 preview)",
+          "csharp-version": "9.0-preview",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/20349622-b776-4fa0-a981-adacd7d57b9c/174f26a811b61a11a2132613e27f442a/dotnet-sdk-5.0.100-preview.7.20366.6-linux-arm.tar.gz",
+              "hash": "2e473ba7d2ed706313a02438da2b338fa91785cbbd68d1c15268641b3d547b7183e9f5be02df8f6d2af537e02280dae94cee63a4d3dd42bfbfb3cb4ce5fade59"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a7d933ce-5f1d-4c7b-a388-509ee6ee710c/152fa9acb7ee9cf34d7cb0eeeb36d448/dotnet-sdk-5.0.100-preview.7.20366.6-linux-arm64.tar.gz",
+              "hash": "34cc65a879c8dedf854e0bb5b8b3f415c7db1ea9281a868516b6c0fdbb6d356dbd41ca258c10aec0c33339a5bc3be6cdf4e4d96099b6e3f73abb841e9c8d2dae"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/30b3cc30-0985-4b87-a7fc-b285bc7798b7/18c6f1b429f4e315d9ce1839191031be/dotnet-sdk-5.0.100-preview.7.20366.6-linux-musl-x64.tar.gz",
+              "hash": "5dc8a07ed8964ed88588b7310ecaeb75be711604334ce6d06b6a6400a28780cbb92264a5022a7acf4b6dbf18c08110a263309dd3adfef3dd1aa20eebbe9ac959"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6e9bdda1-72b5-4d2e-8908-be9321b8db26/cbc8ab6c3a1aca2a8dd92e272edd3293/dotnet-sdk-5.0.100-preview.7.20366.6-linux-x64.tar.gz",
+              "hash": "a1369d4e9e6281a3656acf6ba8357fbb9b25824fa63b42b55700f4d7ab58b2dc355b91c356a13c7d76da92e30dd3a5ccefd1d3396eacc1ac62cbae608b5eed86"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7a2f569c-f3be-43f7-8f5d-ccc2b62b06ca/a7f72e40a5ee418cd15fa477d30d4b30/dotnet-sdk-5.0.100-preview.7.20366.6-osx-x64.pkg",
+              "hash": "fbfaf8900fa35e4656a92981a2d14a578756a2b6fc6ec747d4460be316c6fe07efffeb1f842126b37111404a70f2c43aa516f97494a66b49801710553a62c917"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/76749af6-cccc-430b-91e6-f2beee11d922/4b4594efa029d19c864187820f0a7f97/dotnet-sdk-5.0.100-preview.7.20366.6-osx-x64.tar.gz",
+              "hash": "eed62702c03a3011ccb534f75d4986d09948cf64d601c083759e6770f549cf159bb9adff9c34865e1caa15179f484d22772a4ca79c591823b1ac26025472bf35"
+            },
+            {
+              "name": "dotnet-sdk-win-arm.zip",
+              "rid": "win-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/78b3bbac-4f7e-4be7-8cc2-e4752372c57e/8c594c83509b555c62556460c056bab7/dotnet-sdk-5.0.100-preview.7.20366.6-win-arm.zip",
+              "hash": "ca26bd148a603a352ddf7f8c058fca6607f5e0fb5d485608600c8ea3e267f1cfa5ed5997ab8e7f36b6fcdd32e4ecf255de736a1caec219ad4478e2b63efdd7da"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7c9db83f-13ea-4246-a69d-a51a4e4113ca/5b3ab7f5667fe5bb7b00c9484cada3e2/dotnet-sdk-5.0.100-preview.7.20366.6-win-arm64.zip",
+              "hash": "2c4bee81067deabb53f37935096e81483584f3b634a176824366a647ed1271b307a11ff34f3b0b280c7e2e19c12c4d1d3a37d19c87a51611348fbb04f48733ae"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/21511476-7a5b-4bfe-b96e-3d9ebc1f01ab/f2cf00c22fcd52e96dfee7d18e47c343/dotnet-sdk-5.0.100-preview.7.20366.6-win-x64.exe",
+              "hash": "93400774be604fa238d86fbbbd52eb8488eab317085c6864cdc730e9ea572be46691fa633c5f46bcbe8f7245c5ca722fe23e5d43f654c6d7781cdd292cd2af97"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2febae4a-9ac0-45ea-bf2f-adbe75492a94/d0bee7791c904c5c33bf25b12556aa34/dotnet-sdk-5.0.100-preview.7.20366.6-win-x64.zip",
+              "hash": "a77458590193d71f4c7f483b765fc16495fbb9a83f79cfb943ce46a67c3e9049eef7da87398d8637a4f547cb57a64857584b2b43009593d24daea9f5af6d31cc"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/5d536432-9be1-4193-9fec-9e920663e0d0/4b01d64266b503a320e92072e529033f/dotnet-sdk-5.0.100-preview.7.20366.6-win-x86.exe",
+              "hash": "d505ad12efc18d0a09ccb484136f9aeddde06a85caa37822a81aade1bb8f5b42369cdb4dfe67d62c197cc623383f5566f06be89e06ff5e8e4fdd1db96a4a02b3"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/add0a0a6-088d-4c79-ba7d-199e6fb44f3a/560013573bf4f46bfbdefcb7d770a397/dotnet-sdk-5.0.100-preview.7.20366.6-win-x86.zip",
+              "hash": "eba7c98457d91fecdcd303961866033415631f28088ebd3b43e49c2356aab89b77709c144a8c28939d53edeaab8bf26c9681de79e9df7fb73350f4b92529f497"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.7.20365.19",
+        "version-display": "5.0.0-preview.7",
+        "version-aspnetcoremodule": [
+          "15.0.20198.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f114ff73-807d-47b9-97f7-51b0e156a5e1/58eac9a7e3bc1b3df4fc0fe63ab05846/aspnetcore-runtime-5.0.0-preview.7.20365.19-linux-arm.tar.gz",
+            "hash": "22862455eeb0061c2f7e2e976149be3f5e037128f226e0f1e080b5c75af84a45549e201dddc17a226994b460b8c243d401e0351f8bd7e5b48a6bd74c220b1c42"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/137efdf7-85d5-47b2-abf5-24ffd0aab3df/01e445249ffec368b655afb4caf1d7d7/aspnetcore-runtime-5.0.0-preview.7.20365.19-linux-arm64.tar.gz",
+            "hash": "8b153075d62e3cbeb0878f4af0dee2e8fd76888a17ff02ece60b98905c69f057236e8c9aa6e99d512f2e256513e111ecb1acbbf42d48c949e21c60d744812694"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/50f7778e-c753-4d25-9195-4a47fd5bcbbf/670d67d27e9206e41a537d2850f49b66/aspnetcore-runtime-5.0.0-preview.7.20365.19-linux-musl-arm64.tar.gz",
+            "hash": "733d5ed7fd90eca31a85980dc64d1298a89d17157323b7eacc79e0e83592235de68b083ce03cf280608233fc3a5b6a27e8d52516ae543bf29d2d0258a3e156f9"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9707011f-6c4d-435d-9fd0-18f1d0048bfa/a7781a25cc2b5088d6439523f2c07f23/aspnetcore-runtime-5.0.0-preview.7.20365.19-linux-musl-x64.tar.gz",
+            "hash": "ff63042916c597820fa93eac34a6c0d889b9498aae554067010a94af367b8291f59fcd0832227274bb864209de486ba1cff87967388147b6f9433be1b5ce0953"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/623a385b-1bb8-4e4a-a677-eaa41e956f48/82b58a95fc101d3455db376c339e169f/aspnetcore-runtime-5.0.0-preview.7.20365.19-linux-x64.tar.gz",
+            "hash": "6a6bbe7848e835b6dbfc183eb30dad2f88aed5b7a4509584b5309bab5ef6f6f0b5fc4b09d7b557ca4e30b31a93a6583dbe904c185772b8bff58d3d4d7134053e"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/49fb6ead-64b0-4cfa-baf5-060b178bfe18/32ee2fdd5fcd1916095c376c0806dce0/aspnetcore-runtime-5.0.0-preview.7.20365.19-osx-x64.tar.gz",
+            "hash": "12f41424c67b0fa557a214a6a21de6aedee8734b9a622ccc83c2093dce16dc1e7919242ec60ced50aa3695bc2330623ccf41c813426f04d742aec89ecd4012fe"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ad3b43df-717f-4ff2-bbcb-22d9b66eeb0f/137e3a03fdfa553849929afb309c1570/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-arm.zip",
+            "hash": "e69106017d7b98eaaeb78f118ff3f0182472e19612ad1b8c3456889fbaa835f1ecd4e4f9a05b619eae383cfedb0e478f961541721652ca5814f48b0cbc119398"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c9e68175-6c43-4fe3-82b4-135a0e85ed8b/d4865f422f061e03822b6011350d1bcc/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-arm64.zip",
+            "hash": "e0bc8c07fcdca781ba6bf6783b4d6db5151883bc3be11a3fddaaa8a7a752732c04cf938c8a36a494cb7b0c9c517755eb350b36bee2671d8d8045ea8925a2c0b6"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9d2b759f-1bbb-4b00-a1b9-4b191c074254/cf51d83f10a4dd9327edd7a238cde6ec/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-x64.exe",
+            "hash": "27795c11defee0ec1d3ca531e05a42e0369f8129cdbc9965c2f2f9dfd0173f58260b88a812677917f656395f2170541e7d6dc9ee99fb0d84126c9e1da9299d50"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a0f2fca4-a2bf-4657-834c-be0dec09f04d/27553adf1b80316e194510099830ed20/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-x64.zip",
+            "hash": "2d50901aa5329a00ed339b8bd683a0bfdf115bb6f9bc3b29f408e72c99a27c530812939e37ec467eb5f7756be6153bb314a9e13e10788dcb4d3a3b1377a1a73c"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e0f0dd65-4db3-4ea9-8ddc-0296e290b93f/23faf5910857010dd62dc0233c59fc79/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-x86.exe",
+            "hash": "dfbad08ed65fe4c9b6c098c4455b88ad12e6cf3cab242b4fef0d6f07c09f007385b51ef37741ff6e4c2a21e23503629641c30485cfb52fe2c29c957e83f17bcd"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7deab25e-7e72-49d0-95c9-976ebf929590/560cfb70f894fc6ca3ea3c34ef4b3404/aspnetcore-runtime-5.0.0-preview.7.20365.19-win-x86.zip",
+            "hash": "49d153656f367287b2763b74782fbec96a4391da067a6533d44b3ff204aec76cda3b723ce847af3be8f9be1f61b84e06a70ca8f5dc663f0c36b3380f703d223a"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2fd2cadc-2068-4055-b269-13cf1d06083c/86ef0372321ed82efc7230aa41ebd3db/dotnet-hosting-5.0.0-preview.7.20365.19-win.exe",
+            "hash": "8ab6111bf8e4905189ea69a72bd295e1fa6a14627d213f88f35885e71022d336ca544c4bffaf8c0a954b6240b8a9e61483e24294553477b13c112c4a5aafe71a",
+            "akams": "https://aka.ms/dotnetcore-5-0-windowshosting"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.7.20366.1",
+        "version-display": "5.0.0-preview.7",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b1ad0793-f281-4574-b672-09ac4bd6ff9c/303e98093e01e9b10a425d58b26bb601/windowsdesktop-runtime-5.0.0-preview.7.20366.1-win-x64.exe",
+            "hash": "31bb3a26fed1ff39afc5308a52350bfb3a1bdb5d3a8cac33628ccbd8dd22291b193fcde79a76d8cd3bf69f4e58b3e53716b63fd8434b8ecfeb0e7d7ca3e3bbb3"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d12f1c16-2d25-4a7f-a3cb-cf839b07526a/b9ac0cb450e8563a2272510a379511fc/windowsdesktop-runtime-5.0.0-preview.7.20366.1-win-x86.exe",
+            "hash": "cc464d76b8922ba8f8e5e97475f05b01123952e8410d3f8a7a417c5bc35cfbf60e984a760e8687dc72f40fe545ed24bc6e346bb7a9cd144393022f8de2e71dea"
+          }
+        ]
+      }
+    },
+    {
+      "release-date": "2020-06-25",
+      "release-version": "5.0.0-preview.6",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.6.md",
+      "runtime": {
+        "version": "5.0.0-preview.6.20305.6",
+        "version-display": "5.0.0-preview.6",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c193dbd4-612f-4185-bd89-c79f2c7a57ec/89e9c35b2949436d25df6536f82fba48/dotnet-runtime-5.0.0-preview.6.20305.6-linux-arm.tar.gz",
+            "hash": "7e9a70a13ccd56d282e336beb57e7714c4cc8dadf88cdc77c15be91eb3a24c10742651f07960aacd1ff84402120f7e75652403b2e00db2c5011634a30fcf5811"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/032c7427-1de9-4127-ad97-c2aeb927fe1a/00475ef07e0ee12a161221d1cbe3b5a6/dotnet-runtime-5.0.0-preview.6.20305.6-linux-arm64.tar.gz",
+            "hash": "0890f5e1f54d38a8e4cd99637eb9155da663ae4b466bf56fc36bb9100c688201d814547400859614e41c4946ff05e789a87575ecbe1f15e63b578c8ef4d765ce"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a913f6ee-16ad-493e-bf75-59d2d48de3f1/4105f0f967d03dfc2cdba711323e60cb/dotnet-runtime-5.0.0-preview.6.20305.6-linux-musl-arm64.tar.gz",
+            "hash": "0db9e2b02d42557854d080dad21f027e2967ee2fd0c6a368952526e6b8af1c3f1768d99a642802166201b40ab084a4040588993b6231d65b6edba8e068ae9f72"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f5645d58-d3bf-40b9-9150-400604b3ad36/2a5de2de91b15018ff0ca0f79db1046c/dotnet-runtime-5.0.0-preview.6.20305.6-linux-musl-x64.tar.gz",
+            "hash": "416eeebfd90d66f68cb6e68842b3b89c080adf4a4773d3af822d1cdc4469c3e3f3ff1171bbcbfec0e4e1ca1f2357fa694fff97770bc72893cf375cf9c564e1bc"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/255d9cd2-6371-4fae-9088-0e806faf145f/084be8348ba60f7cab06fc9e6e1a548f/dotnet-runtime-5.0.0-preview.6.20305.6-linux-x64.tar.gz",
+            "hash": "355a0a3e02970a5ecd2bfa06f4690ed8f7ee23bf5544470787c79c80ec5ff7d3a0296fed06d311d2b970fe00db0345856b5cea4e8e0cc3abfab8f2e89d0755e6"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8984e389-5e54-4315-8c1f-d642694a5a3a/fea8df55f4f3b81fbe6bfc57d547fc9d/dotnet-runtime-5.0.0-preview.6.20305.6-osx-x64.pkg",
+            "hash": "00f3beb35aab5b81bf9b72d0a96e15f8dc40afa1c34fd49fb8ab288d888799f818f332352eede62585122d3386b71d548456b1c6aad13d6217f8f57414cb9fe7"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9bcd6a75-2d60-4fdb-ba52-bf8aac3cc8ea/30f94206874e28a08cd1af9b60f76833/dotnet-runtime-5.0.0-preview.6.20305.6-osx-x64.tar.gz",
+            "hash": "1c2b545904528872ee0b8012903b7a42e8980de4296a72f102a2cf696ca6c79acd5710f81d919c81c7fa9dbb5e3f23b2989c4c7799414be39a3a09a5e9fe5534"
+          },
+          {
+            "name": "dotnet-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1ad139a9-4a6f-48fd-93ec-159c642f64c8/fd8178cd24772a3a82394bc1c0104e87/dotnet-runtime-5.0.0-preview.6.20305.6-win-arm.zip",
+            "hash": "ef40dca20592cb1d70cc78dde9c1dc5a58ba0a00b53c07e0999d8f8f0e738226712fbc4b7da5b0022cd3a17ded6bc966a15164fbdbfd63b8163f26b6d7e03c20"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d92cf82f-3605-4e5a-bd45-8b7582a8baa2/d746e5423390263a5fe5b5573ab1da2e/dotnet-runtime-5.0.0-preview.6.20305.6-win-arm64.zip",
+            "hash": "136a875a809d6d7bb54ae6b215ca96b6059504e9bd0cba0f29f8e1b660b52624d6c8ac77cf483131070039d6239b41614bdbd43aa591cd7e62ef209a63d5a76a"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9d9ad166-4ec8-44ce-a3b6-2c9157db98f3/5055fa1ac4cffdfdcfd6c7fc6a1a143f/dotnet-runtime-5.0.0-preview.6.20305.6-win-x64.exe",
+            "hash": "6821be7a59b0d21521a33ca3841a4132ee1f471c779ed353ef766c340818140156befd636a4a15fc76ac5aa0436697c251cf2a97db3dab07172947784d53a683"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7a9b311c-96ff-4275-a4ad-372e10730072/74369b63884ad2950c3304d86d124310/dotnet-runtime-5.0.0-preview.6.20305.6-win-x64.zip",
+            "hash": "eb7b8db4de0149ef14e367e7c8fc92f160be5aabf5380280b6b663afeec993595b674ccd4ece5032dd0187587cb97a1a39cc0d0b1284e913c537ad23aebe1ac7"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/63f91a7f-ba90-4593-915b-083f0ddcb076/b5da51ed6897d98f2f5c8c3f8054e745/dotnet-runtime-5.0.0-preview.6.20305.6-win-x86.exe",
+            "hash": "6053d306567d3c5098194375628d2613e304a0cb09e50d20d19345a05106cd98f20353717ec0f68d44034df8abee8ebdc0c1bc15d6feb3a47184352d206c52da"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0bc6ed8b-b2b1-407a-a68d-08262f1fb752/390fbdc3d59edb2ff9c771d76bb114c8/dotnet-runtime-5.0.0-preview.6.20305.6-win-x86.zip",
+            "hash": "ae3bff284b855735a7589402d6c3931bc9a2d236a3fdcd717a0406b3d8e3a8dd5601983c205b99fc72e496def942f26ae89cb8bab57cf5ddc6cce699c2b71f3a"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.6.20318.15",
+        "version-display": "5.0.100-preview.6",
+        "runtime-version": "5.0.0-preview.6.20305.6",
+        "vs-support": "Visual Studio 2019 (v16.6)",
+        "csharp-version": "9.0-preview",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fc54f62e-c7bd-43a3-a27b-4afb08bc4d6f/b01ccacf3d94efc0bbe26f64f7fde9b7/dotnet-sdk-5.0.100-preview.6.20318.15-linux-arm.tar.gz",
+            "hash": "1dd5c4f90d43983f1b6ccfa7631fd70afe99b26c1111d191dccb860bcfa232052c3589147f730b583b3f498bcd1116a131fae462267b68a00c10d7e7d832e65f"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/164ecfcc-df44-476f-a161-340201aa6fa8/7200eb764dc9ff546d384e3188f98a53/dotnet-sdk-5.0.100-preview.6.20318.15-linux-arm64.tar.gz",
+            "hash": "2a1039c4a94abd33949176407edee84dbd54053b56c7e2d8b69e7cf28e16f89013036cf662403ea8f2ea593b9b1b702e464762d9670da12507d1c1e06a58c04f"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6cfc5668-5c55-4ab4-9266-0d3dd00e6417/c03eb0deb48f9d2cf8d2bde4bf4d9113/dotnet-sdk-5.0.100-preview.6.20318.15-linux-musl-x64.tar.gz",
+            "hash": "e0c5283cd1758f921e25f4653c8c8a3076dd83602c8f036b347450695717ad3c071222b2467df27b8854c55e555f4ed095f9dc072d595caf6fe7b4abde6332d5"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ec4bba83-4586-4705-a6ae-c648861ca284/d9470c2f68161e3c2b8a0785fe7b3329/dotnet-sdk-5.0.100-preview.6.20318.15-linux-x64.tar.gz",
+            "hash": "ae68221770e8f199880f00a29d72c624aaedc0c3ca61a7b543a6555acf27eca4c0c24fbd4eddc1322d7dcb4f342325b1d1521c590556bd95c3c2ec653b914dbb"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f912c99a-c128-4436-8aa5-433cf502d0ab/4ebe252735cb7ae6cc828b2e0bbe107b/dotnet-sdk-5.0.100-preview.6.20318.15-osx-x64.pkg",
+            "hash": "7c3f50b2b7fac2c41fe5074d706d67ee6e8edaa3eb464425ea884add51d92ae82f1a2571ff41ce3114abcdb91ebaa3df893bbf4f9ce2d666bb8a9577551004f5"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ae0be7cb-6553-43e4-ab1c-6355a0ac0b9f/e18a0be6d89ac4cde08e39ce232953b4/dotnet-sdk-5.0.100-preview.6.20318.15-osx-x64.tar.gz",
+            "hash": "03bf06a62c040840825455abe6a94ee6833bc19fe8fb7a38012638a6d7e12dd2b0f0a5efb761c84152cbb09dd659821d2897153918a2dd3ed9d1b07de437e719"
+          },
+          {
+            "name": "dotnet-sdk-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a8b692d7-7f4d-4942-a67d-31b641401393/24e5432311663d3aa9274a2e7f30ddfa/dotnet-sdk-5.0.100-preview.6.20318.15-win-arm.zip",
+            "hash": "9c8fadc64c25c3355dde90ff58099bd030227d95ed929e87210e444a900cba14df42d2e4dacc7fca6224345270fba77585eb3fde5e48a9b842952c2306d3c0f5"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/641b012b-5952-453d-a2b8-46aaab4b5ae4/c0e5b3a90d8027787b358658909695b5/dotnet-sdk-5.0.100-preview.6.20318.15-win-arm64.zip",
+            "hash": "8c0ec61a02daf5ad04b8286b50e90280b45179115400d2375b909d9241d857bcb73aeb929a5a9f42f6981de40252608a980e5118bdd7627686026653f891efea"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fd9433cb-270c-428d-b0b5-a29a0775248e/111429e1df10716fe6d85ab4e658b333/dotnet-sdk-5.0.100-preview.6.20318.15-win-x64.exe",
+            "hash": "cc112b2d93337f70e490861c9f0325d55fea51867b1b53d0157778ec61e776e7dad99a929724aec2d35d809b2c4f80c47e4783150fd6f522dedebddbea71a9db"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/95161504-111d-44b6-a769-72c07d7179a7/47fc56c03ee30f612e1e34e1b7430897/dotnet-sdk-5.0.100-preview.6.20318.15-win-x64.zip",
+            "hash": "46ecc1e10aa9c9296675af55fe93bf003d3984b761e1c1d2af823a24b355ca99e0bce9ceb8856ec29ee1c3dd430c01c0b55901a853a1ef763397eadf9045e01e"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b0062077-f955-4b97-94cd-454f740ff142/ccb371f6fd4b2ca1f54ac0e182778b5f/dotnet-sdk-5.0.100-preview.6.20318.15-win-x86.exe",
+            "hash": "ab14ae0af4103083a4794ca514ba6c5e9ef69d110b099b0ef60df9ffec8a8f1bd5aad280138da9cdec36664f03b83804e1c90bc0c4a647731e190cb8847cad4d"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7f2c7990-e7dc-4937-881c-b58e43f24ed0/78c3c9fd17f4f89c7de4a45d9f17dc00/dotnet-sdk-5.0.100-preview.6.20318.15-win-x86.zip",
+            "hash": "231a0fb7b959b8ea90e16fe03806920d6f60dc54eb537698c0acbbd68a30d92bfa1aa31b1c00798d08d2b0b28554907a0f467cda06fa78d398144f2468a596e6"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.6.20318.15",
+          "version-display": "5.0.100-preview.6",
+          "runtime-version": "5.0.0-preview.6.20305.6",
+          "vs-support": "Visual Studio 2019 (v16.6)",
+          "csharp-version": "9.0-preview",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/fc54f62e-c7bd-43a3-a27b-4afb08bc4d6f/b01ccacf3d94efc0bbe26f64f7fde9b7/dotnet-sdk-5.0.100-preview.6.20318.15-linux-arm.tar.gz",
+              "hash": "1dd5c4f90d43983f1b6ccfa7631fd70afe99b26c1111d191dccb860bcfa232052c3589147f730b583b3f498bcd1116a131fae462267b68a00c10d7e7d832e65f"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/164ecfcc-df44-476f-a161-340201aa6fa8/7200eb764dc9ff546d384e3188f98a53/dotnet-sdk-5.0.100-preview.6.20318.15-linux-arm64.tar.gz",
+              "hash": "2a1039c4a94abd33949176407edee84dbd54053b56c7e2d8b69e7cf28e16f89013036cf662403ea8f2ea593b9b1b702e464762d9670da12507d1c1e06a58c04f"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6cfc5668-5c55-4ab4-9266-0d3dd00e6417/c03eb0deb48f9d2cf8d2bde4bf4d9113/dotnet-sdk-5.0.100-preview.6.20318.15-linux-musl-x64.tar.gz",
+              "hash": "e0c5283cd1758f921e25f4653c8c8a3076dd83602c8f036b347450695717ad3c071222b2467df27b8854c55e555f4ed095f9dc072d595caf6fe7b4abde6332d5"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ec4bba83-4586-4705-a6ae-c648861ca284/d9470c2f68161e3c2b8a0785fe7b3329/dotnet-sdk-5.0.100-preview.6.20318.15-linux-x64.tar.gz",
+              "hash": "ae68221770e8f199880f00a29d72c624aaedc0c3ca61a7b543a6555acf27eca4c0c24fbd4eddc1322d7dcb4f342325b1d1521c590556bd95c3c2ec653b914dbb"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f912c99a-c128-4436-8aa5-433cf502d0ab/4ebe252735cb7ae6cc828b2e0bbe107b/dotnet-sdk-5.0.100-preview.6.20318.15-osx-x64.pkg",
+              "hash": "7c3f50b2b7fac2c41fe5074d706d67ee6e8edaa3eb464425ea884add51d92ae82f1a2571ff41ce3114abcdb91ebaa3df893bbf4f9ce2d666bb8a9577551004f5"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ae0be7cb-6553-43e4-ab1c-6355a0ac0b9f/e18a0be6d89ac4cde08e39ce232953b4/dotnet-sdk-5.0.100-preview.6.20318.15-osx-x64.tar.gz",
+              "hash": "03bf06a62c040840825455abe6a94ee6833bc19fe8fb7a38012638a6d7e12dd2b0f0a5efb761c84152cbb09dd659821d2897153918a2dd3ed9d1b07de437e719"
+            },
+            {
+              "name": "dotnet-sdk-win-arm.zip",
+              "rid": "win-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a8b692d7-7f4d-4942-a67d-31b641401393/24e5432311663d3aa9274a2e7f30ddfa/dotnet-sdk-5.0.100-preview.6.20318.15-win-arm.zip",
+              "hash": "9c8fadc64c25c3355dde90ff58099bd030227d95ed929e87210e444a900cba14df42d2e4dacc7fca6224345270fba77585eb3fde5e48a9b842952c2306d3c0f5"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/641b012b-5952-453d-a2b8-46aaab4b5ae4/c0e5b3a90d8027787b358658909695b5/dotnet-sdk-5.0.100-preview.6.20318.15-win-arm64.zip",
+              "hash": "8c0ec61a02daf5ad04b8286b50e90280b45179115400d2375b909d9241d857bcb73aeb929a5a9f42f6981de40252608a980e5118bdd7627686026653f891efea"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/fd9433cb-270c-428d-b0b5-a29a0775248e/111429e1df10716fe6d85ab4e658b333/dotnet-sdk-5.0.100-preview.6.20318.15-win-x64.exe",
+              "hash": "cc112b2d93337f70e490861c9f0325d55fea51867b1b53d0157778ec61e776e7dad99a929724aec2d35d809b2c4f80c47e4783150fd6f522dedebddbea71a9db"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/95161504-111d-44b6-a769-72c07d7179a7/47fc56c03ee30f612e1e34e1b7430897/dotnet-sdk-5.0.100-preview.6.20318.15-win-x64.zip",
+              "hash": "46ecc1e10aa9c9296675af55fe93bf003d3984b761e1c1d2af823a24b355ca99e0bce9ceb8856ec29ee1c3dd430c01c0b55901a853a1ef763397eadf9045e01e"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/b0062077-f955-4b97-94cd-454f740ff142/ccb371f6fd4b2ca1f54ac0e182778b5f/dotnet-sdk-5.0.100-preview.6.20318.15-win-x86.exe",
+              "hash": "ab14ae0af4103083a4794ca514ba6c5e9ef69d110b099b0ef60df9ffec8a8f1bd5aad280138da9cdec36664f03b83804e1c90bc0c4a647731e190cb8847cad4d"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7f2c7990-e7dc-4937-881c-b58e43f24ed0/78c3c9fd17f4f89c7de4a45d9f17dc00/dotnet-sdk-5.0.100-preview.6.20318.15-win-x86.zip",
+              "hash": "231a0fb7b959b8ea90e16fe03806920d6f60dc54eb537698c0acbbd68a30d92bfa1aa31b1c00798d08d2b0b28554907a0f467cda06fa78d398144f2468a596e6"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.6.20312.15",
+        "version-display": "5.0.0-preview.6",
+        "version-aspnetcoremodule": [
+          "15.0.20164.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/73088968-f3eb-46c5-b762-93118fdc43d3/bb4f75b42f0c4ef4fb4d0fba67a88743/aspnetcore-runtime-5.0.0-preview.6.20312.15-linux-arm.tar.gz",
+            "hash": "5243d7e3e68f5d0e4ac334d00405b3a4a81b6700f5897e3a68cc388c42f70ffbfe2bb41c39466c76ad98996591e88190c079c03dbf23704be6144d763020985a"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/35bc810e-7447-4989-8690-a26bea89978f/8b2b16cdcf73aeb3987a08a4d968fdb6/aspnetcore-runtime-5.0.0-preview.6.20312.15-linux-arm64.tar.gz",
+            "hash": "8bcee151e9a0d41654fe641e9c949ba053394b345ff8250d591929ffb44e9163e800093d1eadfe810f608f87217e27051ddfb284969db71bb386db9ff8b2389d"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ef32de56-e8a7-448f-bed1-f1e8d1b52d61/a83be851e55a895c57001c69e3c40048/aspnetcore-runtime-5.0.0-preview.6.20312.15-linux-musl-arm64.tar.gz",
+            "hash": "2fc1bafb3963ee7f0a250f980434d47b81ce7bad41311eda1391c1d72591bb18b3e49f8aca1331fc4ae2a928d840c4b56809579bf835a427ac4a4208e3ce6136"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/81466dce-451a-480d-b6b1-6dd26841c057/ca724a89b6af524b13a3d8065fdb51d3/aspnetcore-runtime-5.0.0-preview.6.20312.15-linux-musl-x64.tar.gz",
+            "hash": "157b73945e553947147622382fdacbc0649523c383a3bd5a1c65bfbb026e6fead39ee1260af41f1a8c574be0f87d462f18bca540c594422c1f8b4f09e52b2c93"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/72d81bfb-18f8-4f32-bcf2-b96bae1f648b/bcb3c3f6092b646aff08775e48ee1738/aspnetcore-runtime-5.0.0-preview.6.20312.15-linux-x64.tar.gz",
+            "hash": "237019e067d89f0b62d68793f17607fd484a2a9e06ab2423bd31d17fc42933f0d3e1112399309c93da243b0943bcd7317b389efcf83e6cda544dab1a82101bbc"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fb1b59dc-ad8c-4c34-95a0-5eb202916943/9bcbf60f802cf4c9ae67914a57141072/aspnetcore-runtime-5.0.0-preview.6.20312.15-osx-x64.tar.gz",
+            "hash": "330e12e8c52bd4fe07756a6bc3871a5e8838be736f97a238e26d5d53a74d53069a6c330e475bcc38fa68b44cdd6be585d382d20a817a8823783db4428ee352d2"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/275bb38a-fc5a-4811-903c-7fb012507fbe/bfb3c6218b07f8620c6b804700477b16/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-arm.zip",
+            "hash": "d9b15253f3b7ef4b1772e7a6a7fd26cc70336f4fc645c2c43f11100e7ac406b15a61e8e32bed4d1b6e5d5448ba25cbc1c40380f3048c534f35dd1dc926792a73"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ba06eeb6-f5a7-484c-948e-fdcf22ad6198/394e1ea9b4886df2a365085a9ac8cd2e/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-arm64.zip",
+            "hash": "b576a35e31503b1b5d1c2e8b01f64bd4047b4ec76cd528ea6b0552be44318c50a4db276767c0e3852e162b6a286222302440cad57ed1599f83ce10181e023222"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9214582e-ff80-4f31-8b88-5fa9d4b776e5/606ea8c457382a4636283045ac50db6a/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-x64.exe",
+            "hash": "41380dcb37876ad7ad4111c872887e67343ad2087072ba634bec4e0544c68c8dd99a2f252530a711fa23cdac00a03528533ad5e305632fe8398df0e518b5a0fd"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5f067ed8-d2e0-4272-a118-8007892b3fa2/3fecfd00d6263446e1d1ea60059c8acf/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-x64.zip",
+            "hash": "d46f3b92142ed50ba9352bf36c100657028c67700f56617f3df5a050ce2015e8156b1739ec67e49c2d4fb425be2e08c7083513a2a950698027af6bd486e181c6"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9689303a-21cd-43fd-9d4f-a68ee39e190e/542ff84d8e9df559e847bd2bc7200a21/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-x86.exe",
+            "hash": "2a75a810a696020a8fc8fd1d8a9d27b53cc3bcfd55fd318925169de8a7db0776032f81d074288d766072beab924108c7f70abec60a054d7bcd77d28591025539"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4a0ac3d1-1444-4996-9c2b-098890f4a9d1/4e8d5ec188c9e03d4bc74e689823be83/aspnetcore-runtime-5.0.0-preview.6.20312.15-win-x86.zip",
+            "hash": "81b5f72b496b917d1b8977a9cdbf30bb305bd3d6f812e8180a80c20ca66ebbb12251ae549429a76c2a551b65f98b4e88766876ef70e81abc5da1e9113cf36a6c"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2563f05b-8dd1-4d66-92e0-2766ac653df9/cd36906fb799128ee9107e55194cf505/dotnet-hosting-5.0.0-preview.6.20312.15-win.exe",
+            "hash": "8ca3235e36655127a0193d6c88a8a812c1795c1e254f0b41223759239843b5cd6275d026fc30ed7678bbe50fa4c90d2318e974a57f9e6394861f39d9879e8a09"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.6.20308.1",
+        "version-display": "5.0.0-preview.6",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/829c5f36-4be5-4bf0-bf2a-a951ac1a53a9/dcef53f6325d9f055f704e0ebcce4fca/windowsdesktop-runtime-5.0.0-preview.6.20308.1-win-x64.exe",
+            "hash": "4328aad877464821319960ad5ec4795ce8c4f8a99be755c0757326a56e25b800fcaadbb255ed5e91cff018f25b89823bd4b424c0112535263dfc5492c95b47ec"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/877d2802-6181-42de-9ec7-3aa99941c75e/93766366e5475a969ebf514c8bd3f93f/windowsdesktop-runtime-5.0.0-preview.6.20308.1-win-x86.exe",
+            "hash": "a14182c51ea60db77c0428a8b4fa2c8f4c18c48f3d282a67815b3e1929dfd1f5fc9fbf5d191033192a131688fb43988a7d0440fc27518bc1b1f4ad3d2054c7bf"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.6.20305.6",
+        "files": []
+      }
+    },
+    {
+      "release-date": "2020-06-10",
+      "release-version": "5.0.0-preview.5",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.5.md",
+      "runtime": {
+        "version": "5.0.0-preview.5.20278.1",
+        "version-display": "5.0.0-preview.5",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/51a30257-7167-452f-bb48-8bf52874a312/3442cb330320a26a2b6a060202f4ee7a/dotnet-runtime-5.0.0-preview.5.20278.1-linux-arm.tar.gz",
+            "hash": "fbe871f82c7c61195fae789af415c2efd03dae982e131c10cacd95b744b0f498774b014bcb3523cf52153104fdad81759f84e2e72bcda7eec48e3530ffb03e60"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/875a8949-420f-4fdc-858a-30f293a4cc9b/5b44049862dc82764c6e03120d52a9b6/dotnet-runtime-5.0.0-preview.5.20278.1-linux-arm64.tar.gz",
+            "hash": "d081750334a49e9ed6b75468d937e02ce247d8a8f0c66505d048174591a35fd433fc0febb0b551dcaf8a823190cd92fb6578c140f0fa4af859c911f622963724"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b1e4ff98-4e4b-4cd6-981e-33acfc20bc7a/840d6032bc7e4dc55c4d03a6ab44ab98/dotnet-runtime-5.0.0-preview.5.20278.1-linux-musl-arm64.tar.gz",
+            "hash": "249ea41018c76972c2f3e54dbb515b75721a603435cfa9d1100e32a05c3c832674d110729f63d9cbb44768d8444e4799df1bab407f836eb10cd1b3c554259b9e"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f23ebe0b-74be-4fd3-841b-123b32dbcffb/3c33ceb3af2f23632689e670fc9fc397/dotnet-runtime-5.0.0-preview.5.20278.1-linux-musl-x64.tar.gz",
+            "hash": "4e1b8147d82045fb58812a90ae9e70810646dde335844be390ac6adb839f1219fd19811d63e345881532a0d27af91e633cc462218ca7a34d429a3731f7b5a686"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/95306227-0c75-4645-87ef-3d5b46af79a4/bb4aeba4db192c2a62fac09cb797ba08/dotnet-runtime-5.0.0-preview.5.20278.1-linux-x64.tar.gz",
+            "hash": "1bed1c8ee4185c0ced69e415dc25a5040eed68d0d6a7c35c6a83fbe1eb3f71e99e8c9b631a34825141163b9fe105b281f6c7d5d39bbcf40f20b9d81fdb7384d5"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ed4dddfa-d703-451e-bd2f-8dfbe81a735e/9b15085e7d4be3d3c881abc24db523b8/dotnet-runtime-5.0.0-preview.5.20278.1-osx-x64.pkg",
+            "hash": "c4d17cce8804fce39e731bc6a95bbb08bb8a175b6c43bcc2e1bf73c8236b11cfd32cc8ac953a1c15c5f7e15da9013dcd3f25a0996697706316b4ae185ab0a11b"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/896a86ec-29db-4915-b2c6-f2f7b4e672fb/27fe60394d6a00ee18c37038b9e3280e/dotnet-runtime-5.0.0-preview.5.20278.1-osx-x64.tar.gz",
+            "hash": "d672ee9f489a10b33b26626b5959d9dcee8f54079004991615367492eb2c2232299bc3655b1a4f9270b717feffac54466d74a1a8d6e192a367b1e5cfe3a78d1a"
+          },
+          {
+            "name": "dotnet-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/01efb1c0-2b52-4ab7-be2b-38369d8fd806/e8366cf8870271e1da2b6f07a8b983c2/dotnet-runtime-5.0.0-preview.5.20278.1-win-arm.zip",
+            "hash": "7f0214fb8ad7d2e44e3d63a93e729cdab90bb2b7ee231e1ec1fb3639c37f74275fc01dfd810e049fab7b2a8b14c73f01b97158234b0a6845f744833e49f70480"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7e01b3e5-e9ce-4e9c-baa1-ba71a6c7b415/dee7f90305b7bbf9a95d5529cf125eee/dotnet-runtime-5.0.0-preview.5.20278.1-win-arm64.zip",
+            "hash": "0d8e5f049b5022d3ece6e2d8c244f819ade33bcbd4d251cdbfd97811fd2da271eca32cadea65f3d1ac99ec4b642ce16dae8b089b3869f5cc2e8db958490a43b4"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/add3d66a-0362-4963-9cb6-995a35bbc462/8641decedefe5f3026ea00cfb669667b/dotnet-runtime-5.0.0-preview.5.20278.1-win-x64.exe",
+            "hash": "908cb1b453e4bf7f4f03e088f84ecae0ce20e4903527584a246fea75278b9eba48716bec35beef011718efb8518df1067c6937ac20606e41f206dd914b69610c"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/77eae450-bf51-46dd-a464-c705efe62f7f/89c0c2c7a7eed4f492a8cc2ed4342f00/dotnet-runtime-5.0.0-preview.5.20278.1-win-x64.zip",
+            "hash": "6178f4ba6a4bd578eb0a3338621cb26bfb0d92936b1b9af2dbc66d9dd028d1f4e20e58f191eef5e52293b46e3e84a3332a123494bc572822ac68ec05345e8204"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5a1a5d33-3e09-46ee-941c-73ed1f4e5092/dacf37c9b40b973f78a11c95e9550d51/dotnet-runtime-5.0.0-preview.5.20278.1-win-x86.exe",
+            "hash": "ecf24922e05b7e155356171b7e85393284a840d313e83ec9db52a804555d381afaf97759a9d6a59e2459ff20ef9071dcbfaef483485ba22f6895c53fb11cccbd"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2ea3be64-1cec-4ded-a992-703de2aa40c5/1eea262da0c415e926a6b411c2def271/dotnet-runtime-5.0.0-preview.5.20278.1-win-x86.zip",
+            "hash": "3da31d2e6e923b4d56b2920d68a8bb1463e0c733f0309835b6a54c15506be21aff64ecd35e762f9208eb2e001b512e3e32562f6a0dbbecd17a9d82547bc52b50"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.5.20279.10",
+        "version-display": "5.0.100-preview.5",
+        "runtime-version": "5.0.0-preview.5.20278.1",
+        "vs-support": "Visual Studio 2019 (v16.6)",
+        "csharp-version": "9.0-preview",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6fb3f700-22ed-43d8-8f54-8152f359054b/050d3254d477aeb124a45d0cb13f864d/dotnet-sdk-5.0.100-preview.5.20279.10-linux-arm.tar.gz",
+            "hash": "6256e013e0e1a153671b9ac3afb49db2646d5e9710112626f52f91070e9832fd17c475414387c6d544dadf2b62df342400d7c34ac01e7a1807d53587ac2d0bc8"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a529731c-7c51-42f4-9386-46c6466019dc/e408a0275c2333ae29a6e31c00c1ae64/dotnet-sdk-5.0.100-preview.5.20279.10-linux-arm64.tar.gz",
+            "hash": "426caa42f586f5213169828c8ee049f10bb8ee0aa1c8961d006396e74c995f0cadc88c9dffeb13f573f3b21bdd9a11279adb0f00bccd20f38da66153b8be43d0"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/190ba32d-e1d5-442e-ac07-09b002e5750c/da229668b853a5912bdf1b224dbd371c/dotnet-sdk-5.0.100-preview.5.20279.10-linux-musl-x64.tar.gz",
+            "hash": "441ccd3e724599d187363fcc3217e5077efa68218a86b2c7dc24ea776de6618ba9beef3ee2c856e4bffd39aeb4d7257c619af8f8db4ec94cacb2aab35f920b50"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7cf9fa3e-af03-4181-baab-e04ed4b05268/fd44776a5169d6b126ee11d6140691be/dotnet-sdk-5.0.100-preview.5.20279.10-linux-x64.tar.gz",
+            "hash": "0ee982dd7b6015d05c04a33ffba77fa9f61863578c5fd7c4b3847043da2fd17c36b2f8535af53f46dee66e9e59a52f5e7c995af7f9a69fbd3abbc524aca5931b"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f63b5b1e-25f9-4213-a147-ca8a252b8e27/094a39437dfc8f03eda852b36b499115/dotnet-sdk-5.0.100-preview.5.20279.10-osx-x64.pkg",
+            "hash": "cf9f15e8a10fa44988efee31d6a5d610e088555c6116736528682ccbe4ace6791f68751efbfded7c55e1d8202abc77dc1c9a1656a5783b13db9acc95894a615e"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/34e0dc05-8cf3-4deb-a9d2-14a697684cf3/5b37bee096f464f04393ac35cea8439a/dotnet-sdk-5.0.100-preview.5.20279.10-osx-x64.tar.gz",
+            "hash": "91b693142b8e7551cdb9cfd304cf62ec01dfc6d429fca9635976355528319199c5e072d8b62b2e7341ef449429fbe12ca992b9802725d4ebc7a8139b99203775"
+          },
+          {
+            "name": "dotnet-sdk-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7022cbbf-275c-48fd-ba94-a994892e0bdc/91a25f084fe2595ab33fd7431fb68cf5/dotnet-sdk-5.0.100-preview.5.20279.10-win-arm.zip",
+            "hash": "9b770bacfedf0d36bcb57042ace89464a21077659804bd00710fd10f17b9abb6dbd6fa438cb5a50ad987ed04943700fe1fd71c15112b4ea03e4213d3c33a9ea3"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ecd42d26-c097-4755-a5cf-1e1cb0365d62/e71a36687a026248792177e2b42d0602/dotnet-sdk-5.0.100-preview.5.20279.10-win-arm64.zip",
+            "hash": "007032f39d8e52b1e77a2e0f1a1829d51631ca6b6f1dd25b522dcba8abcc474f87e80d3eb4aa00ef3ae19caa8f13f2cdeac3b2fda2369477ef5efb2a188bedde"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/38c82743-6223-4a51-a424-ac79a4db189b/5c88aa3116df3b81564077fe49a83c7f/dotnet-sdk-5.0.100-preview.5.20279.10-win-x64.exe",
+            "hash": "82fdb454f78f659dc43f94cbab034396e10bb1a16ac0101bf9bf473a5e88b3ce441f496a91a89e102deb3b356bd6717128c5a8fb7266896a823f22f95df65083"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d4c38dd9-6cfe-4e0b-91d3-511ede217bcc/6e6a85d8a85194a416503d1a103e95e0/dotnet-sdk-5.0.100-preview.5.20279.10-win-x64.zip",
+            "hash": "086927a537acd60cfe71cfb760d01659c77a7f918f1848b9b5776759043e45d3ead0f394aff6b45cc01f8c0f5f0fc22d0fca5a8ba478b9d514d56547492789be"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6163690f-c627-4063-9229-fed74d955402/e33f89f431867b98e1a74297fe73cc7f/dotnet-sdk-5.0.100-preview.5.20279.10-win-x86.exe",
+            "hash": "87027008020a566c53621c6bc7b67a7ddc6bf621c11b5cbad01c38c4a74958ef904161e35d48b985ab0d5bebdbc792029ef8f62eb8a10b3680ba20c91ca97461"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/63061248-531e-488d-a9c8-794a33a06ab7/910cf966d38c953d94d3140487786bb7/dotnet-sdk-5.0.100-preview.5.20279.10-win-x86.zip",
+            "hash": "2a906c071d3c32f9f2be846675dc3a487ea6e9127ca5dc9cbcf35d3f57cfd4817df1b006360c0455bbb6cd2e711296ccf4250733013b0740ca04509186c8e549"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.5.20279.10",
+          "version-display": "5.0.100-preview.5",
+          "runtime-version": "5.0.0-preview.5.20278.1",
+          "vs-support": "Visual Studio 2019 (v16.6)",
+          "csharp-version": "9.0-preview",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6fb3f700-22ed-43d8-8f54-8152f359054b/050d3254d477aeb124a45d0cb13f864d/dotnet-sdk-5.0.100-preview.5.20279.10-linux-arm.tar.gz",
+              "hash": "6256e013e0e1a153671b9ac3afb49db2646d5e9710112626f52f91070e9832fd17c475414387c6d544dadf2b62df342400d7c34ac01e7a1807d53587ac2d0bc8"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a529731c-7c51-42f4-9386-46c6466019dc/e408a0275c2333ae29a6e31c00c1ae64/dotnet-sdk-5.0.100-preview.5.20279.10-linux-arm64.tar.gz",
+              "hash": "426caa42f586f5213169828c8ee049f10bb8ee0aa1c8961d006396e74c995f0cadc88c9dffeb13f573f3b21bdd9a11279adb0f00bccd20f38da66153b8be43d0"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/190ba32d-e1d5-442e-ac07-09b002e5750c/da229668b853a5912bdf1b224dbd371c/dotnet-sdk-5.0.100-preview.5.20279.10-linux-musl-x64.tar.gz",
+              "hash": "441ccd3e724599d187363fcc3217e5077efa68218a86b2c7dc24ea776de6618ba9beef3ee2c856e4bffd39aeb4d7257c619af8f8db4ec94cacb2aab35f920b50"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7cf9fa3e-af03-4181-baab-e04ed4b05268/fd44776a5169d6b126ee11d6140691be/dotnet-sdk-5.0.100-preview.5.20279.10-linux-x64.tar.gz",
+              "hash": "0ee982dd7b6015d05c04a33ffba77fa9f61863578c5fd7c4b3847043da2fd17c36b2f8535af53f46dee66e9e59a52f5e7c995af7f9a69fbd3abbc524aca5931b"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f63b5b1e-25f9-4213-a147-ca8a252b8e27/094a39437dfc8f03eda852b36b499115/dotnet-sdk-5.0.100-preview.5.20279.10-osx-x64.pkg",
+              "hash": "cf9f15e8a10fa44988efee31d6a5d610e088555c6116736528682ccbe4ace6791f68751efbfded7c55e1d8202abc77dc1c9a1656a5783b13db9acc95894a615e"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/34e0dc05-8cf3-4deb-a9d2-14a697684cf3/5b37bee096f464f04393ac35cea8439a/dotnet-sdk-5.0.100-preview.5.20279.10-osx-x64.tar.gz",
+              "hash": "91b693142b8e7551cdb9cfd304cf62ec01dfc6d429fca9635976355528319199c5e072d8b62b2e7341ef449429fbe12ca992b9802725d4ebc7a8139b99203775"
+            },
+            {
+              "name": "dotnet-sdk-win-arm.zip",
+              "rid": "win-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7022cbbf-275c-48fd-ba94-a994892e0bdc/91a25f084fe2595ab33fd7431fb68cf5/dotnet-sdk-5.0.100-preview.5.20279.10-win-arm.zip",
+              "hash": "9b770bacfedf0d36bcb57042ace89464a21077659804bd00710fd10f17b9abb6dbd6fa438cb5a50ad987ed04943700fe1fd71c15112b4ea03e4213d3c33a9ea3"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ecd42d26-c097-4755-a5cf-1e1cb0365d62/e71a36687a026248792177e2b42d0602/dotnet-sdk-5.0.100-preview.5.20279.10-win-arm64.zip",
+              "hash": "007032f39d8e52b1e77a2e0f1a1829d51631ca6b6f1dd25b522dcba8abcc474f87e80d3eb4aa00ef3ae19caa8f13f2cdeac3b2fda2369477ef5efb2a188bedde"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/38c82743-6223-4a51-a424-ac79a4db189b/5c88aa3116df3b81564077fe49a83c7f/dotnet-sdk-5.0.100-preview.5.20279.10-win-x64.exe",
+              "hash": "82fdb454f78f659dc43f94cbab034396e10bb1a16ac0101bf9bf473a5e88b3ce441f496a91a89e102deb3b356bd6717128c5a8fb7266896a823f22f95df65083"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/d4c38dd9-6cfe-4e0b-91d3-511ede217bcc/6e6a85d8a85194a416503d1a103e95e0/dotnet-sdk-5.0.100-preview.5.20279.10-win-x64.zip",
+              "hash": "086927a537acd60cfe71cfb760d01659c77a7f918f1848b9b5776759043e45d3ead0f394aff6b45cc01f8c0f5f0fc22d0fca5a8ba478b9d514d56547492789be"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6163690f-c627-4063-9229-fed74d955402/e33f89f431867b98e1a74297fe73cc7f/dotnet-sdk-5.0.100-preview.5.20279.10-win-x86.exe",
+              "hash": "87027008020a566c53621c6bc7b67a7ddc6bf621c11b5cbad01c38c4a74958ef904161e35d48b985ab0d5bebdbc792029ef8f62eb8a10b3680ba20c91ca97461"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/63061248-531e-488d-a9c8-794a33a06ab7/910cf966d38c953d94d3140487786bb7/dotnet-sdk-5.0.100-preview.5.20279.10-win-x86.zip",
+              "hash": "2a906c071d3c32f9f2be846675dc3a487ea6e9127ca5dc9cbcf35d3f57cfd4817df1b006360c0455bbb6cd2e711296ccf4250733013b0740ca04509186c8e549"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.5.20279.2",
+        "version-display": "5.0.0-preview.5",
+        "version-aspnetcoremodule": [
+          "15.0.20150.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1c2aaaf5-a2e4-479e-8e66-c75415ea167d/b4b71f1a89af057334187b0c36d5b6dd/aspnetcore-runtime-5.0.0-preview.5.20279.2-linux-arm.tar.gz",
+            "hash": "bb021d67206f48bfb21151181bed0f1b5455a2216c9e9852b0872f8e13d316bb389aeb3cdbe96023f0623d841f7eec0c12624af6749b431175034a883bfe30b4"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/adc871bb-2eb6-4083-8665-a005367fff17/a76aee5f824dc9876a6d27adf9be28a6/aspnetcore-runtime-5.0.0-preview.5.20279.2-linux-arm64.tar.gz",
+            "hash": "68491c16bed5f7fdebc5c806daae3857462b6589cfd2dab0d84f753eefa735a705f72beb1914fe189b40ff274bd658b7c3fefc6ff7c0f9178bdd46e88584c7a6"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/eae4efcc-9105-45ba-a1ee-3a79f9ed51af/f879cce5713bb029254eba12b4aecb0b/aspnetcore-runtime-5.0.0-preview.5.20279.2-linux-musl-arm64.tar.gz",
+            "hash": "0a25aabc07122423ad034809b2806b9322c4e32f965704cc34e828830ee1e6466d117617c37f9cb350d6fe4b7d6165d6eb2c974161949870274f4246800d9121"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5bf853cd-5736-4411-b853-0f6e24430d76/de830144eebdb7f681c1bdefd403c9a3/aspnetcore-runtime-5.0.0-preview.5.20279.2-linux-musl-x64.tar.gz",
+            "hash": "6377ac079540d502902b4ff621638400411f3411839cf711ac49c0f9be63c9eb408febea6e01ef9a81d2c4700263e5d5e57752226f3be0e7980894e9211e2ec3"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c4697b7a-c408-48e9-8d80-4ead593ee22b/8d03d322a7ca93efa1e8dbe66cf7a781/aspnetcore-runtime-5.0.0-preview.5.20279.2-linux-x64.tar.gz",
+            "hash": "5f1b1475f27a07b4d1af2c4bb293f53dc517ed33208669f74f468cbb42773cb4cf01649a13bcefa7070532f5881fe2a61709d029c6f00233790a5205a355e9db"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6aac3844-086d-48d5-9ed3-35ba1df3ba5a/587b8b0af9dda657c2331a3a205d2bf4/aspnetcore-runtime-5.0.0-preview.5.20279.2-osx-x64.tar.gz",
+            "hash": "4e9a7ef33a18ba242c751a289ff67446ec7295bdf32df9670ffd4e4fb7fcdf4fb09318e8ebb0f3afe0743303f240ffddcf979f0f860054b6c7d08626dda37bbf"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/04ad6c6d-c9b6-41f6-8636-671f51581831/429e3ca50495018d31c007f491accb81/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-arm.zip",
+            "hash": "464b7020c95249089c7516f04db8cec4d85d7b1628afdee3a467fea12eb959de8f38ef7cc5171930d01403903e752d273c7a86d1207c890a43ce22803115cfcb"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/42156656-028a-4974-8a9a-cd368740e8fd/c16e719c0636401dd3e7442c436e2b15/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-arm64.zip",
+            "hash": "5783850847619a6cbb3a50acf9b2b6df0d9031b6c1a18769ffee44c320953f88e56e78ff5537a37f58ad0108009dff90a79702a463f90e6f2adc304b32e8897f"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9159b7cf-5285-48dc-b391-14cab2fd15c0/c3ce1d1d230bb2afc924c18b652f68f9/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-x64.exe",
+            "hash": "fd5e74efd0c8ccddce9777f0425656b90b402d6fcf249afe4a0aa22492182819e34583b89d2725bcc682a919efd66b0d32c510a1e20891557dcbbf1f95198aff"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/36105bcc-125d-4269-8504-2c5fe5401fdd/11b4934407d307ab9f3951b6bb1a791a/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-x64.zip",
+            "hash": "09646e89c04993ee42a5d072e5409fe6f389df41f20df30f6c3074d066725606b3958cc9ce07aaa444d4e3b5880800b69dcbeea2a9112059a8ab0b02b5cdbcd1"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/30e238e3-b342-4c67-a71d-e4220625f52d/e11097c56bd2707b1207de183ef3fcdb/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-x86.exe",
+            "hash": "c1afc15206ba8d3db205b8e8f79be31be720424377b4ea223b187f2b813310032906328248479e71d4f7826d9852985e876161d61ff1cc02fb889911674d7a95"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/16474f86-f8d4-456e-85b4-7cd5e2dfe5f4/8935d76519cfa109128ecc66648a8732/aspnetcore-runtime-5.0.0-preview.5.20279.2-win-x86.zip",
+            "hash": "3aa29bc08ab2845e74d56957df90c8daf977a26bd394b75c274e465c4c3a9d678e950e98e444239e85cdeff6aa116242704ea9d45133955d8b53617e9ffe7440"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b1aaa280-c8d3-45cf-990e-cd1c736bb474/0c964ee4264bb54a5893d434942b7c73/dotnet-hosting-5.0.0-preview.5.20279.2-win.exe",
+            "hash": "9b8074c8ae9d4ac511d765effddfc61f7f023fe1cad8158ee707c1b3db4e496de329449b95c1d32204986efe19e2d06626907b6848335bd8e9cd21bfa2f3b39c"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.5.20278.3",
+        "version-display": "5.0.0-preview.5",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6cc1a99f-4e83-408f-95aa-b44dfdc9bc56/88d52d94d7f4f96c1313cb95d72c8515/windowsdesktop-runtime-5.0.0-preview.5.20278.3-win-x64.exe",
+            "hash": "196cf646072177d62b964bb71c480eef7c25e91658e9a2ac4de885f058ea9068b6d05bcac0383a9f03c7c559838458ef01c3d1ed7309bc0e25127a124f9e8004"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/94c3c646-f95d-41d3-a534-6617b3edfe87/4e36ed04c3ea19e82a42104982d1fd3d/windowsdesktop-runtime-5.0.0-preview.5.20278.3-win-x86.exe",
+            "hash": "83a54b3a503b2d27972fe96d9a4f7185e8857561f65c3b9d1733d015a66cf1651cdf5973d53537ba85b0cf75204e27038159431c94532f9c4db3a4872c05a63e"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.5.20278.1",
+        "files": []
+      }
+    },
+    {
+      "release-date": "2020-05-19",
+      "release-version": "5.0.0-preview.4",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.4.md",
+      "runtime": {
+        "version": "5.0.0-preview.4.20251.6",
+        "version-display": "5.0.0-preview.4",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fecfc81f-44c7-41f0-a158-894ca434876c/28cba3884db133373305a03a48f01eeb/dotnet-runtime-5.0.0-preview.4.20251.6-linux-arm.tar.gz",
+            "hash": "1648b613453cfafb755cfb43bbfe81ad7102f181b3a96e2b4ee3b71065b59271f2a1461a90961d416efa098bae223fde0b56e06d3b44ff60b36c0ea3394080fd"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d122c932-67f1-4358-9bdb-64cce009ee27/0a46b82fcb16e952491385149896ccda/dotnet-runtime-5.0.0-preview.4.20251.6-linux-arm64.tar.gz",
+            "hash": "c691e817b72377027936311c7fc8a7a04867ad50fd5189e41caa9222178248d01ad69e8b0fe5e5400815d06c740d9f0ff207e46ad9655dcaa032ee2a2a0c0ec6"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/88c44f96-64fc-47d5-9ff4-58a9cb391887/0f9439c08d08d4e55dd8bb33d7a88c55/dotnet-runtime-5.0.0-preview.4.20251.6-linux-musl-arm64.tar.gz",
+            "hash": "9c3a7b23dd4a0967c66807c899e3ebdc703d863f970ad98cb1ff8950f46a20304db5ba05218bd0b965b28cce5b07b2e790c3a8b89b2c787fdf93713ed8949151"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5da9bee6-e4cc-40a9-9d00-b7b768912a6b/8ca8d545d1e702a984b1f92b44351f05/dotnet-runtime-5.0.0-preview.4.20251.6-linux-musl-x64.tar.gz",
+            "hash": "cdceee3294bbf995b0ff78d6a498be158bcf19d6fb8d8f68d5ec07288e12abad368047298b299e367aa88e00fca796aab70dd3d1ac5b0310f8d1b3ee2476660a"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8be8a5dc-f552-4a64-a55e-d112ab2b0083/7eb1023a4c6937968c5bbfbb05784bb5/dotnet-runtime-5.0.0-preview.4.20251.6-linux-x64.tar.gz",
+            "hash": "7b3e90ccab3abd95bc678551a1778abf8d672978c598974669ba84418adc37d5bf2393a8c194adece7e86998418713e18571953f8ff7bb5780026d8814d882cb"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/25a7898d-1bb3-4472-bae9-ed24c8b4124a/dedf9dbb6d310ac5a9616d7b67fc77d0/dotnet-runtime-5.0.0-preview.4.20251.6-osx-x64.pkg",
+            "hash": "47f022a71c21bd15c21eea4c0a47abb2ed92a117a9c89aa03cd2c7262aef2996102d228e8d0c8e5a7d93beb7cb9205cc8259056e2e402662f72ae2a2447dc0a4"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c522d0fd-ab05-4b4c-9c06-2974973a7796/f202496a9c3b2e160c4b46944f90fb39/dotnet-runtime-5.0.0-preview.4.20251.6-osx-x64.tar.gz",
+            "hash": "a7cff64708e6ac4432c485677650fb6e7805b24088aa448db9ebe0ff2b474e051cef87e6ef2e3ae8d45e84e3db98c082a90de677f9d95f809cc1f7c2b725576d"
+          },
+          {
+            "name": "dotnet-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/78838732-9280-48a6-9af4-b8122fec9dc5/23c65e624d3cb1923b8d4cde9efd909d/dotnet-runtime-5.0.0-preview.4.20251.6-win-arm.zip",
+            "hash": "c4aa260e8f01810a20676042ebc42cc00db45efb2a75de9ed9117555e15aefdff0b5a8dd29a50b09f7d596255fe96ca962dfbd45c89fe750b3dbd593bc4e69e3"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5357cbc2-260c-486b-813b-08718fdcead4/cf3f79f8f5ac8b4b70d87b17e5917b62/dotnet-runtime-5.0.0-preview.4.20251.6-win-arm64.zip",
+            "hash": "e636004e3970e86478b2986252a50e34a2c32d92d4e5472b214fba4f81bafd929e37354f0e01212a6ba9ffacbf76d6f73429452c4e90f7ce525eb0b3dad2506e"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9a9e23ff-e724-4a85-be65-f3e99ebc6ead/24eb14ba173f807b12e3144dbb519931/dotnet-runtime-5.0.0-preview.4.20251.6-win-x64.exe",
+            "hash": "cbb041821cb1cb8512854f1361a5c662ab1c680ef308ec7d15df7acf15fb540c4c68ef60453bc869661194b618fd27d98c85e03afb981966e0aec299161a24b3"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/00e54b94-7eb4-44b6-84bf-405e8fc63fa2/4f0ee4bd09cad478c12e0ec418dc9f30/dotnet-runtime-5.0.0-preview.4.20251.6-win-x64.zip",
+            "hash": "c666a02299e2aa6f20dd5718c90cea1f496712cb93fc7cc300d2184cdd84509647c60daa48f4db4ef4d2e3ac2718c9c50b5d1d8fc139f89e74f1e87649c03c42"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/702a4f3d-3dd6-4a56-94e8-54559f981535/1b79a497066c5c539c5876dc48a280a4/dotnet-runtime-5.0.0-preview.4.20251.6-win-x86.exe",
+            "hash": "fc921133a0e8b1f7a24993701f969f32bf9450659cb5c4bbfd5ea828716425887023ed507d938aef52db60e3d8d79cdd85e950e907e5d47c90bfc806a019739e"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f2a5e1f9-34c9-497a-8606-1bbf12d54ab3/5b520a8b1def8271a89d2215bf643692/dotnet-runtime-5.0.0-preview.4.20251.6-win-x86.zip",
+            "hash": "ae6edf9a4b9c3a0d25f1e4445fd5fb5efff5caec602c004392b2e399ded86b1ffa05152efb00d9128bf6b32ee9ec6050dd3f7f325824c48c1f367d758056eb8d"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.4.20258.7",
+        "version-display": "5.0.100-preview.4",
+        "runtime-version": "5.0.0-preview.4.20251.6",
+        "vs-version": "",
+        "vs-support": "Visual Studio 2019 (v16.6)",
+        "csharp-version": "8.0",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/76bea762-22d3-4ce8-a3cf-64276d4b9aca/74a7bed0b9e67a11cf025115c52506ca/dotnet-sdk-5.0.100-preview.4.20258.7-linux-arm.tar.gz",
+            "hash": "912f33feb15a00cc7d983e2ed7c42750de013f072e5c6f0162410cca5b2aaadb146bfd09f0f4cc7c90ccaacbc5a5301bc91cfbd964312d3e44d5ff6c944baf64"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/adb3ed49-26af-40a2-8df3-1460b178e55e/01187433dc24decf562d90d4bb2ce058/dotnet-sdk-5.0.100-preview.4.20258.7-linux-arm64.tar.gz",
+            "hash": "36e13d6cf4dce12d5f5aa6bf4fa903a2bbe1b816b896ced4ae388514a3ae7a40fdbd918893e7cacfb3f8c8e328995c5c0cce49973785e05568b00aaf6eafe9b6"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/02c5780b-df7c-4b37-a936-10d5d91259f1/7222fd36139fc536e795f7341fb0700b/dotnet-sdk-5.0.100-preview.4.20258.7-linux-musl-x64.tar.gz",
+            "hash": "2da9779628928b896a4285494349fa55efc987633d918d2c136017db6c4179f9ffbce871d1840bacc2c9e06dd54023bfcacd1cc51fbbeb2eaf1ff2cd175a91c6"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/473651e3-55d5-4e7c-b255-2cbe11358eea/6b6f33d86ee00720b36a7c34200f4d0c/dotnet-sdk-5.0.100-preview.4.20258.7-linux-x64.tar.gz",
+            "hash": "d84fc2795ae6128299d318485a5e9ed8717f38aff83cac57ed9baa95785c33db7153e1d44aebfb21ab128f73540d09a5ecd58983345656c33c77c757faa4f624"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6d724fad-a67b-4fed-8152-f6f98aff6d63/fdf36e0be9ca9a92af106e27f1f9547e/dotnet-sdk-5.0.100-preview.4.20258.7-osx-x64.pkg",
+            "hash": "5db580ebe00145f73f881ce8ddec1263bc926d1a87eec7fd6209aeb18564c2d3ab415d547a2cbe28fd71b630de3877955e813e5011e3cc39050d2e1c039ea30e"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d7a77b5b-4592-46ae-8f1e-9e84b5bbc001/30f37207e7e149cbd01cd0ac33086b41/dotnet-sdk-5.0.100-preview.4.20258.7-osx-x64.tar.gz",
+            "hash": "6d2d00d319ad496074aab863bc3156d564872ca46c54bf1b3ed59ed755071c533733a863120da5b533e9bbd5843e276bba6a535e2c7f93a57bb9e858f7fae932"
+          },
+          {
+            "name": "dotnet-sdk-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e80d700f-3910-45e2-9414-320eefa54efa/10b76fbfe00159ad8b4ea81b42daaa5b/dotnet-sdk-5.0.100-preview.4.20258.7-win-arm.zip",
+            "hash": "c22a5089c7e16d1d3d738af29108b7c55bcfeb5724684cb3a5626d5e3d489355ed679f8d88cdbac3234d1ff353e7f7c13e28a3387a5eb14fcbd18b6df779f52c"
+          },
+          {
+            "name": "dotnet-sdk-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/52fdaa14-c08b-407f-bc7c-091af11f243d/7f40461579aa105e47a19c7745287847/dotnet-sdk-5.0.100-preview.4.20258.7-win-arm64.zip",
+            "hash": "055144b345e3920318477e4eb7e1c14706612beb5dc05bdf97e81ae657a525a769cc364d6671ca3d7803bee67931d120d6e27a6b5960c6e4c227aa4e9f09ee99"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/40dff314-f6c2-4aeb-bfc7-7f89fc8d2b61/79b23dcc8727ab76b7df8872968475fe/dotnet-sdk-5.0.100-preview.4.20258.7-win-x64.exe",
+            "hash": "d201ff295c76b41e7a20fef8a79d1a0135d98ee08af472d2e5f565b0163f10a2bf99faccfd27a79ea6e2b0b9089a1aaf4cbb7cf3450975f6ded64b7800ab9a41"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/22e64aea-4ee4-4c98-b913-303a04b89103/adc3fa5461c11e387aa07ab32f513fd9/dotnet-sdk-5.0.100-preview.4.20258.7-win-x64.zip",
+            "hash": "45be2aea1c493c42db6f3a69e36a798e436effc686507a52588030cbc8a39b45445fdea85759f7b7f53ab862b4341da19ef9be1fe0519a4ddac02b2d057a38ed"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2b51d5f6-c84d-40c3-bdd1-518012126a14/b48309f76e99b94c98d3a7b84a851013/dotnet-sdk-5.0.100-preview.4.20258.7-win-x86.exe",
+            "hash": "f56f11baee88e4706e049e31c64007bc7df1d8321c2b05c5a8281e6ca039d60b48422cb3a28463d280c0a458f3f4e2f9c10717dcce26d2e8980a27ecfdbf355a"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7255fb86-edeb-4ce2-b1fc-aae124e22d76/bb5b9b8103346ddf78b9a4c17c006b80/dotnet-sdk-5.0.100-preview.4.20258.7-win-x86.zip",
+            "hash": "a64bbd3f0a6197bbc004c1845bc43f02595d5682839202e17146ec040727f920fff9a1f2866f65931bc9d5796f663c01ab3282418d4b72e5c7a217324e5258bb"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.4.20258.7",
+          "version-display": "5.0.100-preview.4",
+          "runtime-version": "5.0.0-preview.4.20251.6",
+          "vs-version": "",
+          "vs-support": "Visual Studio 2019 (v16.6)",
+          "csharp-version": "8.0",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/76bea762-22d3-4ce8-a3cf-64276d4b9aca/74a7bed0b9e67a11cf025115c52506ca/dotnet-sdk-5.0.100-preview.4.20258.7-linux-arm.tar.gz",
+              "hash": "912f33feb15a00cc7d983e2ed7c42750de013f072e5c6f0162410cca5b2aaadb146bfd09f0f4cc7c90ccaacbc5a5301bc91cfbd964312d3e44d5ff6c944baf64"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/adb3ed49-26af-40a2-8df3-1460b178e55e/01187433dc24decf562d90d4bb2ce058/dotnet-sdk-5.0.100-preview.4.20258.7-linux-arm64.tar.gz",
+              "hash": "36e13d6cf4dce12d5f5aa6bf4fa903a2bbe1b816b896ced4ae388514a3ae7a40fdbd918893e7cacfb3f8c8e328995c5c0cce49973785e05568b00aaf6eafe9b6"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/02c5780b-df7c-4b37-a936-10d5d91259f1/7222fd36139fc536e795f7341fb0700b/dotnet-sdk-5.0.100-preview.4.20258.7-linux-musl-x64.tar.gz",
+              "hash": "2da9779628928b896a4285494349fa55efc987633d918d2c136017db6c4179f9ffbce871d1840bacc2c9e06dd54023bfcacd1cc51fbbeb2eaf1ff2cd175a91c6"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/473651e3-55d5-4e7c-b255-2cbe11358eea/6b6f33d86ee00720b36a7c34200f4d0c/dotnet-sdk-5.0.100-preview.4.20258.7-linux-x64.tar.gz",
+              "hash": "d84fc2795ae6128299d318485a5e9ed8717f38aff83cac57ed9baa95785c33db7153e1d44aebfb21ab128f73540d09a5ecd58983345656c33c77c757faa4f624"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/6d724fad-a67b-4fed-8152-f6f98aff6d63/fdf36e0be9ca9a92af106e27f1f9547e/dotnet-sdk-5.0.100-preview.4.20258.7-osx-x64.pkg",
+              "hash": "5db580ebe00145f73f881ce8ddec1263bc926d1a87eec7fd6209aeb18564c2d3ab415d547a2cbe28fd71b630de3877955e813e5011e3cc39050d2e1c039ea30e"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/d7a77b5b-4592-46ae-8f1e-9e84b5bbc001/30f37207e7e149cbd01cd0ac33086b41/dotnet-sdk-5.0.100-preview.4.20258.7-osx-x64.tar.gz",
+              "hash": "6d2d00d319ad496074aab863bc3156d564872ca46c54bf1b3ed59ed755071c533733a863120da5b533e9bbd5843e276bba6a535e2c7f93a57bb9e858f7fae932"
+            },
+            {
+              "name": "dotnet-sdk-win-arm.zip",
+              "rid": "win-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/e80d700f-3910-45e2-9414-320eefa54efa/10b76fbfe00159ad8b4ea81b42daaa5b/dotnet-sdk-5.0.100-preview.4.20258.7-win-arm.zip",
+              "hash": "c22a5089c7e16d1d3d738af29108b7c55bcfeb5724684cb3a5626d5e3d489355ed679f8d88cdbac3234d1ff353e7f7c13e28a3387a5eb14fcbd18b6df779f52c"
+            },
+            {
+              "name": "dotnet-sdk-win-arm64.zip",
+              "rid": "win-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/52fdaa14-c08b-407f-bc7c-091af11f243d/7f40461579aa105e47a19c7745287847/dotnet-sdk-5.0.100-preview.4.20258.7-win-arm64.zip",
+              "hash": "055144b345e3920318477e4eb7e1c14706612beb5dc05bdf97e81ae657a525a769cc364d6671ca3d7803bee67931d120d6e27a6b5960c6e4c227aa4e9f09ee99"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/40dff314-f6c2-4aeb-bfc7-7f89fc8d2b61/79b23dcc8727ab76b7df8872968475fe/dotnet-sdk-5.0.100-preview.4.20258.7-win-x64.exe",
+              "hash": "d201ff295c76b41e7a20fef8a79d1a0135d98ee08af472d2e5f565b0163f10a2bf99faccfd27a79ea6e2b0b9089a1aaf4cbb7cf3450975f6ded64b7800ab9a41"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/22e64aea-4ee4-4c98-b913-303a04b89103/adc3fa5461c11e387aa07ab32f513fd9/dotnet-sdk-5.0.100-preview.4.20258.7-win-x64.zip",
+              "hash": "45be2aea1c493c42db6f3a69e36a798e436effc686507a52588030cbc8a39b45445fdea85759f7b7f53ab862b4341da19ef9be1fe0519a4ddac02b2d057a38ed"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2b51d5f6-c84d-40c3-bdd1-518012126a14/b48309f76e99b94c98d3a7b84a851013/dotnet-sdk-5.0.100-preview.4.20258.7-win-x86.exe",
+              "hash": "f56f11baee88e4706e049e31c64007bc7df1d8321c2b05c5a8281e6ca039d60b48422cb3a28463d280c0a458f3f4e2f9c10717dcce26d2e8980a27ecfdbf355a"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7255fb86-edeb-4ce2-b1fc-aae124e22d76/bb5b9b8103346ddf78b9a4c17c006b80/dotnet-sdk-5.0.100-preview.4.20258.7-win-x86.zip",
+              "hash": "a64bbd3f0a6197bbc004c1845bc43f02595d5682839202e17146ec040727f920fff9a1f2866f65931bc9d5796f663c01ab3282418d4b72e5c7a217324e5258bb"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.4.20257.10",
+        "version-display": "5.0.0-preview.4",
+        "version-aspnetcoremodule": [
+          "15.0.20129.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/44b81693-0122-4498-8a28-d983173862f6/b453ffd36c5410c581b7f6611d87f1a8/aspnetcore-runtime-5.0.0-preview.4.20257.10-linux-arm.tar.gz",
+            "hash": "368b5ed98f8fb6a80142564ff705571f037143036ed36ef95f235fa67c94fb86038e60601ad1d82a0ee32b2c17fbe33e5cddf358124be30f09ffb452830d5654"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a64a611d-ed13-40e1-a8cc-f7daa3658c0c/58dd8187655361a6f05a798c25321c40/aspnetcore-runtime-5.0.0-preview.4.20257.10-linux-arm64.tar.gz",
+            "hash": "5cfe08a85af590d05f1a384938f13bb471b07d85a2572b622bff77e004f95366c9f347fe384a682480d7fe1547aabbadcf8d82d16605dfd8cf4688a3e082e676"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a753d870-1c08-4896-ae66-eae3566f8e8d/cfc75453b94397533b0089bc6e63e7f5/aspnetcore-runtime-5.0.0-preview.4.20257.10-linux-musl-arm64.tar.gz",
+            "hash": "71fd4f2cc5e3dcd41821be6a82675ce7f3f83637153d438160de51dce48540aec494ee4907f7e48e952bb05db8b746d357308419e6ea9355a3fd430e7dec4708"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/05d52928-7267-44d6-8f9e-f406a0cd76b5/a90fff112297ead1a6801d30945adbab/aspnetcore-runtime-5.0.0-preview.4.20257.10-linux-musl-x64.tar.gz",
+            "hash": "8ca2409c6a44d2ad5949d7107b5855ece12cde95b159f6eaf051f9eb991359fc6c47ec146a100e4169c34f1ee5f98de4b2afadea285ee74748f2cd373b0908cb"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/43b35634-52d0-4c7b-a87a-a709397e88cc/ba7e419c0adba58aa249e818e5c9dc90/aspnetcore-runtime-5.0.0-preview.4.20257.10-linux-x64.tar.gz",
+            "hash": "4e1fcba63e8ed494e29da789a6f737d59769b5be8eca038c070ec1a26ffb6601a14fae53be9e463e45b36957dd3b2e425d02d77c36d8682a93c3e3d9ef2742dc"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d5e0ebfc-70f0-433e-bd24-e5041b7f1ef6/6ccedc8a001967cd643bc79013357f57/aspnetcore-runtime-5.0.0-preview.4.20257.10-osx-x64.tar.gz",
+            "hash": "55a3c09c2ed29013ed70b25c76f6cf88002a291a6dfb6d0442dd49f6c1ef86ac7667ddebb4907a938722a26daaa6e05f631191857829d39f797ed53ec18f8177"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8e5a61bb-2876-4d35-8bda-62b92f9911b1/973720aa0044af2d4507df3ad37e6b60/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-arm.zip",
+            "hash": "b21d84a98fd31741d993d03f7cb6d692b4482d7609e9f853fc6746fc2f49dc6c9eb8a1891f9d458a3e87fae120ac3c22525508d67763b497d2e6f36c44e0a995"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4264fdc0-8a7c-4106-9755-8d37d80f502c/63d504db620cd095d69d0b05231766f3/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-arm64.zip",
+            "hash": "3e04855b0d57743aee5980969eceabfd95dda5b4554924cd48a9bb6d67598e4b372588fc582485e082a9aca0dc7a87cba6bf79fab24e923b1f2d8292188b9c9a"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b471f996-cc2c-4d21-8a9e-d2d308c964d6/80e04c11d6c26ca9e06763e93686b8a8/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-x64.exe",
+            "hash": "e8173192d7a27380b0b8ae1647a07da21c89eaf15a7f2e0ff8389ace9618bb2cfa00a73dee5bdacd0ee77f35eabf51e2d1915d671707442ec45568f3796f4794"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d0dee1e2-650f-49f9-9c11-05711913eff4/639c43205bd858f8ef297d8cda6e9b42/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-x64.zip",
+            "hash": "eca3ecb2d6bc2af36a514adb3cf7031c0183a0358d2b4b0092716513faad848d118b619e7f710b90aa0854ffb3b324fe73d4d19f451422a694e8bd4fa95ca480"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2f677755-3ed1-4545-9a39-5bd3207c0e48/c8f1212b509b4e83944a03bcfa23d15d/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-x86.exe",
+            "hash": "356b63ad570bf07f08bcc686badcfdecd5a509b04746ee72e359d5fb76ab697937b59986aedc15636fda17702a1cc22e4829a9c8ca7253ccc4754a7c1ac5a5be"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a3cfd250-c211-481d-9871-df7b9dfa769a/d09ce5d0295d467f368d8b6b0e2474a5/aspnetcore-runtime-5.0.0-preview.4.20257.10-win-x86.zip",
+            "hash": "ea126d6cb4147e70fb5aeb0c6e52cee6e7ca78eef48975e1fdbc0112557235e0ae16845d51981a4ad8c88443c9d773966d5818d9ae9c22ffc0cafc9d5545d70c"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/55d3864f-c0d9-4a7e-91c4-1e5cba1735c1/4a5ec8eb28c680c8faf22fe25fb77e06/dotnet-hosting-5.0.0-preview.4.20257.10-win.exe",
+            "hash": "9241e9020cf06bc70b44677a6c562676649833edf4edc02e359d0229fa8e28f06ad9ee3294434815b385ede7f7846c4d0abf0d52ba1d80c139ea7ea0555b5b27"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.4.20251.1",
+        "version-display": "5.0.0-preview.4",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ebbde6b8-a9a7-4cf2-ae76-b2c787948382/7a32a40e86e714ac3cab6c777b6b6bfa/windowsdesktop-runtime-5.0.0-preview.4.20251.1-win-x64.exe",
+            "hash": "f720f676df221e74280899e9c58774b97797d91b9dd2bffc9056ce4e8fb14b57026730d350dec03deb4c3755417046aba37800c2943b3a2ac05dd3a3b28510cd"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/62345c12-033d-4103-ae89-df63514bbee8/b2a4bd7488c12b028fab7e1afadd8ae6/windowsdesktop-runtime-5.0.0-preview.4.20251.1-win-x86.exe",
+            "hash": "cecef9c570348f31fe66206726b4db444fd71e24f21c65eca749f483bbe8d8c8cb5b2f701306b1db0f6b477821fb3ab3dc93bee3a582ceb2d3d80e561e3f6a42"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.4.20251.6",
+        "files": []
+      }
+    },
+    {
+      "release-date": "2020-04-23",
+      "release-version": "5.0.0-preview.3",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.3.md",
+      "runtime": {
+        "version": "5.0.0-preview.3.20214.6",
+        "version-display": "5.0.0-preview.3",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ca8f37c7-b5b2-450b-9469-b2941861df64/c722ff6e03c6c8f276faf391c7a8bae4/dotnet-runtime-5.0.0-preview.3.20214.6-linux-arm.tar.gz",
+            "hash": "ebcb583f3900dad27555461a0fe2a871d047004d6feba1026d540d3887b3d9f116533d1f3247d90fa943a9d819e6bc78f084a248574ec33e6d57e2079b18b397"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/56f1893f-d059-4825-ad3f-488859fb86d7/022976b07c9b8bfc9e650c95fc3b91be/dotnet-runtime-5.0.0-preview.3.20214.6-linux-arm64.tar.gz",
+            "hash": "392a9550b50cd01b3a33ff67022dffc6827320a1036a923c513ff87a9a4166c85c4a93fbede1608db43cf3083916268aaf4e782842b7618b99d429ca0762862e"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/858f5b65-8b2c-4ab1-9769-7fec5b38c8a1/44a1c0f6131e44f21425076ac295a41b/dotnet-runtime-5.0.0-preview.3.20214.6-linux-musl-arm64.tar.gz",
+            "hash": "91f27c9d67ed88b54f0fe5869222fedd081ed89c227d2fadeebe48228f501b5bf36b98b84b9926eaad6d8a50bd44958e1fc30d0cce3ffb7d3deef6cf7a57e677"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d5f23cce-759b-44c7-a456-a668d855b506/3dd2f633b763236a6bcb7d4bf63f1ec0/dotnet-runtime-5.0.0-preview.3.20214.6-linux-musl-x64.tar.gz",
+            "hash": "bd6ff3556e4096842a582511beb216a91b2576c6b6b12ab668e581d610611ec682bf1c00181a330a0117a068883f043b51d54e8f3fe00a0f1bef49df74ac84d3"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/038fae85-6953-4518-adc6-55038ccf1c33/ccf2b3e7ba7ebe4da8b35c91eede7d6a/dotnet-runtime-5.0.0-preview.3.20214.6-linux-x64.tar.gz",
+            "hash": "459a5aab9dea6d27e15a55f8fdc4e44e6ed05b20c6d1bd9aba4fbc3b9176ffe79d9ae57b7757401e7c4ed0a11e483c6729b8a25f5af8dd6346dbb0fd025d0f2a"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/de092180-43f4-4f89-b72c-a149aa86caf4/d603d2b043ae80556f1239946140471a/dotnet-runtime-5.0.0-preview.3.20214.6-osx-x64.pkg",
+            "hash": "5b8bddfb1406974c5ad328f9689b2a692edefb821d743aa3dd5148ee6a53b93f21aae3d6f781a7a593f9ec3db86c746f72dfe5e48d7fb3299bf0cc782bd42a15"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/933ae6ba-87e0-4d25-86b8-51ae5a7c709e/7849e0ef58f691fce783ed5e00001833/dotnet-runtime-5.0.0-preview.3.20214.6-osx-x64.tar.gz",
+            "hash": "78a6fa0b9bae717c945e58ae04f30a64d015031f9a474e2dbf23e54625f615d55adf377d334b7fb9f78caaa6cab9a6722d78b66e44faf73878185c3e73864c7b"
+          },
+          {
+            "name": "dotnet-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a4deeca3-1c0c-40c5-8225-163f7ae7e5e5/a18293ed8f7329f99ffca364a9a86107/dotnet-runtime-5.0.0-preview.3.20214.6-win-arm.zip",
+            "hash": "fecd2c1bca639d608c435372f57c135fe5dccf8975a21657c5f8e8a54202c81d12a9206076626cb2fad348ac720bf6161571be22003ec5b9314c7735377e1186"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6a69b58d-7aa2-4b11-b679-762b0cc48427/cf23f3f6a78c36936a486d8d35a3e105/dotnet-runtime-5.0.0-preview.3.20214.6-win-arm64.zip",
+            "hash": "3e50ff8d24154e4140003fbd255f4f746995590bb8b19939025d795a5927e9ce5c9dce11ed51a94f2cb97faaf7724ae11876294c5273087211e3b2952075199d"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/138d840f-5583-4f3d-bd79-05f0ff719cc9/5cfa84f529bf0227427beda07c74d7f7/dotnet-runtime-5.0.0-preview.3.20214.6-win-x64.exe",
+            "hash": "7f9fd0452ef178f6df58e5de619dad7effbfd1985acc4fc6dd718bb26c228dd1df999af2482d80a925fd84e8f22f6f74a38f0d1c801c8417255abd766438d3c8"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bbd5a03c-0a4e-4530-947f-eb4f44eb30f4/34f0574dbe0525a1073e4b7c83c340bb/dotnet-runtime-5.0.0-preview.3.20214.6-win-x64.zip",
+            "hash": "d7660d441063e6eb2a289e9953d9102742efc88d1de73ede25cce0df687b02b9db2b89e61423c5fa90902b2d001e1e81b3ebabaad69815049a2641ba7b36b6dd"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/020c789e-510a-4c61-8614-18f48272cc89/097461f8baa43cc90d1507460cb75ed0/dotnet-runtime-5.0.0-preview.3.20214.6-win-x86.exe",
+            "hash": "72d90cb5a1317e1a9f939f5341fc396368a99c528074d689cdcb6082a60323663ce59f4840f47c94641ce8184195135ca81f2ee6bcad83b34c601fc3b101f1a9"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8d0c54d3-f87b-42f8-904e-ac7a093f3a00/677c2cc203a451eb31cf8a461440c428/dotnet-runtime-5.0.0-preview.3.20214.6-win-x86.zip",
+            "hash": "fdc8c090bf98f481e28d34f0ee0b61400e65f3ec1c1b56fb5d7105e0d500ead7e6afbd34cc0da7682ffcba2c9c5bf2137c9b212543a4688a28de593878924aaa"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.3.20216.6",
+        "version-display": "5.0.100-preview.3",
+        "runtime-version": "5.0.0-preview.3.20214.6",
+        "vs-version": "",
+        "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+        "csharp-version": "8.0",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/58276f20-1ff1-49e7-afbd-fcc6a20acf56/18aacff58da12a91e691036be7ef8063/dotnet-sdk-5.0.100-preview.3.20216.6-linux-arm.tar.gz",
+            "hash": "608c204bced8e6c6d315c0e1f418b7c7b9bc794a2c2eb70e1bd55f0ffec5782a1006175f1a50f23e2cd2d004fb22a5bfea61dd7d0f573c2352c71e322163b02b"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/67d8e63e-753d-4900-997f-b332bb63b025/303b7ac855985d077056ef4552f4a4e9/dotnet-sdk-5.0.100-preview.3.20216.6-linux-arm64.tar.gz",
+            "hash": "595ed5608ef0c7ba1cae7298ea540b9c165f135afc7126b46e3263de3753f8da6edd6459b5c4a8ec5edb5b00964c5228a2d070cb9b037106260d5b4a9bf8962b"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a9d2501d-4089-4255-9d5c-e94e1ec6532c/9abb1d2998427fa23701649a7b1b1513/dotnet-sdk-5.0.100-preview.3.20216.6-linux-musl-x64.tar.gz",
+            "hash": "4466be190e90ffd85b4dd0a2abc5cacad188ea8f29d7019a2915f98b281a06840a1636f464e6a4a4f871399ca7e1fe00f937cdaa1dd11a27753b606c76c28bdc"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7ceba34e-5d50-4b23-b326-0a7d02b4decd/62dd73db9be67127a5645ef0efb0bba4/dotnet-sdk-5.0.100-preview.3.20216.6-linux-x64.tar.gz",
+            "hash": "0ee4a4f3eb082dee321ae4fbd61c3d425225dfe3c0947108bbb2df9f3644e0eeebd0fd4db237cf6b06aa56b0a7ca10eb45c481558ffe4e7422e7e7c4f7369804"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3fa9a36e-907c-4d7a-a98a-e50ad0aa4990/ff63364b94e98687d5933c1b9a50a5d0/dotnet-sdk-5.0.100-preview.3.20216.6-osx-x64.pkg",
+            "hash": "78cc44d2af20e7278d5cd5dd11ca8cc957c225023555f060e2e54d11a3b5add2c2d9c8012552d45aa27eafcc20c10579fb15180e7c906b1382c583abb4fe2316"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4b8fe806-7a65-43e8-889d-215999715bbf/22005a4af0c34e257e652dbe39d3661f/dotnet-sdk-5.0.100-preview.3.20216.6-osx-x64.tar.gz",
+            "hash": "341462f073f3642291a65fea8e7af98655aababb7b5c6e0574b7d0e16ab38f20f4bf84cbac24120f1bc22df12e426c4dec5d5353a3f69f748d4f68215dcb081b"
+          },
+          {
+            "name": "dotnet-sdk-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/585c7f99-1d47-4422-8e74-4beb2809e9c7/531e64c80bfa9937ad5a3e19f78847c0/dotnet-sdk-5.0.100-preview.3.20216.6-win-arm.zip",
+            "hash": "4a205f6f48e2898151661455ebee7dcf3e70ea85421503e4c5bc10809c98af136515c66759e3a0aa26c015fbacc9f9f051d323200e627f54f6e380d9916c55d1"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/848d5ef2-81ca-43ff-81f7-6b6e9e38c186/e3462954d7cd7ac54e40d45b9d07d9c9/dotnet-sdk-5.0.100-preview.3.20216.6-win-x64.exe",
+            "hash": "ab652850ca80fea4491888c114802fdfd37715805fd297b842dd087828119b17c332adc388c2321de5cb9dd5f091f2fa22ac2c46e76bc33ee0dd377c8a5f1415"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5d93d786-1442-4479-868d-5d3b4175b160/b7629a4cd3f95cb0a2d7b202537fdc2d/dotnet-sdk-5.0.100-preview.3.20216.6-win-x64.zip",
+            "hash": "f9268b2007e5f7df5048b3e9e3f1edd5dc63d5aa3431b497285cf5c5c90dca93dcc247b3b6eef5966671431d0f11419584ff25c4a8c0b9faf210df61bf8553f6"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ed38b46c-2373-4e81-aab9-18a7f727685e/018f9be726039087d1654b055c2eb641/dotnet-sdk-5.0.100-preview.3.20216.6-win-x86.exe",
+            "hash": "7f52de73342dae67ac09d362b87087d2dc6de59e6470ab67065ee95da9d97dc8863cee62fa1d425814aa9ea622e16e02a49cb962295fdfa917e26b6846ea4f47"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/be4d30a2-9cb9-43d0-b5a7-b6ba63d77bbe/f77ee9cd22084283dd23762b23996db8/dotnet-sdk-5.0.100-preview.3.20216.6-win-x86.zip",
+            "hash": "bf89fb973a9b37f7ffb6c37ed9ff513bb13f786f7225ab9eaac3ae16a43f90b249881926e1bf020fcdd7db94027586811b21002e374be3fed613424d7e06f328"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.3.20216.6",
+          "version-display": "5.0.100-preview.3",
+          "runtime-version": "5.0.0-preview.3.20214.6",
+          "vs-version": "",
+          "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+          "csharp-version": "8.0",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/58276f20-1ff1-49e7-afbd-fcc6a20acf56/18aacff58da12a91e691036be7ef8063/dotnet-sdk-5.0.100-preview.3.20216.6-linux-arm.tar.gz",
+              "hash": "608c204bced8e6c6d315c0e1f418b7c7b9bc794a2c2eb70e1bd55f0ffec5782a1006175f1a50f23e2cd2d004fb22a5bfea61dd7d0f573c2352c71e322163b02b"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/67d8e63e-753d-4900-997f-b332bb63b025/303b7ac855985d077056ef4552f4a4e9/dotnet-sdk-5.0.100-preview.3.20216.6-linux-arm64.tar.gz",
+              "hash": "595ed5608ef0c7ba1cae7298ea540b9c165f135afc7126b46e3263de3753f8da6edd6459b5c4a8ec5edb5b00964c5228a2d070cb9b037106260d5b4a9bf8962b"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a9d2501d-4089-4255-9d5c-e94e1ec6532c/9abb1d2998427fa23701649a7b1b1513/dotnet-sdk-5.0.100-preview.3.20216.6-linux-musl-x64.tar.gz",
+              "hash": "4466be190e90ffd85b4dd0a2abc5cacad188ea8f29d7019a2915f98b281a06840a1636f464e6a4a4f871399ca7e1fe00f937cdaa1dd11a27753b606c76c28bdc"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7ceba34e-5d50-4b23-b326-0a7d02b4decd/62dd73db9be67127a5645ef0efb0bba4/dotnet-sdk-5.0.100-preview.3.20216.6-linux-x64.tar.gz",
+              "hash": "0ee4a4f3eb082dee321ae4fbd61c3d425225dfe3c0947108bbb2df9f3644e0eeebd0fd4db237cf6b06aa56b0a7ca10eb45c481558ffe4e7422e7e7c4f7369804"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/3fa9a36e-907c-4d7a-a98a-e50ad0aa4990/ff63364b94e98687d5933c1b9a50a5d0/dotnet-sdk-5.0.100-preview.3.20216.6-osx-x64.pkg",
+              "hash": "78cc44d2af20e7278d5cd5dd11ca8cc957c225023555f060e2e54d11a3b5add2c2d9c8012552d45aa27eafcc20c10579fb15180e7c906b1382c583abb4fe2316"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/4b8fe806-7a65-43e8-889d-215999715bbf/22005a4af0c34e257e652dbe39d3661f/dotnet-sdk-5.0.100-preview.3.20216.6-osx-x64.tar.gz",
+              "hash": "341462f073f3642291a65fea8e7af98655aababb7b5c6e0574b7d0e16ab38f20f4bf84cbac24120f1bc22df12e426c4dec5d5353a3f69f748d4f68215dcb081b"
+            },
+            {
+              "name": "dotnet-sdk-win-arm.zip",
+              "rid": "win-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/585c7f99-1d47-4422-8e74-4beb2809e9c7/531e64c80bfa9937ad5a3e19f78847c0/dotnet-sdk-5.0.100-preview.3.20216.6-win-arm.zip",
+              "hash": "4a205f6f48e2898151661455ebee7dcf3e70ea85421503e4c5bc10809c98af136515c66759e3a0aa26c015fbacc9f9f051d323200e627f54f6e380d9916c55d1"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/848d5ef2-81ca-43ff-81f7-6b6e9e38c186/e3462954d7cd7ac54e40d45b9d07d9c9/dotnet-sdk-5.0.100-preview.3.20216.6-win-x64.exe",
+              "hash": "ab652850ca80fea4491888c114802fdfd37715805fd297b842dd087828119b17c332adc388c2321de5cb9dd5f091f2fa22ac2c46e76bc33ee0dd377c8a5f1415"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/5d93d786-1442-4479-868d-5d3b4175b160/b7629a4cd3f95cb0a2d7b202537fdc2d/dotnet-sdk-5.0.100-preview.3.20216.6-win-x64.zip",
+              "hash": "f9268b2007e5f7df5048b3e9e3f1edd5dc63d5aa3431b497285cf5c5c90dca93dcc247b3b6eef5966671431d0f11419584ff25c4a8c0b9faf210df61bf8553f6"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ed38b46c-2373-4e81-aab9-18a7f727685e/018f9be726039087d1654b055c2eb641/dotnet-sdk-5.0.100-preview.3.20216.6-win-x86.exe",
+              "hash": "7f52de73342dae67ac09d362b87087d2dc6de59e6470ab67065ee95da9d97dc8863cee62fa1d425814aa9ea622e16e02a49cb962295fdfa917e26b6846ea4f47"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/be4d30a2-9cb9-43d0-b5a7-b6ba63d77bbe/f77ee9cd22084283dd23762b23996db8/dotnet-sdk-5.0.100-preview.3.20216.6-win-x86.zip",
+              "hash": "bf89fb973a9b37f7ffb6c37ed9ff513bb13f786f7225ab9eaac3ae16a43f90b249881926e1bf020fcdd7db94027586811b21002e374be3fed613424d7e06f328"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.3.20215.14",
+        "version-display": "5.0.0-preview.3",
+        "version-aspnetcoremodule": [
+          "15.0.20077.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ffbb2903-bd07-47e0-aa7d-9264c942cc38/9937a6b2cf97e16f878f4f3feb874479/aspnetcore-runtime-5.0.0-preview.3.20215.14-linux-arm.tar.gz",
+            "hash": "d81b656b357b16e9a4bfbf095c0641f56fe5276a0ce587ca8b31c4792f8b782aafc57d4cf97837901ff1dca8f6eaad462ba137967a6c2f36d90f277fbf4aa8c2"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0d7fdf8a-9163-4044-8626-a0e83bf2a4d9/a02834ce1a5f88021e0c764ccef582c1/aspnetcore-runtime-5.0.0-preview.3.20215.14-linux-arm64.tar.gz",
+            "hash": "01e30fc2ee685e1f2bfcff9abd862d353796a25757cdc60598060dc84cbce8b057ba070626f0e96385c0a34d00f9e41861cfd12a782a9ea2a253c32c7bca9d5e"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f2bbffd9-83c3-4ad0-aabd-0f6a54b720d4/a6b5f14b44aaf5abb6dea3ad9e88b7d5/aspnetcore-runtime-5.0.0-preview.3.20215.14-linux-musl-arm64.tar.gz",
+            "hash": "35efa93b5dec1184510bcb1ab454770f577c163967933257bfce56be5596633f6873671350819044b737e4fd6f6ff19d5904164f496ad633068a39efe77070d3"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/20473703-695e-45c5-b5f3-7d307d3e1aa5/e09ef05ba456f3968d5cff24ceff3358/aspnetcore-runtime-5.0.0-preview.3.20215.14-linux-musl-x64.tar.gz",
+            "hash": "ff46d723137d1b60717027035ee597ae993bff17a43f88e00fb44e8f271c7267f1e639079cfe03a717b9e42baef84cacfb464b25791165f94573f504d8ce7b89"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/76655cff-bf24-4445-a4af-9dbca1f00e86/4366686af0585397f290d27a042a1449/aspnetcore-runtime-5.0.0-preview.3.20215.14-linux-x64.tar.gz",
+            "hash": "1839e36b03c7c1da497f8ee6f2b484591513742a8aae897281a4be17f22d1d7ca5e9d877e4b90ab6100136564efc41c47287ef9fa071441f7d2e203816e0f1b7"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dcf33838-366b-45c9-9db5-8ae6d59c1433/afa19a627e073b7f7e26c740ba56f352/aspnetcore-runtime-5.0.0-preview.3.20215.14-osx-x64.tar.gz",
+            "hash": "d269cb1627a175e6d33486c4f8df8873b9af5a67d8f6794fba7b8bc320338bdd2e29872120e0a86ed5f5de081dc87a025d46c0c0b6393b92ee0ede127b061d5a"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/64048ca3-4b02-422a-a8aa-e088b7dd521c/b7007855d06ccba94111e8bccdd8e968/aspnetcore-runtime-5.0.0-preview.3.20215.14-win-arm.zip",
+            "hash": "435bb0d625e8f64f5a6618431a47b29143970f6aee878f9ab7e832f343a15baa4e29e1bd5a5246d3604ac63e7b44404bbee76d5993264435ef20b32ddcf33040"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/389a714a-d6e9-4e2d-a78c-04e45ed12e17/7cfbdf77fc2a0dc1dbdf2bd0985e5199/aspnetcore-runtime-5.0.0-preview.3.20215.14-win-x64.exe",
+            "hash": "7f99511598257374de2f05c9eb2fc2ebfccee6bf1638408106f0ec15b6e8741ed614948f54ed63178d9c4a96439d5be30605a32effc7da1112fd56216efbaf65"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7683a95e-1336-4f8b-a3a0-21f6dab44138/9248f166869d1906a6e37a80e81b7b16/aspnetcore-runtime-5.0.0-preview.3.20215.14-win-x64.zip",
+            "hash": "d26caa3490f4a62921733a28a464f049fa812d94b19332c5c4106ac86b044e28a625ce5d966cdcb5ba3a4929845bb2cbf847f95714e4efa253dbc92d16d55128"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f309e08f-d2f6-46a4-92bf-09cc20475884/06fd23949d41b46fcb76e3ee60c3c4e2/aspnetcore-runtime-5.0.0-preview.3.20215.14-win-x86.exe",
+            "hash": "cfee7eb241919c56db6b099c768b2835274f4a42a866c79f5dc572c228fa0393e6b8bd0cfbe50f37fcc99bef6f65dec49fe49165ce5a1b4f5fc2c90b10fbba33"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cf56d473-8868-41c2-b86f-14c7b0ae56ef/4c54b358bdb5f86ca77df4a3a79d0f59/aspnetcore-runtime-5.0.0-preview.3.20215.14-win-x86.zip",
+            "hash": "1e954e62fe4c64805a5b9b5c3ff1eaf2b5f707b93394da0fcee7f40cdf8425a9457fe8e00336d3eadd060faec5816906fe5df1d333634462659f07a546724af4"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f84dffc7-f825-47d4-aad5-f3af1444ecc1/935d1397344d5179cf210787d6435c44/dotnet-hosting-5.0.0-preview.3.20215.14-win.exe",
+            "hash": "460832918ab1ecb158f5c756e7c6eda468d0b997ec0467e946c6b64977485ab0470f54297164c6f182348eaac77b3b371382024f06f94bd3b26fd49cea5cd139"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.3.20214.2",
+        "version-display": "5.0.0-preview.3",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3d928a84-9d22-44e2-b273-c0ba24d95018/7f168212264a949c0f3799cf450f0a14/windowsdesktop-runtime-5.0.0-preview.3.20214.2-win-x64.exe",
+            "hash": "131ceeae5b4b00baa572865c7402dfd5432a865bf493b46db61f196679d14847b64afee73cffeb3a7d19db5d3886921987d6b5080270ec4ff08dc64d29df9a15"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/39d51d83-8b69-4b8b-8fd2-8ea451fc743e/dd667944896af153df70036bd9323fef/windowsdesktop-runtime-5.0.0-preview.3.20214.2-win-x86.exe",
+            "hash": "6fda214d9d80feec7867fa0d9285400fbc9fde0fc263ab2d00924a4f8386824adfb7be8dd7f6ef17a902a33cb8f68dae1a4486a089d101270eaa09950919653d"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.3.20214.6",
+        "files": []
+      }
+    },
+    {
+      "release-date": "2020-04-02",
+      "release-version": "5.0.0-preview.2",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.2.md",
+      "runtime": {
+        "version": "5.0.0-preview.2.20160.6",
+        "version-display": "5.0.0-preview.2",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-apphost-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/44853b8b-53b4-4f85-affc-b98f62167358/0b690b9675696ae8a2f2d4ea86c5de3a/dotnet-apphost-pack-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "979220a6468bcdae67a0886d1ae8b4492b30d2e24ae3795087214c33bee4c368a58febbda7194fa9fed471f8d74e8b3107062ecedd38138ecf159f9ed31ad17a"
+          },
+          {
+            "name": "dotnet-apphost-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/364e6a3a-486a-48ae-9f7e-b6ed36c72e55/9432eb01047c21d2999357dfcbdec0a2/dotnet-apphost-pack-5.0.0-preview.2.20160.6-x64.rpm",
+            "hash": "14dd10bfb83f20b04306188f86bd75c27c2b39d6f4bf2fe49b2343cfc265c3e71a71757ca2765f79895791d4026cc480f92de938dc127a9fd3224f03060955e4"
+          },
+          {
+            "name": "dotnet-host-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7ae67930-daf1-4eb7-9a90-0b119c8c0be4/b1b0776885d0895384bb82e1c9b2205c/dotnet-host-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "8a470a4e0336d563edf447373c40983360f513e5f08b44747c67c851acfb162d5d6c9c427edc67e5c5db3a44f367fc9b64294a8cf115bc9a085b8dd1e6eaf1ad"
+          },
+          {
+            "name": "dotnet-host-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4b5422a7-1b37-45b1-985d-357599a7e838/ddfe668bd25054a0ab0d37940d70b80a/dotnet-host-5.0.0-preview.2.20160.6-x64.rpm",
+            "hash": "f6aa1db3b7b2ee706aacaef43cc0c4e6872243be7de3afd9bad7774929004c66693dcbcb1b2ccda39f371c20fcc338a2b458a242fe2df195ee1161ce7addc7b1"
+          },
+          {
+            "name": "dotnet-hostfxr-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/eeeea1b9-55f4-41de-b1d9-eaff6f4548d1/84d6146b817601fbd57e982d02c9fad5/dotnet-hostfxr-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "bf04bdd0fa17a3b197da2360d36cad723898fbacca53fc614b0154a9f60c37a1e314daea1291757d187a4a54dc424fcb223572585d516e0e10d4c337d6f6e9c0"
+          },
+          {
+            "name": "dotnet-hostfxr-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0bc83586-0c67-4de4-9234-b3f25478da34/307c9c79dfac51dfc1e775b00407e59a/dotnet-hostfxr-5.0.0-preview.2.20160.6-x64.rpm",
+            "hash": "edcddb1da7aaf6c2f68c0a9a0e3a606080db9c9a51150782050ad1153b049cf4f0aa278041cb8c3c40a3e8c12ccfe7a5aba8365ff1e0f942ea1214ef3128b9e9"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6f0267d8-77f6-4677-8c7d-757b100d3b54/f57788735881fd95b90ca020653c6bb6/dotnet-runtime-5.0.0-preview.2.20160.6-linux-arm.tar.gz",
+            "hash": "4c8256f03d3d1185801cb8d58cb456eece964e9d0e87c57ac1ba09316ae0808929f63cb73dc029eb2519ffda7f6204c2c40c154621c2dd02d32164b2860f8080"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7c224d38-8f76-4ae7-808b-c9617fc46d27/26bee5ca707c17eb8afec45acd4785fe/dotnet-runtime-5.0.0-preview.2.20160.6-linux-arm64.tar.gz",
+            "hash": "f06dc6c0166b154d87eaa581691bb8cdbace4c38eed25faf23f21fcad29688d45cc9b6905bf3de9891bcd2ed1ac85e571c799174d480595e6821e7d9ed0fe250"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bf5994eb-1eda-49b1-8912-2bd7386b4f56/380f690e7904a32e4b8ce89736458d8d/dotnet-runtime-5.0.0-preview.2.20160.6-linux-musl-arm64.tar.gz",
+            "hash": "ed87ce53b2b22c8e4b407657546182217905e39d7ee43cf9baa31d9598303e1bebddba1f57f77298c6131e413334b58c62254a0c7c7ce27f622367430b1f69b9"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/85a0c2f5-f0b7-445a-84c1-bfcea1c94d9c/7c0808ed36558df5487b6196967344e8/dotnet-runtime-5.0.0-preview.2.20160.6-linux-musl-x64.tar.gz",
+            "hash": "f8dcf9f498feffbca4b0649086cffd298cd98189b2950c32dd52b07179b7f33e1acfe14ae59a266502a3518089ca55f224e007628d16194f94be7dc419c1b2b4"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f98746fd-2d36-4181-9978-e373a321e247/7cf737bead76e4b09b309fa7122cd134/dotnet-runtime-5.0.0-preview.2.20160.6-linux-x64.tar.gz",
+            "hash": "4454d8cb79f9a14ee9f0aa5c6b91a2d26de8e3748add0396f65f59a78b5c96e8ff2fe5bc0156915a7eebcdcb71bfc3b60d7a5cd66d28b96cc043357c9b07f106"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e486a3b0-7689-4429-8c6b-8388df41c14c/3ccd26660a01b4af7b24d77d0f4128b1/dotnet-runtime-5.0.0-preview.2.20160.6-osx-x64.pkg",
+            "hash": "acb3a49ca2f20b320f427951886971ee810cb9e66a1ab525c826dba3fa4defc55ea59547b51855038c9b1f440a856fb99b33c157b64318eed50606fd86d4c0b7"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/da039879-4fea-4e4b-a779-2f3c271c0a09/777fc8882d54407f82bf3d0b801d853f/dotnet-runtime-5.0.0-preview.2.20160.6-osx-x64.tar.gz",
+            "hash": "970d045fc325b1f74d1f092280b320a0c800f8632bdf16cc1f7e29a3145135dc22a2a05709bae2ab3c2ed7e7ecaa18253628fe1bc2b25665fe20fb3c9015f3c0"
+          },
+          {
+            "name": "dotnet-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/90f0831b-4699-4314-866a-977ac8a64e59/794fd7e14bc6404257a04d225d0ade79/dotnet-runtime-5.0.0-preview.2.20160.6-win-arm.zip",
+            "hash": "7dcd5b42b2da129c661c0e950ed27e33a1a6080b163c1e5b49a712547811df0fa2f95d8ff821ebf1efb6a2e1acc09f805fa35db61ddee582210059e5c72c7551"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a26cea08-bc46-4d97-a8a3-0aebb3f135f4/2aece2998f2eb12292bb410912c8cca3/dotnet-runtime-5.0.0-preview.2.20160.6-win-arm64.zip",
+            "hash": "9461a367ea1c550552be08fb09f1eb352793e029bb13073761860ae738b9561d1ed51c2a4892226347a51cc189e6ddd376e09fd27eca973cc5bf8c3a15cd73f7"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ca6db74a-5f97-48e5-9abf-14414e825215/d6f04952fd2bb61d7af4a4fa6d8d0759/dotnet-runtime-5.0.0-preview.2.20160.6-win-x64.exe",
+            "hash": "6d0b38f55014111755982bf71f9cc2d071018e1230279abc3ac2ecebc73ba8d4f7182b97cb35b829cd533fb23d044ab53bc05b04a60e6e480d8e54e826374b3b"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6d7798d7-2df3-469e-a6ff-f3e99c35838f/9aa0b9ada7f2c43524e67c0ead227693/dotnet-runtime-5.0.0-preview.2.20160.6-win-x64.zip",
+            "hash": "db4f24db1e20dbdd0242b8c5730a98612954e28ebc18db655147d80cf4865ecad7ad6a72952750638b4205870ec86eee5a1073fd2f13b98811fc4e8b420f5082"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a82ac5a9-cd97-4a27-a02e-5fcf98be31f2/014f4378b742465f7772998b25cf53bc/dotnet-runtime-5.0.0-preview.2.20160.6-win-x86.exe",
+            "hash": "24373413835460e0c972318b11692b4cbe8e6cb997d108f6ec45d9b0b8af16328ef99e08cbc2b42337c48aee1caeb7461eee06c0c0445ab575b65f89cc2d2d84"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/236c8426-af8a-40b1-b1f7-449971674dd9/db79bdd104621b1e6fde4e334cbb534a/dotnet-runtime-5.0.0-preview.2.20160.6-win-x86.zip",
+            "hash": "ecb6323acbb0dbe340fd11e1a19b339595c26063b75be3a7cbe2cb5ad8dc15e62526d827e7f9e64a3333a02a6c01f49813bb16950744fe589b4e513a9996d5f0"
+          },
+          {
+            "name": "dotnet-runtime-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7636e659-2bdd-4a99-82d8-852a76623d7c/c9bd97db81e20d4a6323acaaf8315695/dotnet-runtime-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "a927d064084e0081d8603e8d7d934fbd19768e305f0f9f0c589c2b9902001277ee523df4e928a6dca26304f461a965d5fcd9c75456b267a95053473f92af15e2"
+          },
+          {
+            "name": "dotnet-runtime-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e9d54bc7-511c-45e9-b1cd-be7000ebae4d/e9428374b9b96b59cb534ecb7972a08d/dotnet-runtime-5.0.0-preview.2.20160.6-x64.rpm",
+            "hash": "7cec60a908e3dc8af3805a915894ee39c0f2c18fadfd039b6dfa57165c9ba713ba972710396d36c69a4655cd14b9aea148bf60d9c698057f8e50e750a21dbc74"
+          },
+          {
+            "name": "dotnet-runtime-deps-centos.7-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/473bf5ec-2cb8-41fe-bc20-7ed3aff24e97/da775dc162abd69f4f56ec3bd5a4eab3/dotnet-runtime-deps-5.0.0-preview.2.20160.6-centos.7-x64.rpm",
+            "hash": "f312459b881887b189e6ccc839bae4a29ec2d5f4520f789fae27e51ff2112aa32afb4fe7160c3526b825ac2a07ce691f810655d17b2f85960b865c2b6e54df7c"
+          },
+          {
+            "name": "dotnet-runtime-deps-fedora.27-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/331480bd-392e-441f-a2fd-7cc44eb91963/4bd8a7444c84cdb330a57e112b378840/dotnet-runtime-deps-5.0.0-preview.2.20160.6-fedora.27-x64.rpm",
+            "hash": "4d29ded139c046d7733a530e1a8e995dee65c0b5b1b8dea4aea5e42763ae0a4f5979a96920856ac1e23b2ee008ab216a54f78d2f29b860572d7deca8221ae4fd"
+          },
+          {
+            "name": "dotnet-runtime-deps-opensuse.42-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/016e84d1-12cd-4936-a395-f59175f315c1/3be52ec84087310f818062c9eddfb8cd/dotnet-runtime-deps-5.0.0-preview.2.20160.6-opensuse.42-x64.rpm",
+            "hash": "c2437ceb83413aebf1505e4018a3077da701159134a2da9b23a77163217178f2e1c8b723ccb416e1ad0bbf81719240331211c031f8ef46e49003b71ddf3be112"
+          },
+          {
+            "name": "dotnet-runtime-deps-oraclelinux.7-x64.rpm",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a90a5ac1-a810-4949-9a80-375edb781a20/7446a37848fbfbd71a7a5712fa1b00e2/dotnet-runtime-deps-5.0.0-preview.2.20160.6-oraclelinux.7-x64.rpm",
+            "hash": "64a14417e0402796f6242bcab6306b07da015dd9612280cce068e9e78f40035d4a9ec3a74d06cb03a91e476f6c60a55a5baa9ac3a720320b55f9f92723caaf51"
+          },
+          {
+            "name": "dotnet-runtime-deps-rhel.7-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/8a3a4c2a-2d1c-452c-98e2-f7d311e5da6c/be182c8bab34374882fc9e8983401ff0/dotnet-runtime-deps-5.0.0-preview.2.20160.6-rhel.7-x64.rpm",
+            "hash": "afd2c1b50828c644bc289faf982106a3c753fb46281256f8a4b8d3ef26475838ad3db9870721925117420ef64728fc843e37b8269fa4acb6d133b2eb959f6250"
+          },
+          {
+            "name": "dotnet-runtime-deps-sles.12-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/44284ae1-547f-4b70-aae5-ed4845c062dc/2dc547727ead01a436355f5ef62fa0fb/dotnet-runtime-deps-5.0.0-preview.2.20160.6-sles.12-x64.rpm",
+            "hash": "8e9109572fe21308f202d8cd338773dd52bef7c8c802e2b2c7fa6a6a9265757045a3f328e58918e8208c44a7b412fb67e77896766dc371f8dc1527355333bfb0"
+          },
+          {
+            "name": "dotnet-runtime-deps-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f2690fbb-0339-451a-b9d9-2524e5e0f5ca/96b2876bce44409090b0f9f6e857e50e/dotnet-runtime-deps-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "1a59f6efe4de5812c421356118215fd82b9d8e75df3d2ae92dcfaf6a824366c25fcd689db0e2fa1d3a2570e77649e3e750a04842a74fc8aead4805f9ee09352b"
+          },
+          {
+            "name": "dotnet-targeting-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/76d622f8-a4ac-48f7-91ee-067a57b3f1fa/c806d99c72e3df42e804d42790fbde17/dotnet-targeting-pack-5.0.0-preview.2.20160.6-x64.deb",
+            "hash": "247d7c0da1ce5e82e56965e82cadd03cce22ec32e6a041ec3a261be707718350926389c58b6843a61e08694d8c41c152182593d132ea7632fcd9cb91e4cef267"
+          },
+          {
+            "name": "dotnet-targeting-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/123647ba-a2f7-42b6-b0ab-71ca13eedcdc/821eeda51d3c6f1f10d5131ac75eaa9a/dotnet-targeting-pack-5.0.0-preview.2.20160.6-x64.rpm",
+            "hash": "21de82a79f02465896de9b10f487354931f3e9f207599180fe7bbde28516b5b3c0dae040f0028207c37e45848cd3cbbd6f18a1e32362ae5f301cc675cfe33670"
+          },
+          {
+            "name": "netstandard-targeting-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/52431976-cd2a-4c7a-a8e3-7b5f1d76fdd8/f8c4af99f9c02963a5d152bd65017013/netstandard-targeting-pack-2.1.0-preview.2.20160.6-x64.deb",
+            "hash": "483d0091f151677d5407fdd9fd718a606ba33ed25f895f4b76b45b020e2434b9b4f8a660783b031b022a1d1e6d877c5e8159121915c0e0fd158081afb4d5727f"
+          },
+          {
+            "name": "netstandard-targeting-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/41364085-9a79-4cbf-ad99-ad7fbe075196/4e0965ed7e784897e433af673b85ea69/netstandard-targeting-pack-2.1.0-preview.2.20160.6-x64.rpm",
+            "hash": "25374b1deb14bba20d1b97ab557274aa58278957d271c046a7ba41f84a073aa6b7c5bfac5337f7466f3f0b562748fa512a8c56fd8576870bb6ee32fb4a8dc759"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.2.20176.6",
+        "version-display": "5.0.100-preview.2",
+        "runtime-version": "5.0.0-preview.2.20160.6",
+        "vs-version": "",
+        "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+        "csharp-version": "8.0",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c35cd82b-2b99-4572-a8f3-64718bb62ad1/c7e67beb45f7819545e1a62139ed96a7/dotnet-sdk-5.0.100-preview.2.20176.6-linux-arm.tar.gz",
+            "hash": "0d11dc0dbaa68278021491ee1327a736e353be6891de48e276283f9ea74ccc171250df170f5981737e9826bd49fdaf80d0808dd7c1c939e3defb2cbdc5dd32db"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f87574ee-c128-4e91-b436-68c99d801daf/b296bea9d987a4edaa71df47cd2e7aca/dotnet-sdk-5.0.100-preview.2.20176.6-linux-arm64.tar.gz",
+            "hash": "53cbf213e2e97b909b256d931f061178f26e5647424f144266d4af2e12d6443ef7398207a8f4e6f220c61db9ce49de3dc09d88417288a6a61d9b05e1def6b279"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a759ab8d-26fe-4862-8b02-788f6ec47ede/7c2ca8984e9a0bfef27ab95cf28379a1/dotnet-sdk-5.0.100-preview.2.20176.6-linux-musl-x64.tar.gz",
+            "hash": "83b65c6d95d04213685761cbb36a65c1b4c2a2991deeee421446f8e5956acfd1275243f3bd1ce95726b8564d7d88c6a48aa1f7f728b406a385c41e506fb13d29"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/727a5825-d29a-4f45-beaa-053399f8b5ee/5f15827ceb4851ef87a008f5de0acf6c/dotnet-sdk-5.0.100-preview.2.20176.6-linux-x64.tar.gz",
+            "hash": "fface8ff5facdec10d11f8249b426a71cd5bc17aa4e4b1fbe85f4a462e55bdb648a456973a3257f0a700be1aeb0f9bb41639ceca12c2e67d1571e4544ae62bd7"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3ce4af4f-f5d5-406c-a065-2ecc9bcc5fd2/353affd22a0727b476998312738ac35f/dotnet-sdk-5.0.100-preview.2.20176.6-osx-x64.pkg",
+            "hash": "895f31e3c46081f66a24704a4483cb76abc2ae2c4c790f134650c02be9aee7477a0e0de2329e36c05b6267bb19260e7e32b5b8b7b7a9be36d9d06972d43db7ab"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5046ce80-6398-4173-9717-e2947f2585eb/841aad7475e8c9b78cbc50e3b8d35dae/dotnet-sdk-5.0.100-preview.2.20176.6-osx-x64.tar.gz",
+            "hash": "7359a8ae35265c47a8e893e6b32f13063e4d139ad4a9e89f4e08e01acff2aa92b32d40c19e1b117b5e24e2eda132ea46bfb4a9ad3f409c7b60bc70f9a97a492f"
+          },
+          {
+            "name": "dotnet-sdk-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7d12d31d-a6c7-49d4-b1d3-91f531932553/43331ea36d39b63238d30c19e5a4bec9/dotnet-sdk-5.0.100-preview.2.20176.6-win-arm.zip",
+            "hash": "2fa5d214e4b645f38d071d3e08332d64bd7e9ca41d26aca2b6c66ec1a71d6f2793513725e30108569e87463c0674e9f8b9c1dc9430677afe66b59b8ac2378d8d"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/00296620-d967-4ae4-af29-bef9b0019970/4cdb51006f22059c14913bdfca57f5a1/dotnet-sdk-5.0.100-preview.2.20176.6-win-x64.exe",
+            "hash": "c3f511623b89662a95ce08ba00d0b7f588591eed62fd0c205c4916c8e540fdbfd9dead85da31b50aa085702dc5dbe98f8629f99ff4bcc49a2e115d48b7534d38"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/023b41aa-073b-491e-93ac-7e726fb81bda/b06f72654e32d1bddc941ff932f32c59/dotnet-sdk-5.0.100-preview.2.20176.6-win-x64.zip",
+            "hash": "94ec391e19232abc419e4327bbafe9e1f1b363bdda8c280da97f8cdc9f511747d3add76e0fb9909080c554f5acc61ebf7292d84ec5a81acf22d49760bf36ad72"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2f9d9ebd-07b9-4c88-b4e6-8cff9d5be760/ac3e76c14c15cf0999b3b8d2bb3a904a/dotnet-sdk-5.0.100-preview.2.20176.6-win-x86.exe",
+            "hash": "d9a4241a782913a0e371acf25744e40f16a469e19b80054387c1eef911aceb7d71794910a0e9629d593b0d16371a7d66ea19651701c6ce1d8d1db52f036774d9"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c1a5bd0c-6236-45a9-bda4-fb9e2007e770/0a078520e350f64a92d5f97ee9b89a9f/dotnet-sdk-5.0.100-preview.2.20176.6-win-x86.zip",
+            "hash": "0ea68fa63d537252436cd2721a2b0fbb256549b5f0d093536d5aa1692697fb17e62df36a22fd19daa47f8b20bbe1ee85aafb5a8c47298c45ddafe27e56223fc9"
+          },
+          {
+            "name": "dotnet-sdk-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d10bf368-79f0-4635-a04f-93301569844d/a3991083c98a2cc5ba1700e0048aaa88/dotnet-sdk-5.0.100-preview.2.20176.6-x64.deb",
+            "hash": "d3527bbea25ce0aa6eeab39d997dd8c2fba8a7b0c9b07d8a523205edb4dfaa5bc4c15c018354c4f812a5c26592f3becaca80bbb793d9535ce49a0ae8c2fac832"
+          },
+          {
+            "name": "dotnet-sdk-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ce4434c6-31be-4f7b-9c42-3c43a3e3a9cc/becff13989b2a126637acc2692e223cf/dotnet-sdk-5.0.100-preview.2.20176.6-x64.rpm",
+            "hash": "31f3ede22c545003bc371806eab559bba5c5d5ab1816a5e9516cc80540be77997094db690ba0493e8b3804c6fe474995d2a5ae343db28961b3e60651fada8350"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.2.20176.6",
+          "version-display": "5.0.100-preview.2",
+          "runtime-version": "5.0.0-preview.2.20160.6",
+          "vs-version": "",
+          "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+          "csharp-version": "8.0",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/c35cd82b-2b99-4572-a8f3-64718bb62ad1/c7e67beb45f7819545e1a62139ed96a7/dotnet-sdk-5.0.100-preview.2.20176.6-linux-arm.tar.gz",
+              "hash": "0d11dc0dbaa68278021491ee1327a736e353be6891de48e276283f9ea74ccc171250df170f5981737e9826bd49fdaf80d0808dd7c1c939e3defb2cbdc5dd32db"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f87574ee-c128-4e91-b436-68c99d801daf/b296bea9d987a4edaa71df47cd2e7aca/dotnet-sdk-5.0.100-preview.2.20176.6-linux-arm64.tar.gz",
+              "hash": "53cbf213e2e97b909b256d931f061178f26e5647424f144266d4af2e12d6443ef7398207a8f4e6f220c61db9ce49de3dc09d88417288a6a61d9b05e1def6b279"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/a759ab8d-26fe-4862-8b02-788f6ec47ede/7c2ca8984e9a0bfef27ab95cf28379a1/dotnet-sdk-5.0.100-preview.2.20176.6-linux-musl-x64.tar.gz",
+              "hash": "83b65c6d95d04213685761cbb36a65c1b4c2a2991deeee421446f8e5956acfd1275243f3bd1ce95726b8564d7d88c6a48aa1f7f728b406a385c41e506fb13d29"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/727a5825-d29a-4f45-beaa-053399f8b5ee/5f15827ceb4851ef87a008f5de0acf6c/dotnet-sdk-5.0.100-preview.2.20176.6-linux-x64.tar.gz",
+              "hash": "fface8ff5facdec10d11f8249b426a71cd5bc17aa4e4b1fbe85f4a462e55bdb648a456973a3257f0a700be1aeb0f9bb41639ceca12c2e67d1571e4544ae62bd7"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/3ce4af4f-f5d5-406c-a065-2ecc9bcc5fd2/353affd22a0727b476998312738ac35f/dotnet-sdk-5.0.100-preview.2.20176.6-osx-x64.pkg",
+              "hash": "895f31e3c46081f66a24704a4483cb76abc2ae2c4c790f134650c02be9aee7477a0e0de2329e36c05b6267bb19260e7e32b5b8b7b7a9be36d9d06972d43db7ab"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/5046ce80-6398-4173-9717-e2947f2585eb/841aad7475e8c9b78cbc50e3b8d35dae/dotnet-sdk-5.0.100-preview.2.20176.6-osx-x64.tar.gz",
+              "hash": "7359a8ae35265c47a8e893e6b32f13063e4d139ad4a9e89f4e08e01acff2aa92b32d40c19e1b117b5e24e2eda132ea46bfb4a9ad3f409c7b60bc70f9a97a492f"
+            },
+            {
+              "name": "dotnet-sdk-win-arm.zip",
+              "rid": "win-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/7d12d31d-a6c7-49d4-b1d3-91f531932553/43331ea36d39b63238d30c19e5a4bec9/dotnet-sdk-5.0.100-preview.2.20176.6-win-arm.zip",
+              "hash": "2fa5d214e4b645f38d071d3e08332d64bd7e9ca41d26aca2b6c66ec1a71d6f2793513725e30108569e87463c0674e9f8b9c1dc9430677afe66b59b8ac2378d8d"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/00296620-d967-4ae4-af29-bef9b0019970/4cdb51006f22059c14913bdfca57f5a1/dotnet-sdk-5.0.100-preview.2.20176.6-win-x64.exe",
+              "hash": "c3f511623b89662a95ce08ba00d0b7f588591eed62fd0c205c4916c8e540fdbfd9dead85da31b50aa085702dc5dbe98f8629f99ff4bcc49a2e115d48b7534d38"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/023b41aa-073b-491e-93ac-7e726fb81bda/b06f72654e32d1bddc941ff932f32c59/dotnet-sdk-5.0.100-preview.2.20176.6-win-x64.zip",
+              "hash": "94ec391e19232abc419e4327bbafe9e1f1b363bdda8c280da97f8cdc9f511747d3add76e0fb9909080c554f5acc61ebf7292d84ec5a81acf22d49760bf36ad72"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2f9d9ebd-07b9-4c88-b4e6-8cff9d5be760/ac3e76c14c15cf0999b3b8d2bb3a904a/dotnet-sdk-5.0.100-preview.2.20176.6-win-x86.exe",
+              "hash": "d9a4241a782913a0e371acf25744e40f16a469e19b80054387c1eef911aceb7d71794910a0e9629d593b0d16371a7d66ea19651701c6ce1d8d1db52f036774d9"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/c1a5bd0c-6236-45a9-bda4-fb9e2007e770/0a078520e350f64a92d5f97ee9b89a9f/dotnet-sdk-5.0.100-preview.2.20176.6-win-x86.zip",
+              "hash": "0ea68fa63d537252436cd2721a2b0fbb256549b5f0d093536d5aa1692697fb17e62df36a22fd19daa47f8b20bbe1ee85aafb5a8c47298c45ddafe27e56223fc9"
+            },
+            {
+              "name": "dotnet-sdk-x64.deb",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/d10bf368-79f0-4635-a04f-93301569844d/a3991083c98a2cc5ba1700e0048aaa88/dotnet-sdk-5.0.100-preview.2.20176.6-x64.deb",
+              "hash": "d3527bbea25ce0aa6eeab39d997dd8c2fba8a7b0c9b07d8a523205edb4dfaa5bc4c15c018354c4f812a5c26592f3becaca80bbb793d9535ce49a0ae8c2fac832"
+            },
+            {
+              "name": "dotnet-sdk-x64.rpm",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/ce4434c6-31be-4f7b-9c42-3c43a3e3a9cc/becff13989b2a126637acc2692e223cf/dotnet-sdk-5.0.100-preview.2.20176.6-x64.rpm",
+              "hash": "31f3ede22c545003bc371806eab559bba5c5d5ab1816a5e9516cc80540be77997094db690ba0493e8b3804c6fe474995d2a5ae343db28961b3e60651fada8350"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.2.20167.3",
+        "version-display": "5.0.0-preview.2",
+        "version-aspnetcoremodule": [
+          "15.0.20077.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/30617205-4338-4610-aa52-f15e92f9cbca/e6e9e688f333bab1aeaf8a94ded6b894/aspnetcore-runtime-5.0.0-preview.2.20167.3-linux-arm.tar.gz",
+            "hash": "f3397ddab68b19c0fb479835a98275315250c09ce0e2445d322fa743327bce3fd21580bdd6f480a650d9f0019afdc04df68ff689623fdc6b367589c840ac6c4e"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/75836796-02cf-4fe6-a3ea-e80aca657853/6ae8b11f79026141b47205cbe22fb549/aspnetcore-runtime-5.0.0-preview.2.20167.3-linux-arm64.tar.gz",
+            "hash": "d8c08a4b104b1d9aaf7c88e09c48cc2b17af7fa218c895d6dcbd9bf5c3afd2560ff8d647389ba7d8d5416e178897e128bd14c3f4598e821beb3bb8964dc862e8"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9ed6c92e-e82a-4b9f-8241-f589903bb9d2/4328a009d8296b949a9f5dd845e42cfd/aspnetcore-runtime-5.0.0-preview.2.20167.3-linux-musl-arm64.tar.gz",
+            "hash": "3d40c20c865dc7a686cad0f30810052387222f5840e81a3b1f352294722335aa44ca29b62106f8161790c7a92f663a934197b5890d641cacc05e886d76f1f7e7"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/05b6fd6b-3233-43dc-885e-6f25b1fe15c1/7834ecd7688f9e258ce78fbf942f0fb9/aspnetcore-runtime-5.0.0-preview.2.20167.3-linux-musl-x64.tar.gz",
+            "hash": "029ed32f8a7dfdb258438177b7fd40c187830db35b3d973dec296d8948f99d30a74269c45d31876c9b4533b8d7b6af65dea319299bd9a7081c6881cf026274b4"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/169871b7-ce8f-4518-a342-209f98342569/4bb2abeecf4b064eac907fb28f96b5ca/aspnetcore-runtime-5.0.0-preview.2.20167.3-linux-x64.tar.gz",
+            "hash": "c155a94b463020f413b9cc6650219b27c08f331f9d1926966e4c4471b1a3cc79e199fbbd4747e8ad89bd03d66cd90cbc68a5554c54e931ac59f7508810303327"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b8c4d3d2-b298-481c-8058-2f297c679be7/77e5e16c704720a52f89d39e676a3e7c/aspnetcore-runtime-5.0.0-preview.2.20167.3-osx-x64.tar.gz",
+            "hash": "774911ba77a3c7868a87ba34784f71f3ff7899d806e1cc1d7e1f5d53bcd7d9031addf75d062efbc5f8a5f38506c09ff8ae17deae191c8b8dfcb708a9b28a4fa1"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9fa60f80-a627-4dfc-8013-33f407112328/7809d7025c557beba477a0a49da6b9a0/aspnetcore-runtime-5.0.0-preview.2.20167.3-win-arm.zip",
+            "hash": "bdcd5a26e32398354cdf79b9a81c92e7c83b4dd649d2b8c2f41636c9c5b90977a0b132a6fb74b54b7dacc8860baeaaf46018246c4a9989687c356f0978d1f679"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/fbe8e0a5-7d9b-4cc4-bb16-7166ac5c8caa/3dde80bb4d0e312a418d20ba459b2a88/aspnetcore-runtime-5.0.0-preview.2.20167.3-win-x64.exe",
+            "hash": "ddc7128e48440faced3081367f506d9b85dc26ad2f3b2655ab5059769702762fffd36efe086d3215be21fbd44f8fdb0118776322a0de53ab58ead006b282e426"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a0bf9c39-d15e-4957-a7f2-cdd7aef660bf/d171c3c8ae27d6887eeec4e834f79234/aspnetcore-runtime-5.0.0-preview.2.20167.3-win-x64.zip",
+            "hash": "559adef282a0f5f70986a27672bc209278791952307cd0442f85cb249ee330ba3998cd4fd57333b057f1cb4149ecd2c1036db09cb8af78d6139ed45665722548"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b87565ce-850f-4406-813e-d38911d6528c/5828bcf354e2d7de213b097077e37ead/aspnetcore-runtime-5.0.0-preview.2.20167.3-win-x86.exe",
+            "hash": "de1ae921ed53d01eed636cde1894555d077d97299d3736416a4e861216c47ffe90e19bc3634431addd8e8c96b057fe8c79847c4ab6fe862ed96daaa2348c838d"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9b0aea06-9e28-4fc0-8a47-5d999a6d2589/7e243fc0b1ddcc61a971a7f36a36a2cd/aspnetcore-runtime-5.0.0-preview.2.20167.3-win-x86.zip",
+            "hash": "cb9c9a0b15e514fc8c65ef22e56eec4a82b1d95214a997c2d353f6312df6602086968e057a60ac1f5fc18d9bdafa4cad2975cbbc5bed38babe9531f064dcf0d9"
+          },
+          {
+            "name": "aspnetcore-runtime-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/450b65be-bd49-40d8-be9a-627dd060e014/b5d03d57ae4a0f489a61514f7f328beb/aspnetcore-runtime-5.0.0-preview.2.20167.3-x64.deb",
+            "hash": "5f0445df666983228431744dce9919523952fa4ce3a4fddd41bbbfc907202d6d9a39cf52b1f5879b11e0bce9a820a415028757a2ba803e694e90357d04993b2d"
+          },
+          {
+            "name": "aspnetcore-runtime-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c56b28c4-4af7-42d9-9951-389d50d6704b/8369cd45ef688c8b9c2e05aee0c5df25/aspnetcore-runtime-5.0.0-preview.2.20167.3-x64.rpm",
+            "hash": "346303c4384afabf5367b748415721ed9262e3af7b1ed0de62ef453161a69f35a553fd66e38c18e06269172870a799bb9dd1818a9abef9cd0afc06193a9a06ba"
+          },
+          {
+            "name": "aspnetcore-targeting-pack.deb",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4fbbab52-c028-4a68-85a3-158278c82006/ee9fda837661283d82a78ff1a6ad4ebd/aspnetcore-targeting-pack-5.0.0-preview.2.20167.3.deb",
+            "hash": "3b1c444f0e0e2adbf4f338c183ddd631d6694c91118de30c2d879ebf1e4b00b8a8a0afb6783c7cc31b3481d5a183a9151234804d6efc88b3b47061d6ecde2ecc"
+          },
+          {
+            "name": "aspnetcore-targeting-pack.rpm",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c45beaea-2f14-4ff6-bc9a-a1a3e7260055/b1f0a2d352cfab9de6bbb3611da00a99/aspnetcore-targeting-pack-5.0.0-preview.2.20167.3.rpm",
+            "hash": "c6c0c92ec89244ff10daa92e559746f2e3364659c343e318bec64c5dc4f3c4475dd6c67d33e7d0de90c751f9b273484d4703583980c50e0f3f79a9728bf72603"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e563b5c8-380d-4ccc-8e5e-272c6cee6520/66a77e469c68453714dfe13a281b89a9/dotnet-hosting-5.0.0-preview.2.20167.3-win.exe",
+            "hash": "d087a4e6c25608bb384e032cc1cd37bf8ea420fa2f249f5279755cbda9ca6b6c8f3ebb7cb7bd731da8440d758aae2f40ba7a5097da371da1035cb34e66076b8a"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.2.20160.6",
+        "version-display": "5.0.0-preview.2",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7fac4640-23f9-4e48-bce1-988292457ece/c6eff69e2d349a94794825a651657442/windowsdesktop-runtime-5.0.0-preview.2.20160.6-win-x64.exe",
+            "hash": "1b083768f30518cd63748a026c19d2624324f4438c4c00118d241d2b6bc5236cf0308cb366938dd748d68d3956091ab996fc3267666c71d70827886c7054e4cb"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/db134090-e6c1-4354-94ef-72a8bf42b6d6/c33b7f134c8778107d58b70aaf17af24/windowsdesktop-runtime-5.0.0-preview.2.20160.6-win-x86.exe",
+            "hash": "4e16206556e3944899807bfd914962e9422b5916dd794bb67bf11997fbed78525e20337f0029f66f01687b17492d97feb5f93b317c09d12a23fe6a37554184ce"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.2.20160.6",
+        "files": []
+      }
+    },
+    {
+      "release-date": "2020-03-16",
+      "release-version": "5.0.0-preview.1",
+      "security": false,
+      "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.1.md",
+      "runtime": {
+        "version": "5.0.0-preview.1.20120.5",
+        "version-display": "5.0.0-preview.1",
+        "vs-version": "",
+        "files": [
+          {
+            "name": "dotnet-apphost-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/34382598-1e4e-4749-91e9-3560aa47f442/98fbae8e122b0eeae86d83ec58fb04b6/dotnet-apphost-pack-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "ed117b0c19b53641c960e16f028c1fa17fadab377ffb7fae6de75b8d23f15ad22f8f5f124093a723cb3a2d7877963b4264a316aa3ca6140feedb4f399050b1a7"
+          },
+          {
+            "name": "dotnet-apphost-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/589d3958-8943-4454-83cd-210fce321f1d/8c3a236db7232b77cb0c8802f0e7cd30/dotnet-apphost-pack-5.0.0-preview.1.20120.5-x64.rpm",
+            "hash": "6ddc9e4cd7ca7bb78fbb9d88ba28acc978e4a2abf7ac01a82b0ec842c51df63679591cde194e3ea28e1655054248c044c2d6f0e0cdcbfbc85f60586f250c6b12"
+          },
+          {
+            "name": "dotnet-host-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/9208ba47-f1e0-433b-98b2-b5b088cabc20/cd0c47fb9d317eae9425e34220b7c3f5/dotnet-host-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "350f664500eda05fbd207c3260739291b7ef5aca24f19d9de4d0126d843805de59f6774c75b55727f93f4a4bdda64ae6333c7e41c17a97671f1b2b5e5803492b"
+          },
+          {
+            "name": "dotnet-host-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6b2e16fa-3c9f-4b7e-b93e-674740f6d5bc/4733ba774c769f54cfebc6eb26fa7fb7/dotnet-host-5.0.0-preview.1.20120.5-x64.rpm",
+            "hash": "aafb470c8f29a4db82f8fc36f3a5b840016c6e87e11de12b606127f931328e72a6fb193b6164cf51850bf6206e314dfee6f55f74968f7590ecdf09ff6d0a1c9c"
+          },
+          {
+            "name": "dotnet-hostfxr-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/62b018ee-b945-4668-8568-d7efdd642347/a9b9be49357574955f1f0e0c8d652f0c/dotnet-hostfxr-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "605103f3ed2ae03b4d32d65102e84d3ed363e5ddcaaa72caafd9c08885e1317bc76df499e05fa7ecd29f42e3dc52f307400c045028467a52c7bc786479bd6b2c"
+          },
+          {
+            "name": "dotnet-hostfxr-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/6ea43576-5e32-4bbd-b209-7367e75bce14/1f3af8f6c5aad98a6340abdbd95f7876/dotnet-hostfxr-5.0.0-preview.1.20120.5-x64.rpm",
+            "hash": "e6592b38ce4cbbe087eb0075990e7b3d9c7ed6aeff5d5164e86b0e6468d4a0c9af3ab67a5b1880354131dbb219c49b8e434fb19ebdec6645a727c9c3c711b2c1"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bf01eb4f-b9b4-4e31-a68d-6b7f4af49562/0eab2711796c422875dfd06b1c650b5b/dotnet-runtime-5.0.0-preview.1.20120.5-linux-arm.tar.gz",
+            "hash": "4dac1fee28b385c4e9fb133eb5ab7cf281f72c99d8cae3ba1f1b8b077c9424878da4a6d45cc72a3c09e5a37e1c93ac2f78dcc902838ea9f9875848dca78b74de"
+          },
+          {
+            "name": "dotnet-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/92e433ed-d058-4e45-bc13-3fe6b36c581d/a167eef99a3a52cc68d64801ab0ed1dd/dotnet-runtime-5.0.0-preview.1.20120.5-linux-arm64.tar.gz",
+            "hash": "bac5b22fc5ad2b633d650fb779e37b29339cbf2a4a764583e58927e95d9ac627f75e532e45ca775ec94859580fb865431abc36efcf7aaf3c11eb373a607e0e05"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/bdd99baa-336f-4a86-adbb-48d34061ba89/65eeff3091374af37a30ac54444ffb17/dotnet-runtime-5.0.0-preview.1.20120.5-linux-musl-arm64.tar.gz",
+            "hash": "8329ac14d78f119ab905d8770f52f0ad7b17a8c6a0c880618318aba1106fbdb04a3f7769c76708c5603101c575acfe401df002777b5ca8e4ea7a0e3604cfe05d"
+          },
+          {
+            "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/4ed97b16-e142-49e8-aaf1-e93b875031eb/870ed7cdbd0e4da3815de83466dbe0f8/dotnet-runtime-5.0.0-preview.1.20120.5-linux-musl-x64.tar.gz",
+            "hash": "a6dcbfc86a65e1c7fa58155df7255c5bc8387361501dac79827f98c92146194b18872dbf2d6c75402ffb08bf7b8111601733cfb20edc8f1e037e108f5b127042"
+          },
+          {
+            "name": "dotnet-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/a1965dfc-2402-49d2-b36b-f48530926905/ba965c0d696396d38315e06da03b8ebd/dotnet-runtime-5.0.0-preview.1.20120.5-linux-x64.tar.gz",
+            "hash": "488f96949f8835b99a688a6ff1699702f476bfd12d2aed5063d89ceaff801fd63e77160838ea57ce9b97f0770e29233e271948f69c790ef5daaa84382ab3d2c3"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/777eb5e6-abe3-4bc0-a19e-22709b26193a/f8ae123ccae445af01d8747616bb6893/dotnet-runtime-5.0.0-preview.1.20120.5-osx-x64.pkg",
+            "hash": "ed395dab0cbc6036cac52d9c4cc269558263bfe86f49cb36971c130960f6374ba8834ba25b5de1a2bd7cf34d94cad56136ee69c486a26c8d9a4b2cfb0c1585a0"
+          },
+          {
+            "name": "dotnet-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/64e79ce7-5064-4925-83c3-15efee6a49ce/ea6c15edbf449799c6b4c56fa211f780/dotnet-runtime-5.0.0-preview.1.20120.5-osx-x64.tar.gz",
+            "hash": "934eed60b76428a8a16cfe4dd46b72e39a0d413a8155072514a409957a099318a38ffbd2c08330d94fb8d5dd0176d502cfa6c3fb0d82e5908aa368b476b988e4"
+          },
+          {
+            "name": "dotnet-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/91c552ce-361b-43c9-86da-a5e5d9774bb0/bdde93ba13fad4c324268c230b9862ac/dotnet-runtime-5.0.0-preview.1.20120.5-win-arm.zip",
+            "hash": "4c260f97e0ec98ef08c3a3a26db7999e729b58aa1f7acda5f0f43df42ca707b9fb405d284629ca180742aa9ce51d67e7e1509296d5d2b44df41fa588e1a3e7ba"
+          },
+          {
+            "name": "dotnet-runtime-win-arm64.zip",
+            "rid": "win-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3e5b6a1d-b739-4885-8a6a-96cc0860240e/1d316a8ced559ff6304fe5c4f0b4a84e/dotnet-runtime-5.0.0-preview.1.20120.5-win-arm64.zip",
+            "hash": "18fc835f51f23d090460b197f08b3262386d9b9037cac93440a6311e65ec77558e15a52f7b9e5514ddb2f1808b736bf379fcd5bfa99e424024ba2e103e49554a"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/b17fa329-bb11-4dab-8998-993cf4c7c5b3/3beb0227b41619ed42e38e99fdf072a1/dotnet-runtime-5.0.0-preview.1.20120.5-win-x64.exe",
+            "hash": "cef89a83d64aa4ff9b17549439686b40527a0b1e019592b83bb46c641060cfe583fb8889b0ae9ea009aead27673082f26776690685f08798f35e9e6363a391d1"
+          },
+          {
+            "name": "dotnet-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3fa0154e-0d31-4182-a548-30beb70d3ddf/0dd379104b461fdf4b310b479e62ea95/dotnet-runtime-5.0.0-preview.1.20120.5-win-x64.zip",
+            "hash": "6c3afe3b51b85b53a03b448d6fe122a5e7d7da60d904b10040e99a218092e2632ea25bf58b5c9a3cb40151c41ec0fad158ce3487265df4d7eae67e3768408fb8"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1cfbb1b6-2a9f-4d03-9926-de56e7601534/e030d924094d5f840a0260e0c33a205e/dotnet-runtime-5.0.0-preview.1.20120.5-win-x86.exe",
+            "hash": "09c5ef8a4f4fa7e7437bc870f47f7e2375ff52b57560076b5f41c58205071b3db478c1779baac02a2bd633a28ee3878634da05bc50945145a7a31244e6203782"
+          },
+          {
+            "name": "dotnet-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/d81db672-e51a-4691-943f-2c513cf41ead/4e1a4ae6815c476937334467b7d3ea8b/dotnet-runtime-5.0.0-preview.1.20120.5-win-x86.zip",
+            "hash": "09006d52e8d9f95714c3a2a7a8523f08d4bb44ea99a04db2a8432d986c39b871fac79ec8419727410a7814bd21d64f7282595fcc3db1df5262f8de2c9aa0f916"
+          },
+          {
+            "name": "dotnet-runtime-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/edbaf09d-5d01-4b21-97c5-f3cf75bba5f9/cbf40693a286fbc5126823c6042c7b33/dotnet-runtime-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "3f5bcd7c487532caca918ff433eaeeacb7339a87019735285b93546d7cbf0d64825007cb8cec9e6d7923f810b886a812238cc4ada2dd77b7768c61b367d423d4"
+          },
+          {
+            "name": "dotnet-runtime-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/465089a5-3f71-476b-b611-1b9f41bdec6e/df51cc884314a400ad65f32e21ea5d78/dotnet-runtime-5.0.0-preview.1.20120.5-x64.rpm",
+            "hash": "49407155f0dc672150464ca20dedc87e6085090426fcc65b57b5f99fd255ad951d5adfeede8868762805ad05a4784c51f4b957fd802cc3544e9c0580e50686b6"
+          },
+          {
+            "name": "dotnet-runtime-deps-centos.7-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0f07009b-1ccd-4c98-8d19-bd8223912798/e988b9e568c6ef57edb1327b29ecab4c/dotnet-runtime-deps-5.0.0-preview.1.20120.5-centos.7-x64.rpm",
+            "hash": "12950ed76f3f352f4a7b8fc8cef6320e4f0968ee5db0d67a8f57b66ff3ed44a46d92f83856e8e55dbe601136d5c80449dd75636942651848bcaa0bf098639747"
+          },
+          {
+            "name": "dotnet-runtime-deps-fedora.27-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/94b6a141-63b2-4e5e-b38e-ff4b02a6f20f/db41939e5e796b9049390ba679bca686/dotnet-runtime-deps-5.0.0-preview.1.20120.5-fedora.27-x64.rpm",
+            "hash": "c4eae900802004f63c076abd5d2eef841f19bd04c14983cd9576febde92d9b76a0f4d81d9f6c5aec32e72652a8ff88eecba974e50ed17999073954ca75ac8c6e"
+          },
+          {
+            "name": "dotnet-runtime-deps-opensuse.42-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aa5d2001-25a1-4716-af60-0a7ac450019c/ff3f7336144059d8839f2a09cb952dcc/dotnet-runtime-deps-5.0.0-preview.1.20120.5-opensuse.42-x64.rpm",
+            "hash": "20ae5fc88c113047eef5a65bb86ff2f4a663acc2466451de66fa758c66213e89cb15c31bd0b5c33a6f0a51ab766dc94ccdb7275ae6cfad6e615f2790d0c822fd"
+          },
+          {
+            "name": "dotnet-runtime-deps-oraclelinux.7-x64.rpm",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0c651a3d-1fc7-4d05-8949-4f11709de28b/66ca7ddcff2677e22443d63634992365/dotnet-runtime-deps-5.0.0-preview.1.20120.5-oraclelinux.7-x64.rpm",
+            "hash": "d4343571ebd7cb391c4a87320817880abf70375ce1f3a633c2549253ff891746cf209c13a25f1c8b44f6871a044c248552682f553b3dbf63d95ccd138cb86eac"
+          },
+          {
+            "name": "dotnet-runtime-deps-rhel.7-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1caee7b0-4ca5-4bf7-981e-8d0b85d3dfd6/9b03a14654d00e7604eadd8675aa3fed/dotnet-runtime-deps-5.0.0-preview.1.20120.5-rhel.7-x64.rpm",
+            "hash": "4352bd9d2f1154167493c27a16fa6cbbe4b0e0956497951af86c4ed3643502ac811422cd65125add042756b78ab5498120d4bec1d0948e99bdc042a2ef95589f"
+          },
+          {
+            "name": "dotnet-runtime-deps-sles.12-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ef5e1e72-6b7b-41e7-98f0-7131305d0056/498593e7e06f38d49217c917cb8ea5a0/dotnet-runtime-deps-5.0.0-preview.1.20120.5-sles.12-x64.rpm",
+            "hash": "ac5c52035fe0816909dbe82d562e21d87e6a0f29487318cdf72e5399b51d481b999c06514fc5dc8f082d2a808f62d3835ec80e5b7f7b0639b17f10eeaf92a20a"
+          },
+          {
+            "name": "dotnet-runtime-deps-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/23f9bc1f-6829-4ba0-89e5-0dac90239e5e/37f8056bc3521edd8f4360b04db5dde4/dotnet-runtime-deps-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "cf9934aeae86f9a12003cb577e395ebd11f0d73369f1d964f08ba382de7ab876bdf5af92fc2c28ebae55874bd4785c6fd23607fe68adc639bfac90d37aa44da6"
+          },
+          {
+            "name": "dotnet-targeting-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ae77fe31-a115-4c21-b686-61d2ee5a44ac/82b99cf66d59147022f673e82de4275b/dotnet-targeting-pack-5.0.0-preview.1.20120.5-x64.deb",
+            "hash": "cd7225363d24162561e8b14c83f03bfaf1174b7e9c2e2ccb15ef8f2e4ec43208b0314646069a85332313e34b1628cb976d84cdc8fa2b5e9e03a6eddbe1b03401"
+          },
+          {
+            "name": "dotnet-targeting-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/564562cb-862b-42d9-9c27-e1bbf373ff35/7b6ad66ecaa6d398d91614c4848426d1/dotnet-targeting-pack-5.0.0-preview.1.20120.5-x64.rpm",
+            "hash": "4a429a1397615bdbc420ddbd195b3053c8c171105c92815496394dc43de28c4fb69e0ddb1957c7d973bd8b169c1a424438e1aae5d9ff39f0b197230efabd4eef"
+          },
+          {
+            "name": "netstandard-targeting-pack-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7877ce02-66ba-440f-a7f0-5cad36d94667/5c840bf4c473caf208c1b46b317264ac/netstandard-targeting-pack-2.1.0-preview.1.20120.5-x64.deb",
+            "hash": "1085b801e774bfc9c286a33c11983738febfcaedf611791f34285de8ded20f9ed7046dade34fc6a0278d55ea6715f93fe8492dad9bcfd2d96cef758466c26cc3"
+          },
+          {
+            "name": "netstandard-targeting-pack-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/657a9470-0342-471f-8e94-f1c9c2967ede/d244046503fdaf0c485639df83190285/netstandard-targeting-pack-2.1.0-preview.1.20120.5-x64.rpm",
+            "hash": "39956a7c90516e58c0a6bb19c69f5b4a1ee510042c92715914922b8ea67fd47b484c202c564cb1490bed59ef2f0d0bf2155f8cc7b140c9793dfebee66836d72f"
+          }
+        ]
+      },
+      "sdk": {
+        "version": "5.0.100-preview.1.20155.7",
+        "version-display": "5.0.100-preview.1",
+        "runtime-version": "5.0.100-preview.1.20155.7",
+        "vs-version": "",
+        "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+        "csharp-version": "8.0",
+        "fsharp-version": "5.0-preview",
+        "vb-version": "15.5",
+        "files": [
+          {
+            "name": "dotnet-sdk-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/658cb5dd-9a5f-481e-b481-f80a1ed802b3/9ab953320b89d5690a4fcda48b635986/dotnet-sdk-5.0.100-preview.1.20155.7-linux-arm.tar.gz",
+            "hash": "40752321856230ec4be50b3900909d002d28415e3ee6b499c605c922713b2867a736bbde9337c8a7e4e84260a5216f644c15d1660a74923ee06aae75bc62a54b"
+          },
+          {
+            "name": "dotnet-sdk-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/af8bf205-ea0d-47fe-a8bd-fd0a14add533/b926f87ea13147cd9dc80202a464d4b1/dotnet-sdk-5.0.100-preview.1.20155.7-linux-arm64.tar.gz",
+            "hash": "022a1f8cf19361f5ac1b7e0635864828266abbaf7bd26955c751a004ab9b5176a71567cba902ced0d2d48265ee0d3468af9ec931c6c9f5375f2d5c33ca14a439"
+          },
+          {
+            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0885bb3a-60d6-4dd7-82d4-2ccbdda2f90a/6f181788c4f85cc77076dd34b9f8bc05/dotnet-sdk-5.0.100-preview.1.20155.7-linux-musl-x64.tar.gz",
+            "hash": "a346eeda7140c2d674b5a9b1f777d3d4803d340f28466072c5662fcd0c8f002a411f5525845aeefc7e02ada9e22e05fce387f04260f9c3ec2c352a8155553489"
+          },
+          {
+            "name": "dotnet-sdk-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c3d1886b-6846-4328-9692-a0adcdf30959/f0bd5e15b1825fc8f5b0a8166008e08a/dotnet-sdk-5.0.100-preview.1.20155.7-linux-x64.tar.gz",
+            "hash": "e768641ef12604400edf4ba25bd7ea7a2e64c69fa447661b478ceff89f3c77c07ec69f3aa05b966400e88caae4f548a7bfc5a0747f511b5a10e88dd616f73b21"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.pkg",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f262d833-69d3-4aa1-bac1-b32075bebed3/474be39cca68cd46d3dc2cc03188f217/dotnet-sdk-5.0.100-preview.1.20155.7-osx-x64.pkg",
+            "hash": "b3807b8d3b8780146c801d8ed0bfd878b5bbdae3a6dbf89e4d97f29c2de4ac1b3cb8017e67174221ee8f4cac8a232060bd99e94a614143d4f47682838e227a4a"
+          },
+          {
+            "name": "dotnet-sdk-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/1c0e369e-945d-4618-b3f2-499190fb3cd3/369a29dced485be37eecf10728a96382/dotnet-sdk-5.0.100-preview.1.20155.7-osx-x64.tar.gz",
+            "hash": "243e84d0c1b61bde82c99c603fc2ef78e556850329772a828095bbbaef8f151c90b5474152fca57a25329517a0513dd22f591cccc853cc2525ce1aa10175cb41"
+          },
+          {
+            "name": "dotnet-sdk-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/2b45bc3f-9336-42e3-a936-a103293b0cc7/dcfa56be87e92b650fb057b7718a7467/dotnet-sdk-5.0.100-preview.1.20155.7-win-arm.zip",
+            "hash": "1794da1ef0697b0b0a2b3cb11133761191f2906bbc89989d581cacce0328da6f4ff3fe393ab671ab394816bfc50ee346cf93a0d76da33b3884bd3a7171ef633d"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f765753f-9647-4bdf-b66e-da211a949cc8/93c69234b471dad3d5b5d9e54e2fae8d/dotnet-sdk-5.0.100-preview.1.20155.7-win-x64.exe",
+            "hash": "a485ace9750f845f4037d7ac7c8cd3174f8db4eb2a8b7ea690a03be611fe5b0a2b3d37a696f8c38ab829e63af7a829a84aec3dd46a88ef5f993daa4dca1cc2a9"
+          },
+          {
+            "name": "dotnet-sdk-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/cdd81f5c-3920-4fa6-95a0-3c6267e9c614/705ea68fff8c01e4938daa2a2e33234c/dotnet-sdk-5.0.100-preview.1.20155.7-win-x64.zip",
+            "hash": "7f3ac46d09df12788061cfe3fd0ef32eaeeb5656e727f20888113d6028f035b2b724f10b9536eb968c4579b65571c7aba01c8b2b1c5b98ef141cfb5f9c063c91"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0781f119-edf1-4d4b-b0ed-193e30fdb3d4/73ff445ca02c7b21e19bb588228a0382/dotnet-sdk-5.0.100-preview.1.20155.7-win-x86.exe",
+            "hash": "d47dbf9e46075050a10a0e78830ca901fd667a2a4691bf5fe41ebb805cd6298d5f558178bd5aa5ad07ca2b9205fa4077a548f1a9060cf82f4ae5ebb87d5e0aee"
+          },
+          {
+            "name": "dotnet-sdk-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/dfd7d728-b4d1-4029-a80d-fd032a8ac5dd/f7cd8feff63a4058a2c81bd1b3532fe8/dotnet-sdk-5.0.100-preview.1.20155.7-win-x86.zip",
+            "hash": "8b2d7269fe8ae3a70b1776d102c4a84e3fc742be12e548577344146ff9d43193c5addeb847ec0e2c87618ca88721f54787e30d55ea9e970417c8c91e6f0db7f2"
+          },
+          {
+            "name": "dotnet-sdk-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/c5a2b347-3eaa-4dcc-a697-737513998d36/17ab4a4271a20a99d0731a3cf924fa44/dotnet-sdk-5.0.100-preview.1.20155.7-x64.deb",
+            "hash": "77f01a7fdddc80cb92521fc73ca618f1631f7c90a5c1d3531f5876836ce0576567bbf31dfa232b88755c46fb230752a393c8344b238c98b7c143654b0d816468"
+          },
+          {
+            "name": "dotnet-sdk-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/aa0c7248-c76f-460b-84ec-3a89730f2517/d10d65f633f76eb7d0b7330ade514992/dotnet-sdk-5.0.100-preview.1.20155.7-x64.rpm",
+            "hash": "54dfbaa8b63cbd79b7e64f6f9ee11e9d22f789e600bd69eacdab3e4946e1136056a9e17a71dff9f913ef62c80559a3e15e6eb05c988413f5275ab822ce7442b1"
+          }
+        ]
+      },
+      "sdks": [
+        {
+          "version": "5.0.100-preview.1.20155.7",
+          "version-display": "5.0.100-preview.1",
+          "runtime-version": "5.0.0-preview.1.20120.5",
+          "vs-version": "",
+          "vs-support": "Visual Studio 2019 (v16.6 - latest preview)",
+          "csharp-version": "8.0",
+          "fsharp-version": "5.0-preview",
+          "vb-version": "15.5",
+          "files": [
+            {
+              "name": "dotnet-sdk-linux-arm.tar.gz",
+              "rid": "linux-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/658cb5dd-9a5f-481e-b481-f80a1ed802b3/9ab953320b89d5690a4fcda48b635986/dotnet-sdk-5.0.100-preview.1.20155.7-linux-arm.tar.gz",
+              "hash": "40752321856230ec4be50b3900909d002d28415e3ee6b499c605c922713b2867a736bbde9337c8a7e4e84260a5216f644c15d1660a74923ee06aae75bc62a54b"
+            },
+            {
+              "name": "dotnet-sdk-linux-arm64.tar.gz",
+              "rid": "linux-arm64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/af8bf205-ea0d-47fe-a8bd-fd0a14add533/b926f87ea13147cd9dc80202a464d4b1/dotnet-sdk-5.0.100-preview.1.20155.7-linux-arm64.tar.gz",
+              "hash": "022a1f8cf19361f5ac1b7e0635864828266abbaf7bd26955c751a004ab9b5176a71567cba902ced0d2d48265ee0d3468af9ec931c6c9f5375f2d5c33ca14a439"
+            },
+            {
+              "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+              "rid": "linux-musl-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/0885bb3a-60d6-4dd7-82d4-2ccbdda2f90a/6f181788c4f85cc77076dd34b9f8bc05/dotnet-sdk-5.0.100-preview.1.20155.7-linux-musl-x64.tar.gz",
+              "hash": "a346eeda7140c2d674b5a9b1f777d3d4803d340f28466072c5662fcd0c8f002a411f5525845aeefc7e02ada9e22e05fce387f04260f9c3ec2c352a8155553489"
+            },
+            {
+              "name": "dotnet-sdk-linux-x64.tar.gz",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/c3d1886b-6846-4328-9692-a0adcdf30959/f0bd5e15b1825fc8f5b0a8166008e08a/dotnet-sdk-5.0.100-preview.1.20155.7-linux-x64.tar.gz",
+              "hash": "e768641ef12604400edf4ba25bd7ea7a2e64c69fa447661b478ceff89f3c77c07ec69f3aa05b966400e88caae4f548a7bfc5a0747f511b5a10e88dd616f73b21"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.pkg",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f262d833-69d3-4aa1-bac1-b32075bebed3/474be39cca68cd46d3dc2cc03188f217/dotnet-sdk-5.0.100-preview.1.20155.7-osx-x64.pkg",
+              "hash": "b3807b8d3b8780146c801d8ed0bfd878b5bbdae3a6dbf89e4d97f29c2de4ac1b3cb8017e67174221ee8f4cac8a232060bd99e94a614143d4f47682838e227a4a"
+            },
+            {
+              "name": "dotnet-sdk-osx-x64.tar.gz",
+              "rid": "osx-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/1c0e369e-945d-4618-b3f2-499190fb3cd3/369a29dced485be37eecf10728a96382/dotnet-sdk-5.0.100-preview.1.20155.7-osx-x64.tar.gz",
+              "hash": "243e84d0c1b61bde82c99c603fc2ef78e556850329772a828095bbbaef8f151c90b5474152fca57a25329517a0513dd22f591cccc853cc2525ce1aa10175cb41"
+            },
+            {
+              "name": "dotnet-sdk-win-arm.zip",
+              "rid": "win-arm",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/2b45bc3f-9336-42e3-a936-a103293b0cc7/dcfa56be87e92b650fb057b7718a7467/dotnet-sdk-5.0.100-preview.1.20155.7-win-arm.zip",
+              "hash": "1794da1ef0697b0b0a2b3cb11133761191f2906bbc89989d581cacce0328da6f4ff3fe393ab671ab394816bfc50ee346cf93a0d76da33b3884bd3a7171ef633d"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.exe",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/f765753f-9647-4bdf-b66e-da211a949cc8/93c69234b471dad3d5b5d9e54e2fae8d/dotnet-sdk-5.0.100-preview.1.20155.7-win-x64.exe",
+              "hash": "a485ace9750f845f4037d7ac7c8cd3174f8db4eb2a8b7ea690a03be611fe5b0a2b3d37a696f8c38ab829e63af7a829a84aec3dd46a88ef5f993daa4dca1cc2a9"
+            },
+            {
+              "name": "dotnet-sdk-win-x64.zip",
+              "rid": "win-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/cdd81f5c-3920-4fa6-95a0-3c6267e9c614/705ea68fff8c01e4938daa2a2e33234c/dotnet-sdk-5.0.100-preview.1.20155.7-win-x64.zip",
+              "hash": "7f3ac46d09df12788061cfe3fd0ef32eaeeb5656e727f20888113d6028f035b2b724f10b9536eb968c4579b65571c7aba01c8b2b1c5b98ef141cfb5f9c063c91"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.exe",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/0781f119-edf1-4d4b-b0ed-193e30fdb3d4/73ff445ca02c7b21e19bb588228a0382/dotnet-sdk-5.0.100-preview.1.20155.7-win-x86.exe",
+              "hash": "d47dbf9e46075050a10a0e78830ca901fd667a2a4691bf5fe41ebb805cd6298d5f558178bd5aa5ad07ca2b9205fa4077a548f1a9060cf82f4ae5ebb87d5e0aee"
+            },
+            {
+              "name": "dotnet-sdk-win-x86.zip",
+              "rid": "win-x86",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/dfd7d728-b4d1-4029-a80d-fd032a8ac5dd/f7cd8feff63a4058a2c81bd1b3532fe8/dotnet-sdk-5.0.100-preview.1.20155.7-win-x86.zip",
+              "hash": "8b2d7269fe8ae3a70b1776d102c4a84e3fc742be12e548577344146ff9d43193c5addeb847ec0e2c87618ca88721f54787e30d55ea9e970417c8c91e6f0db7f2"
+            },
+            {
+              "name": "dotnet-sdk-x64.deb",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/c5a2b347-3eaa-4dcc-a697-737513998d36/17ab4a4271a20a99d0731a3cf924fa44/dotnet-sdk-5.0.100-preview.1.20155.7-x64.deb",
+              "hash": "77f01a7fdddc80cb92521fc73ca618f1631f7c90a5c1d3531f5876836ce0576567bbf31dfa232b88755c46fb230752a393c8344b238c98b7c143654b0d816468"
+            },
+            {
+              "name": "dotnet-sdk-x64.rpm",
+              "rid": "linux-x64",
+              "url": "https://download.visualstudio.microsoft.com/download/pr/aa0c7248-c76f-460b-84ec-3a89730f2517/d10d65f633f76eb7d0b7330ade514992/dotnet-sdk-5.0.100-preview.1.20155.7-x64.rpm",
+              "hash": "54dfbaa8b63cbd79b7e64f6f9ee11e9d22f789e600bd69eacdab3e4946e1136056a9e17a71dff9f913ef62c80559a3e15e6eb05c988413f5275ab822ce7442b1"
+            }
+          ]
+        }
+      ],
+      "aspnetcore-runtime": {
+        "version": "5.0.0-preview.1.20124.5",
+        "version-display": "5.0.0-preview.1",
+        "version-aspnetcoremodule": [
+          "15.0.20055.0"
+        ],
+        "vs-version": "",
+        "files": [
+          {
+            "name": "aspnetcore-runtime-linux-arm.tar.gz",
+            "rid": "linux-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/29aa86cb-69c7-40ee-a43f-ed3a88327a38/16f0e2751e1beb740c3f74fbf26be2f6/aspnetcore-runtime-5.0.0-preview.1.20124.5-linux-arm.tar.gz",
+            "hash": "0592fdc197b07151970fdc64e3f40d5551bb2d0bc821241e1068ee1446606d5f7569bdd74a4744efa29b86b01a6600807c6c31630c6651d44281ab38767fd172"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+            "rid": "linux-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/93b0f737-6af5-418d-a801-daaba67561e5/4fea7595d0101eaca86bed539f2cfdf4/aspnetcore-runtime-5.0.0-preview.1.20124.5-linux-arm64.tar.gz",
+            "hash": "bc4d66c2c81ba81afa63226444bad97d590b08c35a4f13e2bc972fd11f313bc524286384925c1db0d882acd5ef17ea9cc7715331cfaa2394019cd5bca461d6f5"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+            "rid": "linux-musl-arm64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/7c4daf05-27e3-46ee-a9fe-937dcff55b17/bf88e4f1ee7b47739921e224a83aa41d/aspnetcore-runtime-5.0.0-preview.1.20124.5-linux-musl-arm64.tar.gz",
+            "hash": "1b989ff55f0d63be0f512db1caf1b7c571fcf1c30785a4077f43b4ebe9646088a85ec929fb2242bd1f6f16ae236278aafa9827b10420a81d0466eb83d791c2b7"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+            "rid": "linux-musl-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/05aa85ef-f4d2-491d-9740-846d319302ee/a741ae607242a3626fa2ad8ca00c91ac/aspnetcore-runtime-5.0.0-preview.1.20124.5-linux-musl-x64.tar.gz",
+            "hash": "05bc089d6587b7d4afda29c793b602b549fbf2eaa631ce7339167f5f5f572267e36414f01755eb34dfc89bfd4081ef1b61b56e322aefccfe1b1c805ad77d5a15"
+          },
+          {
+            "name": "aspnetcore-runtime-linux-x64.tar.gz",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/56b46d73-ccf0-47df-8a41-a90cd2333304/271d1b5ad2162b721b4b88a1fcad5bc1/aspnetcore-runtime-5.0.0-preview.1.20124.5-linux-x64.tar.gz",
+            "hash": "4ec2c9e8ed5e8ddaa52ed291c263412b754691ae2b95362ddc6fa75cfe087dbe59c7e4f65f21b0f096bc93967d04f4ea612a0c42c8a124ef4583d0de8daac01c"
+          },
+          {
+            "name": "aspnetcore-runtime-osx-x64.tar.gz",
+            "rid": "osx-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/94ec572d-4b5a-4077-a96d-0da66a95cece/eb406d9b0e4628f5e259452ca08145eb/aspnetcore-runtime-5.0.0-preview.1.20124.5-osx-x64.tar.gz",
+            "hash": "79b48ab04f28e173d561bfe0ffd8d1099ae98c6a3a927c68a774a98b123c660cdcd68ea654c3baf3c87e1109a6e48a9fe54d9bcbed17655673789e8bc5c35225"
+          },
+          {
+            "name": "aspnetcore-runtime-win-arm.zip",
+            "rid": "win-arm",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0b69fc69-14ad-4848-a063-63931fe47d8b/0b30a487be3314763c6139d19b27cad0/aspnetcore-runtime-5.0.0-preview.1.20124.5-win-arm.zip",
+            "hash": "c1779c1bedc8ab7a40ccaf79b6291d1d21a4ca19a7932d57e682dd483b42cf0afe179220101154c34c9be88f01d9e60ca49c1b615d4043a8b7feff165d2b12d1"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/f0fcc7bd-977d-4e47-ae93-6cef16bffa52/2bac08d7be3f536baef009d7e2f51c27/aspnetcore-runtime-5.0.0-preview.1.20124.5-win-x64.exe",
+            "hash": "9b1d72c312b773ca4d7ae5193f2d52123d784186e1bbbe62050887418425201cec440cc0cbf0e7cf398f5bfdb1266eef98270b232d8853cffd20f6bf15274eab"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x64.zip",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/09dd37c6-1597-4e43-914c-2c97c257d527/c2551b6d795fe1d46e62121c1ee66ca0/aspnetcore-runtime-5.0.0-preview.1.20124.5-win-x64.zip",
+            "hash": "47ca5820673f38c4ba6760ea87495dc016d832028b4eba3dc087dce3be6c6bd9dd21293eb564870e349e72dd4572cfce442daaec9785ebfec8a3d1cde9b26744"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/97ca32bd-11f1-4c6c-9b02-bd7972d5fd49/31ec1ac0056d847f4f139cd6aa6ebd73/aspnetcore-runtime-5.0.0-preview.1.20124.5-win-x86.exe",
+            "hash": "50c6d8c4e6ab321c613056a7f84bef8f6f6877470b488a8ecac6466c2d99e200a66d07f78109828bf884fb1ab1c924181d8d0d1ad58e3f04bb58b3e7d025b814"
+          },
+          {
+            "name": "aspnetcore-runtime-win-x86.zip",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/08e464a2-d72d-4c54-8235-5bfd0cc08c59/63440fe56dc65097152443b0f94a9757/aspnetcore-runtime-5.0.0-preview.1.20124.5-win-x86.zip",
+            "hash": "2552ededd8e11ca1d16066351d91abe93ad85f23e9e79e8b855574df160964dabad537356c0e034ca03ad351799610b63a032e32ab0bc65d07ae7104b5c1ce2e"
+          },
+          {
+            "name": "aspnetcore-runtime-x64.deb",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/338371fd-ee7a-41aa-a012-6d612e92bcb3/4db8b8992a93c47355b2fc7bfed750e0/aspnetcore-runtime-5.0.0-preview.1.20124.5-x64.deb",
+            "hash": "8928f0056c579984e63ae13ee980441f34a8d050dbd4ccaa0968ddf56816b74e2ba001df2582746970eeab4d7850522015355642aa0d8b4901f46ccd50d76238"
+          },
+          {
+            "name": "aspnetcore-runtime-x64.rpm",
+            "rid": "linux-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/5d5e8781-9eb2-4a8e-8b52-42fa82d85d7a/df22d24384a341d956d709a11b29e509/aspnetcore-runtime-5.0.0-preview.1.20124.5-x64.rpm",
+            "hash": "c69518e3dceefc79db961359f5c284e271e22a0a9f348f5de5ee7a72dbbe6001d81d4558671d595d473421e9a6c10dee42a3ce72fa836b708b8864e08c44438f"
+          },
+          {
+            "name": "aspnetcore-targeting-pack.deb",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/3f186eb0-0d3e-49ee-863b-e7e0826b740f/3474a4667520b115f9069f2aadd74d22/aspnetcore-targeting-pack-5.0.0-preview.1.20124.5.deb",
+            "hash": "4c901f7162b9ffb4dd8ab40f3be346c1001f5cbcaff692a23d0bcdb30aa5fbf8803973ee37be6526291d9d54a2e2c76aaaeb7f3a893c03f80c9ef59835e1c6d1"
+          },
+          {
+            "name": "aspnetcore-targeting-pack.rpm",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e7abdd13-9a7e-4a2a-90ac-aa2da134f5f4/1ed614b70ed7d1c5bc32f8a78fbf0672/aspnetcore-targeting-pack-5.0.0-preview.1.20124.5.rpm",
+            "hash": "f9dad74b74f0dc824554db41ff195d12f7a611be11b873fde9b8d80155ec5108c5d98a8473d7e963cf90ebfa2be5889ba704a716bad3ab29303b5c1f8abd6398"
+          },
+          {
+            "name": "dotnet-hosting-win.exe",
+            "rid": "",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/0221e27a-7c9d-4123-aca0-ddde3c4d6001/cf53100f7de5187005cac9a5880e4879/dotnet-hosting-5.0.0-preview.1.20124.5-win.exe",
+            "hash": "e3bb2502552ed73ff48d7b2cd58c59029321c1b49fe93b43eb37ab7fa90f4cf8a91c01af67e3a46c7991db8d5c0cebab1e6cbeb95e49e0f6f49b5bf2846d7535"
+          }
+        ]
+      },
+      "windowsdesktop": {
+        "version": "5.0.0-preview.1.20127.5",
+        "version-display": "5.0.0-preview.1",
+        "files": [
+          {
+            "name": "windowsdesktop-runtime-win-x64.exe",
+            "rid": "win-x64",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/ad44996b-5d71-4b35-a009-08aed1ac1add/3cfc44f1463030caf61049a2d50e483a/windowsdesktop-runtime-5.0.0-preview.1.20127.5-win-x64.exe",
+            "hash": "15de7de22fa6c19c06053a8a88fdde52c6fb10fc7e0bb2703f30c42406a28feaa56de9b11fc295269eb4297c0239c9b558640e9963fa891d803a2072baa64387"
+          },
+          {
+            "name": "windowsdesktop-runtime-win-x86.exe",
+            "rid": "win-x86",
+            "url": "https://download.visualstudio.microsoft.com/download/pr/e6e08491-8da4-4a4d-9a92-e7323cc1174f/447dcd27c06a92f66209c70bdf453b65/windowsdesktop-runtime-5.0.0-preview.1.20127.5-win-x86.exe",
+            "hash": "dfb97c3c85b35ae00b95ad6a60bfdffb9244ec807012d55f0b5bd7696c3600acc006be653ee2045fcf1f368ff4cce26761e504d7cdcf85d94863aa48ce77f4e7"
+          }
+        ]
+      },
+      "symbols": {
+        "version": "5.0.0-preview.1.20120.5",
+        "files": []
+      }
+    }
+  ],
+  "intellisense": {
+    "version": "5.0.0",
+    "version-display": "5.0.0",
+    "files": []
+  }
+}

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/data/releases-index.json
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/data/releases-index.json
@@ -1,25 +1,38 @@
 {
     "releases-index": [
         {
-            "channel-version": "5.0",
-            "latest-release": "5.0.0-preview.7",
-            "latest-release-date": "2020-07-21",
+            "channel-version": "6.0",
+            "latest-release": "6.0.0-preview.1",
+            "latest-release-date": "2021-02-17",
             "security": false,
-            "latest-runtime": "5.0.0-preview.7.20364.11",
-            "latest-sdk": "5.0.100-preview.7.20366.6",
-            "product": ".NET Core",
+            "latest-runtime": "6.0.0-preview.1.21102.12",
+            "latest-sdk": "6.0.100-preview.1.21103.13",
+            "product": ".NET",
             "support-phase": "preview",
+            "eol-date": null,
+            "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json"
+        },
+        {
+            "channel-version": "5.0",
+            "latest-release": "5.0.3",
+            "latest-release-date": "2021-02-09",
+            "security": true,
+            "latest-runtime": "5.0.3",
+            "latest-sdk": "5.0.103",
+            "product": ".NET",
+            "support-phase": "current",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json"
         },
         {
             "channel-version": "3.1",
-            "latest-release": "3.1.6",
-            "latest-release-date": "2020-07-14",
+            "latest-release": "3.1.12",
+            "latest-release-date": "2021-02-09",
             "security": true,
-            "latest-runtime": "3.1.6",
-            "latest-sdk": "3.1.302",
+            "latest-runtime": "3.1.12",
+            "latest-sdk": "3.1.406",
             "product": ".NET Core",
             "support-phase": "lts",
+            "eol-date": "2022-12-03",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json"
         },
         {
@@ -36,13 +49,14 @@
         },
         {
             "channel-version": "2.1",
-            "latest-release": "2.1.20",
-            "latest-release-date": "2020-07-14",
+            "latest-release": "2.1.25",
+            "latest-release-date": "2021-02-09",
             "security": true,
-            "latest-runtime": "2.1.20",
-            "latest-sdk": "2.1.808",
+            "latest-runtime": "2.1.25",
+            "latest-sdk": "2.1.813",
             "product": ".NET Core",
             "support-phase": "lts",
+            "eol-date": "2021-08-21",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json"
         },
         {
@@ -56,11 +70,11 @@
             "support-phase": "eol",
             "eol-date": "2019-12-23",
             "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json"
-          },
+        },
         {
             "channel-version": "2.0",
             "latest-release": "2.0.9",
-            "latest-release-date":"2018-07-10",
+            "latest-release-date": "2018-07-10",
             "security": true,
             "latest-runtime": "2.0.9",
             "latest-sdk": "2.1.202",

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/data/releases.json
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/data/releases.json
@@ -1,0 +1,378 @@
+{
+    "channel-version": "6.0",
+    "latest-release": "6.0.0-preview.1",
+    "latest-release-date": "2021-02-17",
+    "latest-runtime": "6.0.0-preview.1.21102.12",
+    "latest-sdk": "6.0.100-preview.1.21103.13",
+    "support-phase": "preview",
+    "lifecycle-policy": "https://dotnet.microsoft.com/platform/support/policy/",
+    "releases": [
+        {
+            "release-date": "2021-02-17",
+            "release-version": "6.0.0-preview.1",
+            "security": false,
+            "release-notes": "https://github.com/dotnet/core/blob/master/release-notes/6.0/preview/6.0.0-preview.1.md",
+            "runtime": {
+                "version": "6.0.0-preview.1.21102.12",
+                "version-display": "6.0.0-preview.1",
+                "vs-version": "16.9",
+                "vs-mac-version": "",
+                "files": [
+                    {
+                        "name": "dotnet-runtime-linux-arm.tar.gz",
+                        "rid": "linux-arm",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/4e51a05a-48d9-43e7-b01f-d310c72bccec/9d0afbd7768e9375b17242849a5dfb27/dotnet-runtime-6.0.0-preview.1.21102.12-linux-arm.tar.gz",
+                        "hash": "42d9046cef8beeec7774e81cb160fff99d700a78f2e1d26b8a471dec4e727414e65197994ce200785b22d5f073e6402afdb92e62fc86ea38fc8814a1de52f6eb"
+                    },
+                    {
+                        "name": "dotnet-runtime-linux-arm64.tar.gz",
+                        "rid": "linux-arm64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/5e0d0c82-d02e-4538-9368-a811ca5e2e5d/d466e46d5a5902f125557890369bec77/dotnet-runtime-6.0.0-preview.1.21102.12-linux-arm64.tar.gz",
+                        "hash": "4844ab4ce5750d45b552c2bca3a507dae0202f8be7d990506a66940158666897077c0d045b7a7e136a772da3a18b2cf81c932b5874747268aece6846fdc44bb8"
+                    },
+                    {
+                        "name": "dotnet-runtime-linux-musl-arm64.tar.gz",
+                        "rid": "linux-musl-arm64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/982f4116-9fb6-45c6-9dc6-91c468448d75/4e4294ac124e54a5bfe65a85a4c1c781/dotnet-runtime-6.0.0-preview.1.21102.12-linux-musl-arm64.tar.gz",
+                        "hash": "d0e0fac6b159714070d7cb9ac9f184538a8805257b1a362613c28e63998b4439d5e42789c07330747a70704ef2cc5044eca4b269de4ee3f53de68b1af8cc3735"
+                    },
+                    {
+                        "name": "dotnet-runtime-linux-musl-x64.tar.gz",
+                        "rid": "linux-musl-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/d1141a8c-60ef-4e40-9d2f-2731d7a3eb23/1459ce3fc065c0fa32a7c2592f66a126/dotnet-runtime-6.0.0-preview.1.21102.12-linux-musl-x64.tar.gz",
+                        "hash": "06475f29a4bfc8af012a6560f26cfe9c32469263b7c690d73975a2a1790965b139c227dd72961488f774088c45a3ebc8955b13ed1ec070cec7dbda4b51ea4171"
+                    },
+                    {
+                        "name": "dotnet-runtime-linux-x64.tar.gz",
+                        "rid": "linux-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/8f151cb8-5cf0-45e5-b1b0-c16b631b24bd/d12028755ec7abb4f87f16e6fa6e8add/dotnet-runtime-6.0.0-preview.1.21102.12-linux-x64.tar.gz",
+                        "hash": "64114ea881981ed061eb22c97ae8cf5a85209b0a439d6640984e1b423bc934259bcd136484c26f038f19222a9068a5cd687229a8b9b0d0b55efacb0275da082d"
+                    },
+                    {
+                        "name": "dotnet-runtime-osx-x64.pkg",
+                        "rid": "osx-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/62a705de-f063-4dc1-912b-6727ab3295cd/a3845e7371b03fa813384d0e16ebaa20/dotnet-runtime-6.0.0-preview.1.21102.12-osx-x64.pkg",
+                        "hash": "0c3771b56f9fa6b09063fb797e4c264cd7b3723d7cfda6aae5f3a8dfe19bc513acc393761a6b2fdf4dd0a35427fa40392e30969a0eb3076a7f4a1891fcff01c6"
+                    },
+                    {
+                        "name": "dotnet-runtime-osx-x64.tar.gz",
+                        "rid": "osx-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/2b0f29e1-918c-4ede-94c2-4317f1914305/f2b88f8ce148d158e4a6b606b5b75205/dotnet-runtime-6.0.0-preview.1.21102.12-osx-x64.tar.gz",
+                        "hash": "767d1c264ada1dd5f73c403d663bdfeaaafefaf0545d6af1895d1c926dd32385601981fe949340cee5fa8c34698f12c9553b0aaf492d12b0d4288a6e5ea6da08"
+                    },
+                    {
+                        "name": "dotnet-runtime-win-arm64.exe",
+                        "rid": "win-arm64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/dacaafab-f672-4afa-b0c8-b4d531cded4b/516e966b362126a111b77001da9c265e/dotnet-runtime-6.0.0-preview.1.21102.12-win-arm64.exe",
+                        "hash": "97bb0f7b613a4a3abcc4d76d046d5696f84a105c8395105d39bc7b12150bd047900abe2d769d2fffd07d3b9c1b21295135abaf570c86f678a500315d174f7c6f"
+                    },
+                    {
+                        "name": "dotnet-runtime-win-arm64.zip",
+                        "rid": "win-arm64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/3f917e65-d6cc-40f8-af28-477aea7dffe1/2bf1a0e12dff945518591646abe24a01/dotnet-runtime-6.0.0-preview.1.21102.12-win-arm64.zip",
+                        "hash": "8d141409f6439b227e1165caa91450908e4d18132080d76da588a90c88d0c198196d1a2ba4dcb7b5ec5997bcab80a108f92184dde39e52b73b64b568daee7dfe"
+                    },
+                    {
+                        "name": "dotnet-runtime-win-x64.exe",
+                        "rid": "win-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/79bdf367-c2a7-4f78-a139-e009ebbdff20/c4071c63b9972749ee39b88b4025a0f2/dotnet-runtime-6.0.0-preview.1.21102.12-win-x64.exe",
+                        "hash": "bf94dc2a8e03280298327f7c5eb353f4f1a2854bdcd9b7fa44a30078a09a324b190a7af02d3f10167bb73272dbdf28a12df37b94368bec63c5fc93ffd2557c87"
+                    },
+                    {
+                        "name": "dotnet-runtime-win-x64.zip",
+                        "rid": "win-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/0a605ac5-b3ea-4683-b20e-a96ca05123fa/82bca2ae7d45ccf4adc33caf9f2819c8/dotnet-runtime-6.0.0-preview.1.21102.12-win-x64.zip",
+                        "hash": "e183555b560fa23c86a6060136f8dc9bba0b79d54f673bf155c4843eed2c0a72ee57a06a0a588c70438c066c8093f46d83a077db6891dc21eaa182c8f83d405d"
+                    },
+                    {
+                        "name": "dotnet-runtime-win-x86.exe",
+                        "rid": "win-x86",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/a911ac72-40ea-4ae1-a2e8-ab99c52c8789/e3fece89d74d33e1b431248ed9b6d021/dotnet-runtime-6.0.0-preview.1.21102.12-win-x86.exe",
+                        "hash": "0d0f1491b6c51a45422567894765e2e2117addab42e3b7b747dd5530ae8955c10239e304d2cf4065293fc38574c9c8eb92e50f8ee5ed6356a6892abfec7553ea"
+                    },
+                    {
+                        "name": "dotnet-runtime-win-x86.zip",
+                        "rid": "win-x86",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/000dc492-3559-4c08-b90a-1a404b1a6fb0/574470f804128905a60ec2214de57262/dotnet-runtime-6.0.0-preview.1.21102.12-win-x86.zip",
+                        "hash": "689730a9cd4f1917fd025cf8fc7f1981fc766e96144aced5097e9e8919b1b70644892ac1f25514ced6b0ba84e4fe719cf8b8f475095701c92406cbbbb3edfd28"
+                    }
+                ]
+            },
+            "sdk": {
+                "version": "6.0.100-preview.1.21103.13",
+                "version-display": "6.0.100-preview.1",
+                "runtime-version": "6.0.0-preview.1.21102.12",
+                "vs-version": "16.9",
+                "vs-mac-version": "",
+                "vs-support": "Visual Studio 2019 (v16.9 Preview 4)",
+                "vs-mac-support": "",
+                "csharp-version": "9.0",
+                "fsharp-version": "5.0",
+                "vb-version": "16.0",
+                "files": [
+                    {
+                        "name": "dotnet-sdk-linux-arm.tar.gz",
+                        "rid": "linux-arm",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/3b62cfcf-589e-43b3-993b-517c70c93a22/0ecae846884376fecc5de8a4f6d6c927/dotnet-sdk-6.0.100-preview.1.21103.13-linux-arm.tar.gz",
+                        "hash": "05a5a0f9b3738042eedbce37105ceb95480ca8175d85ec7300c32949ee205a66b5e12583fff9f72d9161af56923842d388e6791f18aa7109a8c823461dd5d8d5"
+                    },
+                    {
+                        "name": "dotnet-sdk-linux-arm64.tar.gz",
+                        "rid": "linux-arm64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/9143768a-e997-45b5-b818-e5b96ac0c24c/b5c7eb4476e9cdb56deb62d2a26f729d/dotnet-sdk-6.0.100-preview.1.21103.13-linux-arm64.tar.gz",
+                        "hash": "fe79c1554bea30039390e6c9efe00623338fdeb1f471d8c74b41d43d38230d383e215859905f4c057bfd1ba027f7f157c4d5d215f961d3663aed60dcbe870add"
+                    },
+                    {
+                        "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+                        "rid": "linux-musl-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/5d837dff-229d-47cf-b2cf-69dbb3a7e928/8863976e15b6d4391e3611fddb3c073e/dotnet-sdk-6.0.100-preview.1.21103.13-linux-musl-x64.tar.gz",
+                        "hash": "4b8002f608e5354651b9d82fa8442bca68be730dfdb54d026763635185457a23e5e071421bb04de8f8254fe36cc2134b430aaacb363911fd93276b7c34ad935c"
+                    },
+                    {
+                        "name": "dotnet-sdk-linux-x64.tar.gz",
+                        "rid": "linux-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/579aac9e-53dd-404e-9452-9910bc9be422/1c47683215dd54a3837fc4b338ddb6a6/dotnet-sdk-6.0.100-preview.1.21103.13-linux-x64.tar.gz",
+                        "hash": "86f591c70c73732030210e8e7ce39b7b4e4a680098862e340a4a8726bcb3f981f0748baec0fce8c5c4a8615670a72ab92bfad8d0dc0a305401bbc5864116996a"
+                    },
+                    {
+                        "name": "dotnet-sdk-osx-x64.pkg",
+                        "rid": "osx-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/f7224456-9898-45b6-8acc-b110900653cd/817c4e3b1ee787985fdf85032eb2752d/dotnet-sdk-6.0.100-preview.1.21103.13-osx-x64.pkg",
+                        "hash": "0e429d21e9c12f79fa8875670574d123389a4928d3c18d7fcd18fff50cdabb3faa8a2617011a9045b472b2192bcc4c5d5656cf57659357b395bd6fd21e88dd3c"
+                    },
+                    {
+                        "name": "dotnet-sdk-osx-x64.tar.gz",
+                        "rid": "osx-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/e9e781b5-9b2e-4180-9f47-bfb5a5cf98b1/0ad0afbe2d322e521e15156089779f3e/dotnet-sdk-6.0.100-preview.1.21103.13-osx-x64.tar.gz",
+                        "hash": "f4c930c867399fbcffe5c345c54e0595c712419b910df7263b35fc4711307bd5cc3a7878d6e06caf4904d915f371b4ab53d8c763d02d1bbbbee586fb16c137ca"
+                    },
+                    {
+                        "name": "dotnet-sdk-win-arm64.exe",
+                        "rid": "win-arm64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/69c0d82c-78d1-4cf6-b364-68fa96159166/57022ee819185466e0747ef7f48b6276/dotnet-sdk-6.0.100-preview.1.21103.13-win-arm64.exe",
+                        "hash": "cebded348d80d50e60924a2791e683e0751c00eb87ac94388b8f68320936889c92238e56b91b837ec0c87fffe86787d1a0aa412d95c011d8b682f52d72636727"
+                    },
+                    {
+                        "name": "dotnet-sdk-win-arm64.zip",
+                        "rid": "win-arm64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/971194ae-f2fc-48d1-bf90-378f61591188/e7fbf3421848aa2edf3d360005630125/dotnet-sdk-6.0.100-preview.1.21103.13-win-arm64.zip",
+                        "hash": "66b6d3e4d7c3ccfcb99ec01f7b97601d8a20e5c9de2640b327099c5cde4e6e637f4ccd3d4ac94137684719a056bd05ed946ec628bd457288ca7d59ea24bbc376"
+                    },
+                    {
+                        "name": "dotnet-sdk-win-x64.exe",
+                        "rid": "win-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/68e6514a-ec0f-46ea-a00a-76ec205c42cc/f68e27ee1a41320ad5e331ccd6bcab9f/dotnet-sdk-6.0.100-preview.1.21103.13-win-x64.exe",
+                        "hash": "e1800fbe29c667669f0d052dfd8a0d46b6e8b81e4929c2dabe2f2e853146edfa159dab348fe6cf9ab52176e1d99009f2f4281c8a548538fbf25a4d5c6fe5dbc6"
+                    },
+                    {
+                        "name": "dotnet-sdk-win-x64.zip",
+                        "rid": "win-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/44c6ceec-db98-4123-a3fe-93ef2afc3ad5/ba06a9b2045ed9ed7f51cbe62ccdf401/dotnet-sdk-6.0.100-preview.1.21103.13-win-x64.zip",
+                        "hash": "49f4c9385aabf2f16a2744459c3428d49f1fcbf45095a9f03d866a75d28b460f1a44fbdf5e45709bb0e79d9bf44224390366e0a23ae4b5959c242525b3bab8aa"
+                    },
+                    {
+                        "name": "dotnet-sdk-win-x86.exe",
+                        "rid": "win-x86",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/fb137455-6524-4789-9339-e930175f181a/8b415c1334797ffed535317a9d29366e/dotnet-sdk-6.0.100-preview.1.21103.13-win-x86.exe",
+                        "hash": "b55e77ea2b8da0c3fda54a5b3efe3c599c556627ee3826bf5b4a09272be3f7dee302f7322328affb081950706f96dccd4fb110a473f35e55306e452ded502af3"
+                    },
+                    {
+                        "name": "dotnet-sdk-win-x86.zip",
+                        "rid": "win-x86",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/ea41603b-fdff-4e66-bdac-b9a76930a1eb/3b1547d83ef502c887c9d8f7a37df698/dotnet-sdk-6.0.100-preview.1.21103.13-win-x86.zip",
+                        "hash": "f3b64f77760d3ccc907da6dc84a6a3e54a770b2b641fb35b4f87e2145657a47894418fcba8a02ef361ac535c4508f6477af5356c12b233953e95d65c724eca23"
+                    }
+                ]
+            },
+            "sdks": [
+                {
+                    "version": "6.0.100-preview.1.21103.13",
+                    "version-display": "6.0.100-preview.1",
+                    "runtime-version": "6.0.0-preview.1.21102.12",
+                    "vs-version": "16.9",
+                    "vs-mac-version": "",
+                    "vs-support": "Visual Studio 2019 (v16.9 Preview 4)",
+                    "vs-mac-support": "",
+                    "csharp-version": "9.0",
+                    "fsharp-version": "5.0",
+                    "vb-version": "16.0",
+                    "files": [
+                        {
+                            "name": "dotnet-sdk-linux-arm.tar.gz",
+                            "rid": "linux-arm",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/3b62cfcf-589e-43b3-993b-517c70c93a22/0ecae846884376fecc5de8a4f6d6c927/dotnet-sdk-6.0.100-preview.1.21103.13-linux-arm.tar.gz",
+                            "hash": "05a5a0f9b3738042eedbce37105ceb95480ca8175d85ec7300c32949ee205a66b5e12583fff9f72d9161af56923842d388e6791f18aa7109a8c823461dd5d8d5"
+                        },
+                        {
+                            "name": "dotnet-sdk-linux-arm64.tar.gz",
+                            "rid": "linux-arm64",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/9143768a-e997-45b5-b818-e5b96ac0c24c/b5c7eb4476e9cdb56deb62d2a26f729d/dotnet-sdk-6.0.100-preview.1.21103.13-linux-arm64.tar.gz",
+                            "hash": "fe79c1554bea30039390e6c9efe00623338fdeb1f471d8c74b41d43d38230d383e215859905f4c057bfd1ba027f7f157c4d5d215f961d3663aed60dcbe870add"
+                        },
+                        {
+                            "name": "dotnet-sdk-linux-musl-x64.tar.gz",
+                            "rid": "linux-musl-x64",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/5d837dff-229d-47cf-b2cf-69dbb3a7e928/8863976e15b6d4391e3611fddb3c073e/dotnet-sdk-6.0.100-preview.1.21103.13-linux-musl-x64.tar.gz",
+                            "hash": "4b8002f608e5354651b9d82fa8442bca68be730dfdb54d026763635185457a23e5e071421bb04de8f8254fe36cc2134b430aaacb363911fd93276b7c34ad935c"
+                        },
+                        {
+                            "name": "dotnet-sdk-linux-x64.tar.gz",
+                            "rid": "linux-x64",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/579aac9e-53dd-404e-9452-9910bc9be422/1c47683215dd54a3837fc4b338ddb6a6/dotnet-sdk-6.0.100-preview.1.21103.13-linux-x64.tar.gz",
+                            "hash": "86f591c70c73732030210e8e7ce39b7b4e4a680098862e340a4a8726bcb3f981f0748baec0fce8c5c4a8615670a72ab92bfad8d0dc0a305401bbc5864116996a"
+                        },
+                        {
+                            "name": "dotnet-sdk-osx-x64.pkg",
+                            "rid": "osx-x64",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/f7224456-9898-45b6-8acc-b110900653cd/817c4e3b1ee787985fdf85032eb2752d/dotnet-sdk-6.0.100-preview.1.21103.13-osx-x64.pkg",
+                            "hash": "0e429d21e9c12f79fa8875670574d123389a4928d3c18d7fcd18fff50cdabb3faa8a2617011a9045b472b2192bcc4c5d5656cf57659357b395bd6fd21e88dd3c"
+                        },
+                        {
+                            "name": "dotnet-sdk-osx-x64.tar.gz",
+                            "rid": "osx-x64",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/e9e781b5-9b2e-4180-9f47-bfb5a5cf98b1/0ad0afbe2d322e521e15156089779f3e/dotnet-sdk-6.0.100-preview.1.21103.13-osx-x64.tar.gz",
+                            "hash": "f4c930c867399fbcffe5c345c54e0595c712419b910df7263b35fc4711307bd5cc3a7878d6e06caf4904d915f371b4ab53d8c763d02d1bbbbee586fb16c137ca"
+                        },
+                        {
+                            "name": "dotnet-sdk-win-arm64.exe",
+                            "rid": "win-arm64",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/69c0d82c-78d1-4cf6-b364-68fa96159166/57022ee819185466e0747ef7f48b6276/dotnet-sdk-6.0.100-preview.1.21103.13-win-arm64.exe",
+                            "hash": "cebded348d80d50e60924a2791e683e0751c00eb87ac94388b8f68320936889c92238e56b91b837ec0c87fffe86787d1a0aa412d95c011d8b682f52d72636727"
+                        },
+                        {
+                            "name": "dotnet-sdk-win-arm64.zip",
+                            "rid": "win-arm64",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/971194ae-f2fc-48d1-bf90-378f61591188/e7fbf3421848aa2edf3d360005630125/dotnet-sdk-6.0.100-preview.1.21103.13-win-arm64.zip",
+                            "hash": "66b6d3e4d7c3ccfcb99ec01f7b97601d8a20e5c9de2640b327099c5cde4e6e637f4ccd3d4ac94137684719a056bd05ed946ec628bd457288ca7d59ea24bbc376"
+                        },
+                        {
+                            "name": "dotnet-sdk-win-x64.exe",
+                            "rid": "win-x64",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/68e6514a-ec0f-46ea-a00a-76ec205c42cc/f68e27ee1a41320ad5e331ccd6bcab9f/dotnet-sdk-6.0.100-preview.1.21103.13-win-x64.exe",
+                            "hash": "e1800fbe29c667669f0d052dfd8a0d46b6e8b81e4929c2dabe2f2e853146edfa159dab348fe6cf9ab52176e1d99009f2f4281c8a548538fbf25a4d5c6fe5dbc6"
+                        },
+                        {
+                            "name": "dotnet-sdk-win-x64.zip",
+                            "rid": "win-x64",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/44c6ceec-db98-4123-a3fe-93ef2afc3ad5/ba06a9b2045ed9ed7f51cbe62ccdf401/dotnet-sdk-6.0.100-preview.1.21103.13-win-x64.zip",
+                            "hash": "49f4c9385aabf2f16a2744459c3428d49f1fcbf45095a9f03d866a75d28b460f1a44fbdf5e45709bb0e79d9bf44224390366e0a23ae4b5959c242525b3bab8aa"
+                        },
+                        {
+                            "name": "dotnet-sdk-win-x86.exe",
+                            "rid": "win-x86",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/fb137455-6524-4789-9339-e930175f181a/8b415c1334797ffed535317a9d29366e/dotnet-sdk-6.0.100-preview.1.21103.13-win-x86.exe",
+                            "hash": "b55e77ea2b8da0c3fda54a5b3efe3c599c556627ee3826bf5b4a09272be3f7dee302f7322328affb081950706f96dccd4fb110a473f35e55306e452ded502af3"
+                        },
+                        {
+                            "name": "dotnet-sdk-win-x86.zip",
+                            "rid": "win-x86",
+                            "url": "https://download.visualstudio.microsoft.com/download/pr/ea41603b-fdff-4e66-bdac-b9a76930a1eb/3b1547d83ef502c887c9d8f7a37df698/dotnet-sdk-6.0.100-preview.1.21103.13-win-x86.zip",
+                            "hash": "f3b64f77760d3ccc907da6dc84a6a3e54a770b2b641fb35b4f87e2145657a47894418fcba8a02ef361ac535c4508f6477af5356c12b233953e95d65c724eca23"
+                        }
+                    ]
+                }
+            ],
+            "aspnetcore-runtime": {
+                "version": "6.0.0-preview.1.21103.6",
+                "version-display": "6.0.0-preview.1",
+                "version-aspnetcoremodule": [
+                    "16.0.21034.0"
+                ],
+                "vs-version": "",
+                "files": [
+                    {
+                        "name": "aspnetcore-runtime-linux-arm.tar.gz",
+                        "rid": "linux-arm",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/f73111b7-fe98-46b5-8ee2-2daaa9dcd8f8/0e67eddf63fd2921f3712612be496762/aspnetcore-runtime-6.0.0-preview.1.21103.6-linux-arm.tar.gz",
+                        "hash": "05cd6808b256c24e16c91513da712e4dd9cb3189dbd6928cd5959c4805fd5f6fb4b5e6a4cf7156e0af81ca151eac22df185af09567de2cbda4bfc4b4ec3f86b6"
+                    },
+                    {
+                        "name": "aspnetcore-runtime-linux-arm64.tar.gz",
+                        "rid": "linux-arm64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/3071a61a-7fba-46b7-906f-0ccbf376e59e/7fbeb61db58c41427123d67e38efb0ea/aspnetcore-runtime-6.0.0-preview.1.21103.6-linux-arm64.tar.gz",
+                        "hash": "152b93a2b9ef2a481280ce3549b5fea1fe88b86c9c41f2c09499681ec6f485c978a68d484e25e00776bfc2cbc285e968dd4f0b0a9ddb83f57faea2dd3a71faa0"
+                    },
+                    {
+                        "name": "aspnetcore-runtime-linux-musl-arm64.tar.gz",
+                        "rid": "linux-musl-arm64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/2276322a-ce67-4751-b8cc-57203ed8b312/787fdcea85f8dfeea88cb64c5f63bfa2/aspnetcore-runtime-6.0.0-preview.1.21103.6-linux-musl-arm64.tar.gz",
+                        "hash": "75ffdc561476085ccb60472e9d74edd850973b762d0bce490bf3a011c8fc526c90cc04106a89d456735f43335387698c05e472113fa8f40c7741287b77b0f46a"
+                    },
+                    {
+                        "name": "aspnetcore-runtime-linux-musl-x64.tar.gz",
+                        "rid": "linux-musl-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/bbeeaef7-f491-40d1-a040-76ddad5589c7/9f5157798865425100c7b865ab02bef5/aspnetcore-runtime-6.0.0-preview.1.21103.6-linux-musl-x64.tar.gz",
+                        "hash": "b0bc62fbd4c0509e634828089637eb2c0fc326ebfc58913d09ccf7b47b09ad9133e77d2602ee478ac0c1fcad3c89affc48e374675f10457c4b4f6ccef2e2aec8"
+                    },
+                    {
+                        "name": "aspnetcore-runtime-linux-x64.tar.gz",
+                        "rid": "linux-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/46c95bce-e490-4f22-84a6-41258b6416bc/05c05a9eb8b7fe70d91285970d16263b/aspnetcore-runtime-6.0.0-preview.1.21103.6-linux-x64.tar.gz",
+                        "hash": "77b4b2c20c96cd8b4ec152c133f8c0501ab6f38bc3a949461bd0af1246bc2084d687f0c639dbbdf858948c496eaf86749e1ae45eb30ab8d31adca9abac5a7346"
+                    },
+                    {
+                        "name": "aspnetcore-runtime-osx-x64.tar.gz",
+                        "rid": "osx-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/9c1c4e05-2adb-4ea0-9d9a-f0c7406de9c0/af48195a4e770620a0721dd27fdcb4c9/aspnetcore-runtime-6.0.0-preview.1.21103.6-osx-x64.tar.gz",
+                        "hash": "9683bd26914c2312ab6f72dba742cadf364498e86def8633c7c57a6640d0140dd2cb05674b64f032f4d90a7f0a4856e66da793f5c99466d441367234ea7f3074"
+                    },
+                    {
+                        "name": "aspnetcore-runtime-win-arm64.zip",
+                        "rid": "win-arm64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/60be0841-3aec-4a13-8f42-2b2197b9cff7/23e3db6d14bfb2254e1d683ae9a6dd75/aspnetcore-runtime-6.0.0-preview.1.21103.6-win-arm64.zip",
+                        "hash": "dd0865c43d5248500a2e88b091bcb29d9f2b182f138660b144b12d0de23d803ba1e32b89fb86351d24bc190227e1447e4566ec849da845ef50ceeccab24ee60d"
+                    },
+                    {
+                        "name": "aspnetcore-runtime-win-x64.exe",
+                        "rid": "win-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/67eac8cf-f9e0-46a2-996c-04de0385aaeb/6f64f2b56712be7bd6dae93876268aa2/aspnetcore-runtime-6.0.0-preview.1.21103.6-win-x64.exe",
+                        "hash": "78a7cbde432e4ce7726363f04c7efb0da3cf31c8095ea68a2a68d7c6a8d6e8a0d3e20e772b285d02704808c7a37ebaac9b9d4c23ae23f102031c92b9b8448299"
+                    },
+                    {
+                        "name": "aspnetcore-runtime-win-x64.zip",
+                        "rid": "win-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/5306af41-ef80-43c8-b6d9-fbc52e6a055a/2187c965ece1546356bf4a6e18f61939/aspnetcore-runtime-6.0.0-preview.1.21103.6-win-x64.zip",
+                        "hash": "4fe16b63fc0276b4afc718bd33c1a3a8d101bfb29ecb7d89aa22e8c11e948529ead6fa3bca3dde95e69c8c2c205273fe117e02ca5131691ea243431f2af49d5e"
+                    },
+                    {
+                        "name": "aspnetcore-runtime-win-x86.exe",
+                        "rid": "win-x86",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/f2c1e6bc-6282-445a-af57-43fac5a00a61/9244b0c7f5fa793fdeddcb7012798632/aspnetcore-runtime-6.0.0-preview.1.21103.6-win-x86.exe",
+                        "hash": "048737341356cc2b9ccf62fe990d20d101e454390e80e361692912fc0208e4cae1af11376e4a9f412ef5db69ffcf6f525ed687cc7eef40bb86d214c2dbd79de5"
+                    },
+                    {
+                        "name": "aspnetcore-runtime-win-x86.zip",
+                        "rid": "win-x86",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/b26b6b55-2805-4ca1-ab4b-4a256b22446e/a1848abbac5253864c89bd9ad822e441/aspnetcore-runtime-6.0.0-preview.1.21103.6-win-x86.zip",
+                        "hash": "67e4d94f6645510bbf78bfd5ac9d17ff512f335a2207ef1d16a72e9ec7e6b9fd8b27e14b1a34bd6f095478f641051d20cb6429524c338bf084167aa75dcb2810"
+                    },
+                    {
+                        "name": "dotnet-hosting-win.exe",
+                        "rid": "",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/668a80ef-ab83-4680-bdc5-e5e787a1c051/3d10f1e68c802a4e60e9dd45ffd7c32a/dotnet-hosting-6.0.0-preview.1.21103.6-win.exe",
+                        "hash": "46e3b98a2aff2125dd23e968bb66e117934208a176ef86067fea5c7f1e7ed9e8a9b8913933067fda02af7f787a5307d4fde18b2f33417e92982c762f5e910925",
+                        "akams": "https://aka.ms/dotnetcore-6-0-windowshosting"
+                    }
+                ]
+            },
+            "windowsdesktop": {
+                "version": "6.0.0-preview.1.21103.5",
+                "version-display": "6.0.0-preview.1",
+                "files": [
+                    {
+                        "name": "windowsdesktop-runtime-win-x64.exe",
+                        "rid": "win-x64",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/f0b993bb-ac67-4e10-b2b3-193c426dbb32/25aff17ca340404619c01ce5c3b863e9/windowsdesktop-runtime-6.0.0-preview.1.21103.5-win-x64.exe",
+                        "hash": "681d0388e06087a5ef077eab2a756a0ad4ca14270778b1fad8607119e37985f85d305fa57300d2a66006b3a9c97321bbfb6ab73a9717d0eae80af92b62f99838"
+                    },
+                    {
+                        "name": "windowsdesktop-runtime-win-x86.exe",
+                        "rid": "win-x86",
+                        "url": "https://download.visualstudio.microsoft.com/download/pr/4dcdf96f-efab-4e31-9958-a94d9e2d9941/55ba1027551e3c6c554c4687a2e31abc/windowsdesktop-runtime-6.0.0-preview.1.21103.5-win-x86.exe",
+                        "hash": "dab5ea83d60c04531a47a39977d5ec9f44b936eb5014caefd10dabd8443d89ab79bf2b19e48d0260f2fc94a07d24baacb841fd556250b9c5e4e8891a78ee93f3"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Added `DebuggerDisplay` attributes to `Product` and `ProductRelease` classes:

![image](https://user-images.githubusercontent.com/7679720/108860337-b7e89180-75b3-11eb-911c-53bce2d83a76.png)

- Minor clean up for readability
- Use C# 8
- Using declarations
- Pattern matching
- Tuples
- Use `string.IsNullOrWhiteSpace` instead of `string.IsNullOrEmpty`
- Remove redundant parenthesis
- More consistent usage of `var`, following _.editorconfig_
- Prefer object/collection initializers
- Use discards where appropriate
- Prefer expression bodied members where possible
- Ternary expressions, each branch on it's own line when spanning multiple lines
- Added release 6.0 to test cases
- Update unit tests accordingly

/cc @joeloff 