### PR TITLE
Fix desktop release component name

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/WindowsDesktopReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/WindowsDesktopReleaseComponent.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <summary>
         /// The friendly display name for the component.
         /// </summary>
-        public override string Name => ReleasesResources.RuntimeReleaseName;
+        public override string Name => ReleasesResources.WindowsDesktopReleaseName;
 
         internal WindowsDesktopReleaseComponent(JToken token, ProductRelease release) : base(token, release)
         {

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ReleaseComponentTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ReleaseComponentTests.cs
@@ -23,5 +23,21 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
 
             Assert.All(release.Files, f => Assert.True(!f.Name.Contains("-gs") && !f.Name.Contains("-nj")));
         }
+
+        [Fact]
+        public void ReleaseComponentNames()
+        {
+            var release = GetProductRelease("3.1", "3.1.5");
+
+            var sdkComponent = release.Sdks.FirstOrDefault();
+            var aspNetComponent = release.AspNetCoreRuntime;
+            var runtimeComponent = release.Runtime;
+            var desktopComponent = release.WindowsDesktopRuntime;
+
+            Assert.Equal("SDK", sdkComponent.Name);
+            Assert.Equal("ASP.NET Core Runtime", aspNetComponent.Name);
+            Assert.Equal(".NET Core Runtime", runtimeComponent.Name);
+            Assert.Equal("Desktop Runtime", desktopComponent.Name);
+        }
     }
 }


### PR DESCRIPTION
The desktop component name was using the .NET runtime resource string. The change also includes a test to catch this in the future