### PR TITLE
Temporarily disable building native projects

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -70,7 +70,7 @@
 
   <PropertyGroup>
     <!-- Temporarily disable ClickOnce native build due to compiler mismatch issue with libnethost.lib -->
-    <DisableClickOnceNativeBuild>false</DisableClickOnceNativeBuild>
+    <DisableClickOnceNativeBuild>true</DisableClickOnceNativeBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Temporarily disable building native projects, to unblock e2e CI build.