### PR TITLE
#113 - Allow `Launcher.exe` to pass through the `ActivationData` arguments

### DIFF
--- a/src/clickonce/launcher/ProcessHelper.cs
+++ b/src/clickonce/launcher/ProcessHelper.cs
@@ -16,12 +16,21 @@ namespace Microsoft.Deployment.Launcher
         /// </summary>
         /// <param name="exe">Executable name</param>
         /// <param name="args">Arguments</param>
-        public ProcessHelper(string exe, string args)
+        /// <param name="activationData">Activation Data (if any)</param>
+        public ProcessHelper(string exe, string args, string[] activationData)
         {
             psi = new ProcessStartInfo(exe, args)
             {
                 UseShellExecute = false
             };
+
+            if (activationData != null)
+            {
+                // store activation data in the environment variables
+                // of the process being launched.
+                for (int i = 0; i < activationData.Length; i++)
+                    psi.EnvironmentVariables[$"CLICKONCE_ACTIVATIONDATA_{i + 1}"] = activationData[i];
+            }
         }
 
         /// <summary>

--- a/src/clickonce/launcher/Program.cs
+++ b/src/clickonce/launcher/Program.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Deployment.Launcher
                     throw new LauncherException(Constants.ErrorNotAClickOnceDeployment);
                 }
 
-                Launch(GetApplicationPath());
+                string[] activationData = AppDomain.CurrentDomain.SetupInformation.ActivationArguments?.ActivationData;
+                Launch(GetApplicationPath(), activationData);
 
             }
             catch (Exception e)
@@ -43,7 +44,7 @@ namespace Microsoft.Deployment.Launcher
         /// Launches .NET (Core) application.
         /// </summary>
         /// <param name="appToLaunchFullPath">Full path to application binary</param>
-        private static void Launch(string appToLaunchFullPath)
+        private static void Launch(string appToLaunchFullPath, string[] activationData)
         {
             string exe;
             string args;
@@ -65,7 +66,7 @@ namespace Microsoft.Deployment.Launcher
                 throw new LauncherException(Constants.ErrorUnsupportedExtension, appToLaunchFullPath);
             }
 
-            ProcessHelper ph = new ProcessHelper(exe, args);
+            ProcessHelper ph = new ProcessHelper(exe, args, activationData);
             ph.StartProcessWithRetries();
         }
 


### PR DESCRIPTION
Allow `Launcher.exe` pass through the `ApplicationData` arguments to the clickonce application as process scoped environment variables (`CLICKONCE_ACTIVATIONDATA_1`, `CLICKONCE_ACTIVATIONDATA_2`, etc.). This is important in order to get the command line arguments and other information into the clickonce-packaged application runtime. This change directly addresses the issue #113.

This change is backwards compatible, doesn't require any API changes. It does require some effort from the application developers to actually read and parse the environment variables for `CLICKONCE_ACTIVATIONDATA_x` variables, but i wanted to make the change as least invasive as possible.

I couldn't find any existing tests for `Launcher.exe`, but i did test the change locally and it worked fine.

In the following example the name of the file (using file associations in ClickOnce) is passed through by `Launcher.exe` as a process scoped environment variable:
![image](https://user-images.githubusercontent.com/13695064/131595557-1afd8d1c-65e4-4942-84e9-cb9341b86700.png)
