### PR TITLE
Clean up parsing logic for ReleaseVersion

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -22,6 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Deployment.DotNet.Releases.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseVersion.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseVersion.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="obj">An object to compare or null.</param>
         /// <returns>
         /// Returns a signed integer indicating whether this instance precedes, follows or appears in the same position in 
-        /// the sort order as the specified <paramref name="obj"/>.
+        /// the sort order as the <paramref name="obj"/> parameter.
         /// </returns>
         public int CompareTo(object obj) => CompareTo((ReleaseVersion)obj);
 
@@ -224,7 +224,10 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// Compares this instance to the specified object and returns an indication of their relative values.
         /// </summary>
         /// <param name="other">An object to compare.</param>
-        /// <returns></returns>
+        /// <returns>
+        /// Returns a signed integer indicating whether this instance precedes, follows or appears in the same position in 
+        /// the sort order as the <paramref name="other"/> parameter.
+        /// </returns>
         public int CompareTo(ReleaseVersion other)
         {
             int result = ComparePrecedenceTo(other);
@@ -550,8 +553,8 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// </summary>
         /// <param name="input">A string that contains a version to convert.</param>
         /// <returns>An object that is equivalent to the version number specified in the <paramref name="input"/> parameter.</returns>
-        /// <exception cref="ArgumentNullException" />
-        /// <exception cref="FormatException" />
+        /// <exception cref="ArgumentNullException">If <paramref name="input"/> is <see langword="null"/>.</exception>
+        /// <exception cref="FormatException">If <paramref name="input"/> contains an invalid version.</exception>
         public static ReleaseVersion Parse(string input)
         {
             if (input == null)

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleasesResources.Designer.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleasesResources.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.Deployment.DotNet.Releases {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The build metadata cannot be empty if a separator is provided..
+        /// </summary>
+        internal static string BuildMetadataCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("BuildMetadataCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not find the specified file: {0}.
         /// </summary>
         internal static string FileNotFound {
@@ -156,6 +165,15 @@ namespace Microsoft.Deployment.DotNet.Releases {
         internal static string InvalidVersion {
             get {
                 return ResourceManager.GetString("InvalidVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The prerelease value cannot be empty if a separator is provided..
+        /// </summary>
+        internal static string PrereleaseCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("PrereleaseCannotBeEmpty", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleasesResources.Designer.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleasesResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Deployment.DotNet.Releases {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ReleasesResources {
@@ -115,6 +115,15 @@ namespace Microsoft.Deployment.DotNet.Releases {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid numeric identifier: &apos;{0}&apos;..
+        /// </summary>
+        internal static string InvalidNumericIdentifier {
+            get {
+                return ResourceManager.GetString("InvalidNumericIdentifier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid or missing patch version..
         /// </summary>
         internal static string InvalidPatch {
@@ -133,7 +142,16 @@ namespace Microsoft.Deployment.DotNet.Releases {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid version: {0}.
+        ///   Looks up a localized string similar to The specified version is not a valid semantic version..
+        /// </summary>
+        internal static string InvalidReleaseVersion {
+            get {
+                return ResourceManager.GetString("InvalidReleaseVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The specified version does not contain a valid major, minor, and patch version: &apos;{0}&apos;..
         /// </summary>
         internal static string InvalidVersion {
             get {
@@ -169,7 +187,7 @@ namespace Microsoft.Deployment.DotNet.Releases {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;{0}&apos; value cannot be less than 0..
+        ///   Looks up a localized string similar to The value cannot be less than 0..
         /// </summary>
         internal static string VersionPartLessThanZero {
             get {

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleasesResources.resx
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleasesResources.resx
@@ -135,14 +135,20 @@
   <data name="InvalidMinorVersion" xml:space="preserve">
     <value>Invalid or missing minor version.</value>
   </data>
+  <data name="InvalidNumericIdentifier" xml:space="preserve">
+    <value>Invalid numeric identifier: '{0}'.</value>
+  </data>
   <data name="InvalidPatch" xml:space="preserve">
     <value>Invalid or missing patch version.</value>
   </data>
   <data name="InvalidPrerelease" xml:space="preserve">
     <value>The prerelease value is invalid: {0}</value>
   </data>
+  <data name="InvalidReleaseVersion" xml:space="preserve">
+    <value>The specified version is not a valid semantic version.</value>
+  </data>
   <data name="InvalidVersion" xml:space="preserve">
-    <value>Invalid version: {0}</value>
+    <value>The specified version does not contain a valid major, minor, and patch version: '{0}'.</value>
   </data>
   <data name="RuntimeReleaseName" xml:space="preserve">
     <value>.NET Core Runtime</value>
@@ -154,7 +160,7 @@
     <value>Value cannot be empty.</value>
   </data>
   <data name="VersionPartLessThanZero" xml:space="preserve">
-    <value>The '{0}' value cannot be less than 0.</value>
+    <value>The value cannot be less than 0.</value>
   </data>
   <data name="WindowsDesktopReleaseName" xml:space="preserve">
     <value>Desktop Runtime</value>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleasesResources.resx
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleasesResources.resx
@@ -120,6 +120,9 @@
   <data name="AspNetCoreReleaseName" xml:space="preserve">
     <value>ASP.NET Core Runtime</value>
   </data>
+  <data name="BuildMetadataCannotBeEmpty" xml:space="preserve">
+    <value>The build metadata cannot be empty if a separator is provided.</value>
+  </data>
   <data name="FileNotFound" xml:space="preserve">
     <value>Could not find the specified file: {0}</value>
   </data>
@@ -149,6 +152,9 @@
   </data>
   <data name="InvalidVersion" xml:space="preserve">
     <value>The specified version does not contain a valid major, minor, and patch version: '{0}'.</value>
+  </data>
+  <data name="PrereleaseCannotBeEmpty" xml:space="preserve">
+    <value>The prerelease value cannot be empty if a separator is provided.</value>
   </data>
   <data name="RuntimeReleaseName" xml:space="preserve">
     <value>.NET Core Runtime</value>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.cs.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Modul runtime ASP.NET Core</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="translated">Nepovedlo se najít zadaný soubor: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.cs.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Podverze není platná nebo chybí.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="translated">Verze opravy není platná nebo chybí.</target>
@@ -42,9 +47,14 @@
         <target state="translated">Hodnota předběžné verze není platná: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="translated">Neplatná verze: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="translated">Hodnota {0} nemůže být menší než 0.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.de.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">ASP.NET Core-Runtime</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="translated">Die angegebene Datei wurde nicht gefunden: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.de.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Ungültige oder fehlende Nebenversion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="translated">Ungültige oder fehlende Patchversion.</target>
@@ -42,9 +47,14 @@
         <target state="translated">Der Wert für die Vorabversion ist ungültig: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="translated">Ungültige Version: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="translated">Der Wert für "{0}" darf nicht unter 0 liegen.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.es.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">ASP.NET Core Runtime</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="translated">No se encontró el archivo especificado: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.es.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Falta la versión secundaria o no es válida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="translated">Falta la versión de revisión o no es válida.</target>
@@ -42,9 +47,14 @@
         <target state="translated">El valor de versión preliminar no es válido: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="translated">Versión no válida: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="translated">El valor "{0}" no puede ser menor que 0.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.fr.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="new">ASP.NET Core Runtime</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="new">Could not find the specified file: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.fr.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.fr.xlf
@@ -32,6 +32,11 @@
         <target state="new">Invalid or missing minor version.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="new">Invalid or missing patch version.</target>
@@ -42,9 +47,14 @@
         <target state="new">The prerelease value is invalid: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="new">Invalid version: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="new">The '{0}' value cannot be less than 0.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.it.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.it.xlf
@@ -7,6 +7,11 @@
         <target state="new">ASP.NET Core Runtime</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="new">Could not find the specified file: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.it.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.it.xlf
@@ -32,6 +32,11 @@
         <target state="new">Invalid or missing minor version.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="new">Invalid or missing patch version.</target>
@@ -42,9 +47,14 @@
         <target state="new">The prerelease value is invalid: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="new">Invalid version: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="new">The '{0}' value cannot be less than 0.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ja.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">ASP.NET Core ランタイム</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="translated">指定されたファイルが見つかりませんでした: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ja.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">マイナー バージョンが無効か、存在しません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="translated">修正プログラムのバージョンが無効か、見つかりません。</target>
@@ -42,9 +47,14 @@
         <target state="translated">プレリリースの値が無効です: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="translated">無効なバージョン: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="translated">'{0}' 値は、0 未満にできません。</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ko.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">ASP.NET Core 런타임</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="translated">지정된 파일 {0}을(를) 찾을 수 없습니다.</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ko.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">부 버전이 잘못되었거나 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="translated">패치 버전이 잘못되었거나 없습니다.</target>
@@ -42,9 +47,14 @@
         <target state="translated">시험판 값이 잘못되었습니다. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="translated">잘못된 버전: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="translated">'{0}' 값은 0보다 작을 수 없습니다.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.pl.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Środowisko uruchomieniowe platformy ASP.NET Core</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="translated">Nie można znaleźć określonego pliku: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.pl.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Brak wersji pomocniczej lub jest ona nieprawidłowa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="translated">Brak wersji poprawki lub jest ona nieprawidłowa.</target>
@@ -42,9 +47,14 @@
         <target state="translated">Wartość wersji wstępnej jest nieprawidłowa: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="translated">Nieprawidłowa wersja: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="translated">Wartość „{0}” nie może być mniejsza niż 0.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.pt-BR.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Versão secundária inválida ou ausente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="translated">Versão de patch inválida ou ausente.</target>
@@ -42,9 +47,14 @@
         <target state="translated">O valor de pré-lançamento é inválido: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="translated">Versão inválida: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="translated">O valor de '{0}' não pode ser inferior a 0.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.pt-BR.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Runtime do ASP.NET Core</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="translated">Não foi possível localizar o arquivo especificado: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ru.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Среда выполнения ASP.NET Core</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="translated">Не удалось найти указанный файл: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ru.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Дополнительный номер версии является недопустимым или отсутствует.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="translated">Версия исправления является недопустимой или отсутствует.</target>
@@ -42,9 +47,14 @@
         <target state="translated">Значение предварительного выпуска является недопустимым: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="translated">Недопустимая версия {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="translated">Значение "{0}" не может быть меньше 0.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.tr.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">İkincil sürüm geçersiz veya eksik.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="translated">Düzeltme eki sürümü geçersiz veya eksik.</target>
@@ -42,9 +47,14 @@
         <target state="translated">Yayın öncesi sürüm değeri geçersiz: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="translated">Sürüm geçersiz: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="translated">'{0}' değeri 0'dan küçük olamaz.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.tr.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">ASP.NET Core Çalışma Zamanı</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="translated">Belirtilen dosya bulunamadı: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.zh-Hans.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="new">ASP.NET Core Runtime</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="new">Could not find the specified file: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.zh-Hans.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="new">Invalid or missing minor version.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="new">Invalid or missing patch version.</target>
@@ -42,9 +47,14 @@
         <target state="new">The prerelease value is invalid: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="new">Invalid version: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="new">The '{0}' value cannot be less than 0.</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.zh-Hant.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">次要版本無效，或缺少次要版本。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidNumericIdentifier">
+        <source>Invalid numeric identifier: '{0}'.</source>
+        <target state="new">Invalid numeric identifier: '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidPatch">
         <source>Invalid or missing patch version.</source>
         <target state="translated">修補檔版本無效，或缺少修補檔版本。</target>
@@ -42,9 +47,14 @@
         <target state="translated">發行前的值無效: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidReleaseVersion">
+        <source>The specified version is not a valid semantic version.</source>
+        <target state="new">The specified version is not a valid semantic version.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidVersion">
-        <source>Invalid version: {0}</source>
-        <target state="translated">無效的版本: {0}</target>
+        <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
+        <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">
@@ -63,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="VersionPartLessThanZero">
-        <source>The '{0}' value cannot be less than 0.</source>
-        <target state="translated">'{0}' 值不能小於 0。</target>
+        <source>The value cannot be less than 0.</source>
+        <target state="new">The value cannot be less than 0.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsDesktopReleaseName">

--- a/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.zh-Hant.xlf
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/xlf/ReleasesResources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">ASP.NET Core 執行階段</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildMetadataCannotBeEmpty">
+        <source>The build metadata cannot be empty if a separator is provided.</source>
+        <target state="new">The build metadata cannot be empty if a separator is provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find the specified file: {0}</source>
         <target state="translated">找不到指定的檔案: {0}</target>
@@ -55,6 +60,11 @@
       <trans-unit id="InvalidVersion">
         <source>The specified version does not contain a valid major, minor, and patch version: '{0}'.</source>
         <target state="new">The specified version does not contain a valid major, minor, and patch version: '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PrereleaseCannotBeEmpty">
+        <source>The prerelease value cannot be empty if a separator is provided.</source>
+        <target state="new">The prerelease value cannot be empty if a separator is provided.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeReleaseName">


### PR DESCRIPTION
- Don't use regex for parsing.
- Making regex pattern public - there are use cases where we want to extract a version embedded inside other strings
- Add `Parse` and `TryParse` methods to be more consistent with `Version` class
- Cleaning up exception handling
- More unit tests
