### PR TITLE
Fix publishing after update to newest Arcade

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,17 +106,14 @@ stages:
       validateDependsOn:
       - PrepareForPublish
       publishingInfraVersion: 3
-      # Symbol validation is not ready yet. https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false
-      # SourceLink validation doesn't work in dev builds: tries to pull from GitHub. https://github.com/dotnet/arcade/issues/3604
+      enableSigningValidation: false
+      enableNugetValidation: false
       enableSourceLinkValidation: false
       publishInstallersAndChecksums: true
       # Enable SDL validation, passing through values from the 'deployment-tools-sdl-validation' group.
       SDLValidationParameters:
-        enable: true
-        artifactNames:
-        - PackageArtifacts
-        - BlobArtifacts
+        enable: false
         params: >-
           -SourceToolsList @("policheck","credscan")
           -TsaInstanceURL "$(TsaInstanceURL)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,8 @@ variables:
   # Set Official Build Id
   - name: OfficialBuildId
     value: $(Build.BuildNumber)
+  - name: PostBuildSign
+    value: true
 
   # Set the target blob feed for package publish during official and validation builds.
   - name: _DotNetArtifactsCategory

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -8,32 +8,29 @@
     <AllowEmptySignList Condition="'$(SignFinalPackages)' != 'true'">true</AllowEmptySignList>
   </PropertyGroup>
 
-  <!-- Get artifact locations to sign. -->
-  <Import Project="$(RepositoryEngineeringDir)Configurations.props" />
+  <ItemGroup>
+    <!--
+      Replace the default items to sign with the specific set we want. This allows the build to call
+      Arcade's Sign.proj multiple times for different sets of files as the build progresses.
+    -->
+    <ItemsToSign Remove="@(ItemsToSign)" />
 
-  <!-- We need  this to be inside a target to workaround: https://github.com/microsoft/msbuild/issues/5445 -->
-  <Target Name="PrepareItemsToSign" BeforeTargets="Sign">
+    <!-- Find bundle artifacts, which need multiple stages to fully sign. -->
+    <BundleInstallerEngineArtifact Include="$(ArtifactsPackagesDir)**/*engine.exe" />
+    <BundleInstallerExeArtifact Include="$(ArtifactsPackagesDir)**/*.exe" />
 
-    <ItemGroup>
-      <!--
-        Replace the default items to sign with the specific set we want. This allows the build to call
-        Arcade's Sign.proj multiple times for different sets of files as the build progresses.
-      -->
-      <ItemsToSign Remove="@(ItemsToSign)" />
+    <!-- Launcher is not signed, by design. -->
+    <FileSignInfo Include="Launcher.exe" CertificateName="None" />
 
-      <!-- Find bundle artifacts, which need multiple stages to fully sign. -->
-      <BundleInstallerEngineArtifact Include="$(ArtifactsPackagesDir)**/*engine.exe" />
-      <BundleInstallerExeArtifact Include="$(ArtifactsPackagesDir)**/*.exe" />
+    <!-- Do not sign non-Microsoft binaries. -->
+    <FileSignInfo Include="MessagePack.dll" CertificateName="None" />
+    <FileSignInfo Include="MessagePack.Annotations.dll" CertificateName="None" />
+    <FileSignInfo Include="Nerdbank.Streams.dll" CertificateName="None" />
 
-      <!-- Launcher is not signed, by design. -->
-      <FileSignInfo Include="Launcher.exe" CertificateName="None" />
+  </ItemGroup>
 
-      <!-- Do not sign non-Microsoft binaries. -->
-      <FileSignInfo Include="MessagePack.dll" CertificateName="None" />
-      <FileSignInfo Include="MessagePack.Annotations.dll" CertificateName="None" />
-      <FileSignInfo Include="Nerdbank.Streams.dll" CertificateName="None" />
-
-    </ItemGroup>
+  <Choose>
+    <When Condition="'$(PostBuildSign)' != 'true'">
 
     <ItemGroup Condition="'$(SignBinaries)' == 'true'">
       <ItemsToSign Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheck.exe" />
@@ -69,10 +66,30 @@
       <ItemsToSign Update="@(ItemsToSign)" Authenticode="$(CertificateId)" />
     </ItemGroup>
 
-  </Target>
+    </When>
+
+    <!-- When doing post build signing, we sign all artifacts we would push.
+         Symbol packages are included too. -->
+    <When Condition="'$(PostBuildSign)' == 'true'">
+      <ItemGroup>
+        <ItemsToSignWithPaths Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheck.exe" Condition="'$(PrepareArtifacts)' == 'true'" />
+        <ItemsToSignWithPaths Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheckca.dll" Condition="'$(PrepareArtifacts)' == 'true'" />
+        <ItemsToSignWithPaths Include="$(ArtifactsPackagesDir)**/*.msi" Condition="'$(PrepareArtifacts)' == 'true'" />
+        <ItemsToSignWithPaths Include="$(ArtifactsPackagesDir)**/*.cab" Condition="'$(PrepareArtifacts)' == 'true'" />
+        <ItemsToSignWithPaths Include="@(BundleInstallerEngineArtifact)" Condition="'$(PrepareArtifacts)' == 'true'" />
+        <ItemsToSignWithPaths
+          Include="@(BundleInstallerExeArtifact)"
+          Exclude="@(BundleInstallerEngineArtifact)" />
+        <ItemsToSignWithPaths Include="$(DownloadDirectory)**\*.nupkg" Condition="'$(PrepareArtifacts)' == 'true'" />
+
+        <ItemsToSignWithoutPaths Include="@(ItemsToSignWithPaths->'%(Filename)%(Extension)')" />
+        <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <ItemGroup>
-    <FileExtensionSignInfo Include=".msi" CertificateName="Microsoft400" />
+    <FileExtensionSignInfo Include=".msi" CertificateName="Microsoft500" />
     <FileExtensionSignInfo Include=".pkg" CertificateName="8003" />
     <FileExtensionSignInfo Include=".deb;.rpm" CertificateName="LinuxSign" />
   </ItemGroup>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -71,7 +71,7 @@
 
   <PropertyGroup>
     <!-- Temporarily disable ClickOnce native build due to compiler mismatch issue with libnethost.lib -->
-    <DisableClickOnceNativeBuild>true</DisableClickOnceNativeBuild>
+    <DisableClickOnceNativeBuild>false</DisableClickOnceNativeBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/installer/publish/prepare-artifacts.proj
+++ b/src/installer/publish/prepare-artifacts.proj
@@ -1,10 +1,14 @@
-<Project DefaultTargets="Build">
+<Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+    <PrepareArtifacts>true</PrepareArtifacts>
+  </PropertyGroup>
 
   <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(InstallerTasksAssemblyPath)" />
 
   <PropertyGroup>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
 
   <Target Name="CreateChecksums">
@@ -28,11 +32,32 @@
       Properties="DownloadDirectory=$(DownloadDirectory)" />
   </Target>
 
-  <Target Name="PreparePublishToAzureBlobFeed">
-    <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
+  <Target Name="UploadPreparedArtifactsToPipeline"
+          DependsOnTargets="
+            FindDownloadedArtifacts;
+            CreateChecksums">
+    <PropertyGroup>
+      <PreparedFileUploadDir>$(ArtifactsObjDir)PreparedFileUpload\</PreparedFileUploadDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <AllFilesToBlobStorage Include="@(UploadToBlobStorageFile);@(UploadToBlobStorageFile)" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(AllFilesToBlobStorage)" DestinationFolder="$(PreparedFileUploadDir)">
+      <Output TaskParameter="CopiedFiles" ItemName="CopiedUploadToBlobStorageFile" />
+    </Copy>
+
+    <Message Importance="High" Text="Uploading PreparedArtifacts to pipeline" />
+    <Message
+      Text="##vso[artifact.upload containerfolder=PreparedArtifacts;artifactname=PreparedArtifacts]%(CopiedUploadToBlobStorageFile.Identity)"
+      Importance="High" />
+  </Target>
+
+  <Target Name="PreparePublishToAzureBlobFeed"
+          DependsOnTargets="GetProductVersions;FindDownloadedArtifacts">
 
     <PropertyGroup>
-      <ExpectedFeedUrl>$(PackagesUrl)</ExpectedFeedUrl>
       <AssetManifestFilename>Manifest.xml</AssetManifestFilename>
       <AssetManifestFile>$(ArtifactsLogDir)AssetManifest/$(AssetManifestFilename)</AssetManifestFile>
 
@@ -55,79 +80,68 @@
       <ItemsToPush Include="@(ShippingNupkgToPublishFile)" />
       <ItemsToPush Include="@(NonShippingNupkgToPublishFile)" ManifestArtifactData="NonShipping=true" />
       <ItemsToPush Include="@(SymbolNupkgToPublishFile)" />
-    </ItemGroup>
-
-    <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->
-    <PushToAzureDevOpsArtifacts
-      ItemsToPush="@(ItemsToPush)"
-      ManifestBuildData="Location=$(ExpectedFeedUrl)"
-      ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
-      ManifestBranch="$(BUILD_SOURCEBRANCH)"
-      ManifestBuildId="$(BUILD_BUILDNUMBER)"
-      ManifestCommit="$(BUILD_SOURCEVERSION)"
-      IsStableBuild="$(IsStableBuild)"
-      AssetManifestPath="$(AssetManifestFile)"
-      AssetsTemporaryDirectory="$(TempWorkingDir)"
-      PublishingVersion="3" />
-
-    <!-- Copy the generated manifest to the build's artifacts -->
-    <Copy SourceFiles="$(AssetManifestFile)" DestinationFolder="$(TempWorkingDir)" />
-
-    <Message Importance="High" Text="Uploading $(AssetManifestFilename) to pipeline" />
-    <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDir)$(AssetManifestFilename)"
-      Importance="High" />
-  </Target>
-
-  <Target Name="PreparePublishFilesToAzureBlobFeed"
-          DependsOnTargets="GetProductVersions">
-    <Error Condition="'$(PackagesUrl)'==''" Text="Missing property PackagesUrl" />
-
-    <PropertyGroup>
-      <ExpectedFeedUrl>$(PackagesUrl)</ExpectedFeedUrl>
-      <AssetManifestFilename>Manifest_Installers.xml</AssetManifestFilename>
-      <AssetManifestFile>$(ArtifactsLogDir)AssetManifest/$(AssetManifestFilename)</AssetManifestFile>
-
-      <!-- Create temp dir to store generated asset manifest, per Arcade guidance. -->
-      <TempWorkingDir>$(ArtifactsObjDir)TempWorkingDir\$([System.Guid]::NewGuid())\</TempWorkingDir>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <ItemsToPush Remove="@(ItemsToPush)" />
 
       <ItemsToPush
         Include="@(UploadToBlobStorageFile)"
         Exclude="@(NupkgToPublishFile);@(SymbolNupkgToPublishFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
+        <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
 
       <ItemsToPush Include="@(GeneratedChecksumFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
         <Category>Checksum</Category>
+        <PublishFlatContainer>true</PublishFlatContainer>
       </ItemsToPush>
     </ItemGroup>
 
+    <!--
+      The new Maestro/BAR build model keeps separate Azure DevOps and GitHub build information.
+      The GitHub information will be extracted based on the Azure DevOps repository.
+    -->
+
+    <PropertyGroup>
+      <CollectionUri>$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)</CollectionUri>
+      <!-- When we have dev.azure.com/<account>/ -->
+      <AzureDevOpsAccount Condition="$(CollectionUri.IndexOf('dev.azure.com')) >= 0">$(CollectionUri.Split('/')[3])</AzureDevOpsAccount>
+      <!-- When we have <account>.visualstudio.com -->
+      <AzureDevOpsAccount Condition="$(CollectionUri.IndexOf('visualstudio.com')) >= 0">$(CollectionUri.Split('.')[0].Split('/')[2])</AzureDevOpsAccount>
+    </PropertyGroup>
+    <ItemGroup>
+      <ManifestBuildData Include="InitialAssetsLocation=$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$(SYSTEM_TEAMPROJECT)/_apis/build/builds/$(BUILD_BUILDID)/artifacts" />
+      <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
+      <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
+      <ManifestBuildData Include="AzureDevOpsAccount=$(AzureDevOpsAccount)" />
+      <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
+      <ManifestBuildData Include="AzureDevOpsBuildNumber=$(BUILD_BUILDNUMBER)" />
+      <ManifestBuildData Include="AzureDevOpsRepository=$(BUILD_REPOSITORY_URI)" />
+      <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
+    </ItemGroup>
+
     <!-- Push items to AzDO as build artifacts, generating the asset manifest as a side effect. -->
+    <!-- TODO: remove "PublishingVersion" see https://github.com/dotnet/arcade/issues/6082 -->
     <PushToAzureDevOpsArtifacts
+      AzureDevOpsCollectionUri="$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)"
+      AzureDevOpsProject="$(SYSTEM_TEAMPROJECT)"
+      AzureDevOpsBuildId="$(BUILD_BUILDID)"
+      ItemsToSign="@(ItemsToSignPostBuild)"
+      StrongNameSignInfo="@(StrongNameSignInfo)"
+      FileSignInfo="@(FileSignInfo)"
+      FileExtensionSignInfo="@(FileExtensionSignInfo)"
+      CertificatesSignInfo="@(CertificatesSignInfo)"
       ItemsToPush="@(ItemsToPush)"
-      ManifestBuildData="Location=$(ExpectedFeedUrl)"
-      ManifestRepoUri="$(BUILD_REPOSITORY_URI)"
+      ManifestBuildData="@(ManifestBuildData)"
+      ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"
       ManifestBranch="$(BUILD_SOURCEBRANCH)"
       ManifestBuildId="$(BUILD_BUILDNUMBER)"
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       IsStableBuild="$(IsStableBuild)"
-      PublishFlatContainer="true"
       AssetManifestPath="$(AssetManifestFile)"
-      AssetsTemporaryDirectory="$(TempWorkingDir)"
       PublishingVersion="3" />
 
     <!-- Copy the generated manifest to the build's artifacts -->
     <Copy SourceFiles="$(AssetManifestFile)" DestinationFolder="$(TempWorkingDir)" />
 
-    <Message Importance="High" Text="Uploading $(AssetManifestFilename) to pipeline" />
-    <Message
-      Text="##vso[artifact.upload containerfolder=AssetManifests;artifactname=AssetManifests]$(TempWorkingDir)$(AssetManifestFilename)"
-      Importance="High" />
   </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -138,11 +152,10 @@
   -->
   <Target Name="Build"
           DependsOnTargets="
-            FindDownloadedArtifacts;
             SignPackages;
             CreateChecksums;
-            PreparePublishToAzureBlobFeed;
-            PreparePublishFilesToAzureBlobFeed">
+            UploadPreparedArtifactsToPipeline;
+            PreparePublishToAzureBlobFeed">
     <Message Importance="High" Text="Complete!" />
   </Target>
 

--- a/src/installer/publish/prepare-artifacts.proj
+++ b/src/installer/publish/prepare-artifacts.proj
@@ -3,12 +3,19 @@
   <PropertyGroup>
     <PrepareArtifacts>true</PrepareArtifacts>
   </PropertyGroup>
+  <Import Project="../tools/Sign.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <!-- Since this repo doesn't use publish.proj, update the incoming arcade defaults to use MicrosoftDotNet500 -->
+  <ItemGroup>
+    <FileExtensionSignInfo Update="@(FileExtensionSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="$(DotNetCertificateName)" />
+    <StrongNameSignInfo Update="@(StrongNameSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="$(DotNetCertificateName)" />
+    <FileSignInfo Update="@(FileSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="$(DotNetCertificateName)" />
+  </ItemGroup>
 
   <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(InstallerTasksAssemblyPath)" />
 
   <PropertyGroup>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
 
   <Target Name="CreateChecksums">
@@ -21,15 +28,6 @@
     </ItemGroup>
 
     <GenerateChecksums Items="@(ArtifactsForGeneratingChecksums)" />
-  </Target>
-
-  <Target Name="SignPackages"
-          Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'public'">
-    <Message Importance="High" Text="Signing final packages" />
-    <MSBuild
-      Projects="$(SigningToolsDir)\SignFinalPackages.proj"
-      Targets="Build"
-      Properties="DownloadDirectory=$(DownloadDirectory)" />
   </Target>
 
   <Target Name="UploadPreparedArtifactsToPipeline"
@@ -152,7 +150,6 @@
   -->
   <Target Name="Build"
           DependsOnTargets="
-            SignPackages;
             CreateChecksums;
             UploadPreparedArtifactsToPipeline;
             PreparePublishToAzureBlobFeed">

--- a/src/installer/publish/publish-final.proj
+++ b/src/installer/publish/publish-final.proj
@@ -40,14 +40,15 @@
       AccountName="$(AzureAccountName)"
       AccountKey="$(AzureAccessToken)"
       ContainerName="$(ContainerName)"
-      SemaphoreBlob="DeploymentTools/$(Channel)/sharedFxPublishSemaphore"
+      ProductBlobStorageName="$(ProductBlobStorageName)"
+      SemaphoreBlob="$(ProductBlobStorageName)/$(Channel)/sharedFxPublishSemaphore"
       Channel="$(Channel)"
       Version="$(SharedFrameworkNugetVersion)"
       SharedFrameworkNugetVersion="$(SharedFrameworkNugetVersion)"
       SharedHostNuGetVersion="$(HostVersion)"
       ProductVersion="$(ProductVersion)"
       CommitHash="$(LatestCommit)"
-      FinalizeContainer="DeploymentTools/$(SharedFrameworkNugetVersion)"
+      FinalizeContainer="$(ProductBlobStorageName)/$(SharedFrameworkNugetVersion)"
       ForcePublish="true" />
 
     <Error Condition="'$(ChecksumAzureAccessToken)' == ''" Text="Missing required property 'ChecksumAzureAccessToken'" />
@@ -59,14 +60,15 @@
       AccountName="$(ChecksumAzureAccountName)"
       AccountKey="$(ChecksumAzureAccessToken)"
       ContainerName="$(ChecksumContainerName)"
-      SemaphoreBlob="DeploymentTools/$(Channel)/checksumPublishSemaphore"
+      ProductBlobStorageName="$(ProductBlobStorageName)"
+      SemaphoreBlob="$(ProductBlobStorageName)/$(Channel)/checksumPublishSemaphore"
       Channel="$(Channel)"
       Version="$(SharedFrameworkNugetVersion)"
       SharedFrameworkNugetVersion="$(SharedFrameworkNugetVersion)"
       SharedHostNuGetVersion="$(HostVersion)"
       ProductVersion="$(ProductVersion)"
       CommitHash="$(LatestCommit)"
-      FinalizeContainer="DeploymentTools/$(SharedFrameworkNugetVersion)"
+      FinalizeContainer="$(ProductBlobStorageName)/$(SharedFrameworkNugetVersion)"
       ForcePublish="true" />
   </Target>
 


### PR DESCRIPTION
Also switching to post-build signing.

Partially borrows the implementation from other repos that made the switch to new publishing and signing, i.e. WindowsDesktop.