### PR TITLE
Migrate to 1ES hosted pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,8 +94,8 @@ stages:
         publishUsingPipelines: true
         dependsOn: PrepareSignedArtifacts
         pool:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2017
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals build.windows.10.amd64.vs2017
 
 # Stages-based publishing entry point
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -24,11 +24,11 @@ jobs:
         name: dnceng-freebsd-internal
       ${{ if ne(parameters.name, 'FreeBSD_x64') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: buildpool.ubuntu.1604.amd64.open
+          name: NetCore1ESPool-Public
+          demands: ImageOverride -equals build.ubuntu.1604.amd64.open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.ubuntu.1604.amd64
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals build.ubuntu.1604.amd64
     strategy: ${{ parameters.strategy }}
     variables:
       # Preserve the NuGet authentication env vars into the Docker container.

--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -7,8 +7,8 @@ jobs:
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    name: NetCoreInternal-Pool
-    queue: buildpool.windows.10.amd64.vs2017
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals build.windows.10.amd64.vs2017
   # Double the default timeout.
   timeoutInMinutes: 120
   workspace:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -13,11 +13,11 @@ jobs:
     pool:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2019.open
+        name: NetCore1ESPool-Public
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2019
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019
     strategy:
       matrix: 
         debug:


### PR DESCRIPTION
We are moving to 1ES hosted pools. This PR update pipeline yaml to use new pools.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276

/cc: @jonfortescue 