### PR TITLE
Dotnet-mage should target net6.0

### DIFF
--- a/src/clickonce/MageCLI/Certificate.cs
+++ b/src/clickonce/MageCLI/Certificate.cs
@@ -283,7 +283,9 @@ namespace Microsoft.Deployment.Utilities
                             parameters.Flags |= CspProviderFlags.UseMachineKeyStore;
                         }
 
+#pragma warning disable SYSLIB0028
                         certificate.PrivateKey = new RSACryptoServiceProvider(parameters);
+#pragma warning restore SYSLIB0028
                     }
                     else
                     {

--- a/src/clickonce/MageCLI/Command.cs
+++ b/src/clickonce/MageCLI/Command.cs
@@ -1476,8 +1476,10 @@ namespace Microsoft.Deployment.MageCLI
                 Sha256SignatureMethodUri);
 
 #if RUNTIME_TYPE_NETCORE
+#pragma warning disable SYSLIB0021
             CryptoConfig.AddAlgorithm(typeof(SHA256Managed),
                 Sha256DigestMethod);
+#pragma warning restore SYSLIB0021
 #else
             CryptoConfig.AddAlgorithm(typeof(SHA256Cng),
                 Sha256DigestMethod);

--- a/src/clickonce/MageCLI/Mage.cs
+++ b/src/clickonce/MageCLI/Mage.cs
@@ -261,6 +261,11 @@ namespace Microsoft.Deployment.MageCLI
                 }
                 else
                 {
+#if RUNTIME_TYPE_NETCORE
+                    // GetRegisteredOrganization() is a Windows-only API
+                    manifest.Publisher = string.Empty;
+                    if (OperatingSystem.IsWindows())
+#endif
                     // Get the default publisher name
                     manifest.Publisher = Utilities.Misc.GetRegisteredOrganization();
                 }
@@ -359,6 +364,11 @@ namespace Microsoft.Deployment.MageCLI
             }
             else
             {
+#if RUNTIME_TYPE_NETCORE
+                // GetRegisteredOrganization() is a Windows-only API
+                manifest.Publisher = string.Empty;
+                if (OperatingSystem.IsWindows())
+#endif
                 // Get the default publisher name
                 manifest.Publisher = Utilities.Misc.GetRegisteredOrganization();
             }

--- a/src/clickonce/MageCLI/MageCLI.csproj
+++ b/src/clickonce/MageCLI/MageCLI.csproj
@@ -6,7 +6,7 @@
     <SignAssemblyAttribute>true</SignAssemblyAttribute>
     <RCSuppressManifest>true</RCSuppressManifest>
     <AssemblyAttributeClsCompliant>false</AssemblyAttributeClsCompliant>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformSpecificBuild>true</PlatformSpecificBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/src/clickonce/MageCLI/Misc.cs
+++ b/src/clickonce/MageCLI/Misc.cs
@@ -5,6 +5,9 @@ using System;
 using System.IO;
 using System.Xml;
 using Microsoft.Win32;
+#if RUNTIME_TYPE_NETCORE
+using System.Runtime.Versioning;
+#endif
 
 namespace Microsoft.Deployment.Utilities
 {
@@ -148,6 +151,9 @@ namespace Microsoft.Deployment.Utilities
         /// Get the default publisher name 
         /// </summary>
         /// <returns>Publisher name</returns>
+#if RUNTIME_TYPE_NETCORE
+        [SupportedOSPlatform("windows")]
+#endif
         internal static string GetRegisteredOrganization()
         {
             string result = string.Empty;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/deployment-tools/issues/170

Updating dotnet-mage tool to target .NET 6.

Includes changes in code to work-around updates in API support and platform applicability.

Tested on docker image: mcr.microsoft.com/dotnet/sdk:6.0-windowsservercore-ltsc2019
