### PR TITLE
Add support for file scheme URIs

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/tests/TestBase.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/TestBase.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Xunit;
@@ -13,6 +14,11 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
 {
     public class TestBase : IAsyncLifetime
     {
+        /// <summary>
+        /// The path of the test directory.
+        /// </summary>
+        protected static string TestDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
         /// <summary>
         /// A collection of all products.
         /// </summary>

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/UtilsTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/UtilsTests.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Deployment.DotNet.Releases.Tests
 {
-    public class UtilsTests
+    public class UtilsTests : TestBase
     {
         [Fact]
         public void GetFileHashThrowsIfFileNameIsNull()
@@ -38,6 +40,28 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
             });
 
             Assert.Equal($"Value cannot be null.{Environment.NewLine}Parameter name: hashAlgorithm", e.Message);
+        }
+
+        [Fact]
+        public async Task DownloadFileAsyncCanCopyFiles()
+        {
+            string sourceFile = Path.GetTempFileName();
+
+            using (FileStream fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                fs.SetLength(1024);
+            }
+
+            Uri sourceAddress = new Uri(Path.GetFullPath(sourceFile));
+            string destinationFile = Path.GetFullPath(Path.GetTempFileName());
+            await Utils.DownloadFileAsync(sourceAddress, destinationFile);
+
+            HashAlgorithm sha256 = SHA256.Create();
+            string sourceHash = Utils.GetFileHash(sourceFile, sha256);
+            string destinationHash = Utils.GetFileHash(destinationFile, sha256);
+
+            Assert.True(File.Exists(destinationFile));
+            Assert.Equal(sourceHash, destinationHash);
         }
     }
 }


### PR DESCRIPTION
`HttpClient` doesn't support file scheme URIs like `WebClient`, but is preferred over `WebClient`. There are cases where the URLS for releases.json may contain UNC paths, so downloading a file should be able to download or copy