### PR TITLE
Add method to parse single release.json files

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs
@@ -198,6 +198,18 @@ namespace Microsoft.Deployment.DotNet.Releases
             return SupportPhase == SupportPhase.EOL || EndOfLifeDate?.Date <= DateTime.Now.Date;
         }
 
+        /// <summary>
+        /// Gets a collection of all releases defined in the specified file.
+        /// </summary>
+        /// <param name="path">The path of the file containing the releases data.</param>
+        /// <returns>A collection of releases. The releases are not linked to a specific <see cref="Product"/>.</returns>
+        public static async Task<ReadOnlyCollection<ProductRelease>> GetReleasesAsync(string path)
+        {
+            using TextReader reader = File.OpenText(path);
+
+            return await GetReleasesAsync(reader, null);
+        }
+
         private static async Task<ReadOnlyCollection<ProductRelease>> GetReleasesAsync(TextReader reader, Product product)
         {
             if (reader == null)

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ProductReleaseTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ProductReleaseTests.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace Microsoft.Deployment.DotNet.Releases.Tests
 {
@@ -32,6 +33,15 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
             var release = ProductReleases[productVersion].Where(r => r.Version == productReleaseVersion).FirstOrDefault();
 
             Assert.Equal(release.Product.ProductVersion, productVersion);
+        }
+
+        [Fact]
+        public async Task ItCanCreateASingleRelease()
+        {
+            var releases = await Product.GetReleasesAsync(@"data\5.0\releases.json");
+
+            Assert.Equal(new ReleaseVersion("5.0.0-preview.7"), releases[0].Version);
+            Assert.Null(releases[0].Product);
         }
     }
 }


### PR DESCRIPTION
Address #116 

Processing releases currently requires starting with an index file, either local or remote. We have need to process standalone releases.json files to support various tools, especially where a new release is being published, before being merged into the existing releases.json.