### PR TITLE
Update tag references to dotnet-buildtools/prereqs

### DIFF
--- a/tools-local/scripts/arm32_ci_script.sh
+++ b/tools-local/scripts/arm32_ci_script.sh
@@ -174,11 +174,11 @@ function cross_build_core_setup_with_docker {
         # TODO: For arm, we are going to embed RootFS inside Docker image.
         case $__linuxCodeName in
         trusty)
-            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20172211042239"
+            __dockerImage=" mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-0cd4667-20172211042239"
             __runtimeOS="ubuntu.14.04"
         ;;
         xenial)
-            __dockerImage=" microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-ef0ac75-20175511035548"
+            __dockerImage=" mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-ef0ac75-20175511035548"
             __runtimeOS="ubuntu.16.04"
         ;;
         *)

--- a/tools-local/scripts/dev/master-build-deb-rpm-docker.sh
+++ b/tools-local/scripts/dev/master-build-deb-rpm-docker.sh
@@ -84,15 +84,15 @@ package() {
         > "info-$type.txt"
 }
 
-[ "$skipPortable" ] || containerized microsoft/dotnet-buildtools-prereqs:centos-7-b46d863-20180719033416 \
+[ "$skipPortable" ] || containerized mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-b46d863-20180719033416 \
     ./build.sh \
     -c Release \
     /p:PortableBuild=true \
     /p:TargetArchitecture=x64 \
     /bl:artifacts/msbuild.portable.binlog
 
-ubuntu=microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-debpkg-e5cf912-20175003025046
-rhel=microsoft/dotnet-buildtools-prereqs:rhel-7-rpmpkg-c982313-20174116044113
+ubuntu=mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-debpkg-e5cf912-20175003025046
+rhel=mcr.microsoft.com/dotnet-buildtools/prereqs:rhel-7-rpmpkg-c982313-20174116044113
 
 [ "$makeRpm" ] && package rhel $rhel rpm "rpm -qpiR"
 [ "$makeDeb" ] && package ubuntu $ubuntu deb "dpkg-deb -I"

--- a/tools-local/scripts/dev/release-2.1-build-deb-rpm-docker.sh
+++ b/tools-local/scripts/dev/release-2.1-build-deb-rpm-docker.sh
@@ -84,7 +84,7 @@ package() {
         > "info-$type.txt"
 }
 
-[ "$skipPortable" ] || containerized microsoft/dotnet-buildtools-prereqs:centos-7-b46d863-20180719033416 \
+[ "$skipPortable" ] || containerized mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-b46d863-20180719033416 \
     ./build.sh \
     -skiptests=true \
     -ConfigurationGroup=Release \
@@ -94,8 +94,8 @@ package() {
     -- \
     /bl:bin/msbuild.portable.binlog
 
-ubuntu=microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-debpkg-e5cf912-20175003025046
-rhel=microsoft/dotnet-buildtools-prereqs:rhel-7-rpmpkg-c982313-20174116044113
+ubuntu=mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-debpkg-e5cf912-20175003025046
+rhel=mcr.microsoft.com/dotnet-buildtools/prereqs:rhel-7-rpmpkg-c982313-20174116044113
 
 package ubuntu $ubuntu deb "dpkg-deb -I"
 package rhel $rhel rpm "rpm -qpiR"


### PR DESCRIPTION
Updating Docker image tag references that are obsolete and replaced by references to mcr.microsoft.com/dotnet-buildtools/prereqs. See dotnet/dotnet-docker#2848.