### PR TITLE
Fix comparison for numeric identifiers

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseVersion.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseVersion.cs
@@ -547,7 +547,7 @@ namespace Microsoft.Deployment.DotNet.Releases
                 return 1;
             }
 
-            if (b.Length < a.Length)
+            if (a.Length < b.Length)
             {
                 return -1;
             }
@@ -557,7 +557,7 @@ namespace Microsoft.Deployment.DotNet.Releases
             // between 1 and -1 depending on the ordinal value
             // of the character at the current index.
             int r = 0;
-            for (int i = a.Length - 1; i > 0; i--)
+            for (int i = a.Length - 1; i >= 0; i--)
             {
                 int r2 = a[i].CompareTo(b[i]);
                 if (r2 != 0)

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ReleaseVersionTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ReleaseVersionTests.cs
@@ -192,6 +192,20 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
             Assert.True(v1 == v2);
         }
 
+        [Theory]
+        [InlineData("1.0.0-preview.4", "1.0.0-preview.5", -1)]
+        [InlineData("1.0.0-preview.4", "1.0.0-preview.4", 0)]
+        [InlineData("1.0.0-preview.1234567890123456", "1.0.0-preview.12345678901234567", -1)]
+        [InlineData("1.0.0-preview.1.2", "1.0.0-preview.2", -1)]
+        [InlineData("1.0.0-preview.1.2.3.4.6", "1.0.0-preview.1.2.3.4.5", 1)]
+        public void CompareToIncludesPrecedence(string version1, string version2, int expectedResult)
+        {
+            ReleaseVersion v1 = new ReleaseVersion(version1);
+            ReleaseVersion v2 = new ReleaseVersion(version2);
+
+            Assert.Equal(expectedResult, v1.CompareTo(v2));
+        }
+
         [Fact]
         public void OperatorNotEquals()
         {


### PR DESCRIPTION
Comparisons for numeric identifiers was missing good test cases which didn't catch this issue previously. It failed for single digit values and performed an incorrect comparison when the numeric identifiers were off different lengths.