### PR TITLE
Revert version to preview2 to unblock CI

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PreReleaseVersionLabel></PreReleaseVersionLabel>
-    <PreReleaseVersionIteration></PreReleaseVersionIteration>
-    <DotNetFinalVersionKind>true</DotNetFinalVersionKind>
+    <PreReleaseVersionLabel>preview2</PreReleaseVersionLabel>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Revert stable version to preview2 for now until we figure out the separate release process within the repo.

Should address #142 