### PR TITLE
Include SDK files in the File property, exclude marketing files

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/ProductRelease.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ProductRelease.cs
@@ -158,21 +158,18 @@ namespace Microsoft.Deployment.DotNet.Releases
             if (!aspNetCoreRuntimeToken.IsNullOrEmpty())
             {
                 AspNetCoreRuntime = new AspNetCoreReleaseComponent(aspNetCoreRuntimeToken, this);
-                componentList.Add(AspNetCoreRuntime);
                 runtimeList.Add(AspNetCoreRuntime);
             }
 
             if (!runtimeToken.IsNullOrEmpty())
             {
                 Runtime = new RuntimeReleaseComponent(runtimeToken, this);
-                componentList.Add(Runtime);
                 runtimeList.Add(Runtime);
             }
 
             if (!winDesktopToken.IsNullOrEmpty())
             {
                 WindowsDesktopRuntime = new WindowsDesktopReleaseComponent(winDesktopToken, this);
-                componentList.Add(WindowsDesktopRuntime);
                 runtimeList.Add(WindowsDesktopRuntime);
             }
 
@@ -190,6 +187,9 @@ namespace Microsoft.Deployment.DotNet.Releases
             {
                 sdkList.Add(new SdkReleaseComponent(sdkToken, this));
             }
+
+            componentList.AddRange(runtimeList);
+            componentList.AddRange(sdkList);
 
             Sdks = new ReadOnlyCollection<SdkReleaseComponent>(sdkList);
             Components = new ReadOnlyCollection<ReleaseComponent>(componentList);

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseComponent.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Deployment.DotNet.Releases
 
             // Trim out marketing files. Users should never interact with these
             Files = new ReadOnlyCollection<ReleaseFile>(
-                fileList.Where(f => !f.Name.Contains("-gs") || !f.Name.Contains("-nj")).ToList());
+                fileList.Where(f => !(f.Name.Contains("-gs") || f.Name.Contains("-nj"))).ToList());
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ProductReleaseTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ProductReleaseTests.cs
@@ -36,6 +36,15 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         }
 
         [Fact]
+        public void ItContainsAllFiles()
+        {
+            ProductRelease release = GetProductRelease("2.1", "2.1.8");
+
+            Assert.Equal(33, release.Files.Count);
+            Assert.Empty(release.Files.Where(f => f.FileName.Contains("-gs")));
+        }
+
+        [Fact]
         public async Task ItCanCreateASingleRelease()
         {
             var releases = await Product.GetReleasesAsync(@"data\5.0\releases.json");


### PR DESCRIPTION
The ProductRelease.File property did not include SDK files. The SDK files also included marketing files incorrectly.