### PR TITLE
Enable updates with minimum version

### DIFF
--- a/src/clickonce/MageCLI/Command.cs
+++ b/src/clickonce/MageCLI/Command.cs
@@ -705,6 +705,11 @@ namespace Microsoft.Deployment.MageCLI
                     {
                         Version v = new Version(isRequiredUpdateString);
                         minVersion = isRequiredUpdateString;
+
+                        // Specifying minimum version implies that the app will get installed.
+                        // We will set 'install' to true, otherwise, app will not check for future updates.
+                        // Install value can still be overridden on command line, see next code block.
+                        install = TriStateBool.True;
                     }
                     catch (ArgumentOutOfRangeException)
                     {
@@ -718,30 +723,22 @@ namespace Microsoft.Deployment.MageCLI
             // Validate the Install option, if given
             if (installString != null)
             {
-                if (!string.IsNullOrEmpty(minVersion))
+                switch (installString.ToLower(CultureInfo.InvariantCulture))
                 {
-                    Application.PrintErrorMessage(ErrorMessages.InvalidMinVersion, minVersion);
-                    result = false;
-                }
-                else
-                {
-                    switch (installString.ToLower(CultureInfo.InvariantCulture))
-                    {
-                        case "true":
-                        case "t":
-                            install = TriStateBool.True;
-                            break;
+                    case "true":
+                    case "t":
+                        install = TriStateBool.True;
+                        break;
 
-                        case "false":
-                        case "f":
-                            install = TriStateBool.False;
-                            break;
+                    case "false":
+                    case "f":
+                        install = TriStateBool.False;
+                        break;
 
-                        default:
-                            result = false;
-                            Application.PrintErrorMessage(ErrorMessages.InvalidInstall, installString);
-                            break;
-                    }
+                    default:
+                        result = false;
+                        Application.PrintErrorMessage(ErrorMessages.InvalidInstall, installString);
+                        break;
                 }
             }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/deployment-tools/issues/101

When specifying minimum version, app stops checking for updates. This is different from VS experience, where you can specify that app checks for updates and requires a specific minimum version.

This is a simple change, that follows Mage tool's documentation which already specifies that `-mv` option would make the app installable. The fix enforces that, and reestablishes default Mage experience - apps being installed should check for updates.

The change includes removal of the block that prevented user from specifying both `-install` and `-mv` options. This allows user to override new decision, to make install true if `-mv` is specified, for compatibility. Note that Mage documentation implies that `-install` and `-mv` options are not mutually exclusive, so this is also a fix.

Mage documentation: https://docs.microsoft.com/en-us/dotnet/framework/tools/mage-exe-manifest-generation-and-editing-tool