### PR TITLE
[release/5.0] Migrate to 1ES hosted pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ stages:
         publishUsingPipelines: true
         dependsOn: PrepareSignedArtifacts
         pool:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2017
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals build.windows.10.amd64.vs2017
 
   - template: /eng/stages/publish.yml

--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -24,11 +24,11 @@ jobs:
         name: dnceng-freebsd-internal
       ${{ if ne(parameters.name, 'FreeBSD_x64') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: buildpool.ubuntu.1604.amd64.open
+          name: NetCore1ESPool-Public
+          demands: ImageOverride -equals build.ubuntu.1604.amd64.open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.ubuntu.1604.amd64
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals build.ubuntu.1604.amd64
     strategy: ${{ parameters.strategy }}
     variables:
       # Preserve the NuGet authentication env vars into the Docker container.

--- a/eng/jobs/bash-build.yml
+++ b/eng/jobs/bash-build.yml
@@ -25,10 +25,10 @@ jobs:
       ${{ if ne(parameters.name, 'FreeBSD_x64') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Public
-          demands: ImageOverride -equals build.ubuntu.1604.amd64.open
+          demands: ImageOverride -equals build.ubuntu.1804.amd64.open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals build.ubuntu.1604.amd64
+          demands: ImageOverride -equals build.ubuntu.1804.amd64
     strategy: ${{ parameters.strategy }}
     variables:
       # Preserve the NuGet authentication env vars into the Docker container.

--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -7,8 +7,8 @@ jobs:
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    name: NetCoreInternal-Pool
-    queue: buildpool.windows.10.amd64.vs2017
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals build.windows.10.amd64.vs2017
   # Double the default timeout.
   timeoutInMinutes: 120
   workspace:

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -13,11 +13,11 @@ jobs:
     pool:
       # Use a hosted pool when possible.
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCorePublic-Pool
-        queue: buildpool.windows.10.amd64.vs2019.open
+        name: NetCore1ESPool-Public
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCoreInternal-Pool
-        queue: buildpool.windows.10.amd64.vs2019
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals build.windows.10.amd64.vs2019
     strategy:
       matrix: 
         debug:


### PR DESCRIPTION
Same as https://github.com/dotnet/deployment-tools/pull/166 but for `release/5.0` branch.

/cc: @jonfortescue 