### PR TITLE
Fix for package signing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ variables:
   - name: OfficialBuildId
     value: $(Build.BuildNumber)
   - name: PostBuildSign
-    value: true
+    value: false
 
   # Set the target blob feed for package publish during official and validation builds.
   - name: _DotNetArtifactsCategory

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -69,6 +69,8 @@
     <ItemsToSign Update="@(ItemsToSign)" Authenticode="$(CertificateId)" />
   </ItemGroup>
 
+  </Target>
+
   <ItemGroup>
     <FileExtensionSignInfo Include=".msi" CertificateName="Microsoft500" />
     <FileExtensionSignInfo Include=".pkg" CertificateName="8003" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -8,6 +8,12 @@
     <AllowEmptySignList Condition="'$(SignFinalPackages)' != 'true'">true</AllowEmptySignList>
   </PropertyGroup>
 
+  <!-- Get artifact locations to sign. -->
+  <Import Project="$(RepositoryEngineeringDir)Configurations.props" />
+
+  <!-- We need  this to be inside a target to workaround: https://github.com/microsoft/msbuild/issues/5445 -->
+  <Target Name="PrepareItemsToSign" BeforeTargets="Sign">
+
   <ItemGroup>
     <!--
       Replace the default items to sign with the specific set we want. This allows the build to call
@@ -29,64 +35,39 @@
 
   </ItemGroup>
 
-  <Choose>
-    <When Condition="'$(PostBuildSign)' != 'true'">
+  <ItemGroup Condition="'$(SignBinaries)' == 'true'">
+    <ItemsToSign Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheck.exe" />
+    <ItemsToSign Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheckca.dll" />
+  </ItemGroup>
 
-    <ItemGroup Condition="'$(SignBinaries)' == 'true'">
-      <ItemsToSign Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheck.exe" />
-      <ItemsToSign Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheckca.dll" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(SignMsiFiles)' == 'true'">
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.msi" />
+    <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.cab" />
+  </ItemGroup>
 
-    <ItemGroup Condition="'$(SignMsiFiles)' == 'true'">
-      <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.msi" />
-      <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.cab" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(SignBurnEngineFiles)' == 'true'">
+    <ItemsToSign Include="@(BundleInstallerEngineArtifact)" />
+  </ItemGroup>
 
-    <ItemGroup Condition="'$(SignBurnEngineFiles)' == 'true'">
-      <ItemsToSign Include="@(BundleInstallerEngineArtifact)" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(SignBurnBundleFiles)' == 'true'">
+    <!-- Sign the bundles, now that the engine is reattached. Avoid re-signing the engine. -->
+    <ItemsToSign
+      Include="@(BundleInstallerExeArtifact)"
+      Exclude="@(BundleInstallerEngineArtifact)" />
+    <!-- Note: wixstdba is internal to the engine bundle and does not get signed. -->
+  </ItemGroup>
 
-    <ItemGroup Condition="'$(SignBurnBundleFiles)' == 'true'">
-      <!-- Sign the bundles, now that the engine is reattached. Avoid re-signing the engine. -->
-      <ItemsToSign
-        Include="@(BundleInstallerExeArtifact)"
-        Exclude="@(BundleInstallerEngineArtifact)" />
-      <!-- Note: wixstdba is internal to the engine bundle and does not get signed. -->
-    </ItemGroup>
+  <ItemGroup Condition="'$(SignFinalPackages)' == 'true'">
+    <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
+    <ItemsToSign Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolPackages)" />
 
-    <ItemGroup Condition="'$(SignFinalPackages)' == 'true'">
-      <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
-      <ItemsToSign Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolPackages)" />
+    <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
+    <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />
+  </ItemGroup>
 
-      <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
-      <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ItemsToSign Update="@(ItemsToSign)" Authenticode="$(CertificateId)" />
-    </ItemGroup>
-
-    </When>
-
-    <!-- When doing post build signing, we sign all artifacts we would push.
-         Symbol packages are included too. -->
-    <When Condition="'$(PostBuildSign)' == 'true'">
-      <ItemGroup>
-        <ItemsToSignWithPaths Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheck.exe" Condition="'$(PrepareArtifacts)' == 'true'" />
-        <ItemsToSignWithPaths Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheckca.dll" Condition="'$(PrepareArtifacts)' == 'true'" />
-        <ItemsToSignWithPaths Include="$(ArtifactsPackagesDir)**/*.msi" Condition="'$(PrepareArtifacts)' == 'true'" />
-        <ItemsToSignWithPaths Include="$(ArtifactsPackagesDir)**/*.cab" Condition="'$(PrepareArtifacts)' == 'true'" />
-        <ItemsToSignWithPaths Include="@(BundleInstallerEngineArtifact)" Condition="'$(PrepareArtifacts)' == 'true'" />
-        <ItemsToSignWithPaths
-          Include="@(BundleInstallerExeArtifact)"
-          Exclude="@(BundleInstallerEngineArtifact)" />
-        <ItemsToSignWithPaths Include="$(DownloadDirectory)**\*.nupkg" Condition="'$(PrepareArtifacts)' == 'true'" />
-
-        <ItemsToSignWithoutPaths Include="@(ItemsToSignWithPaths->'%(Filename)%(Extension)')" />
-        <ItemsToSignPostBuild Include="@(ItemsToSignWithoutPaths->Distinct())" />
-      </ItemGroup>
-    </When>
-  </Choose>
+  <ItemGroup>
+    <ItemsToSign Update="@(ItemsToSign)" Authenticode="$(CertificateId)" />
+  </ItemGroup>
 
   <ItemGroup>
     <FileExtensionSignInfo Include=".msi" CertificateName="Microsoft500" />

--- a/src/installer/publish/prepare-artifacts.proj
+++ b/src/installer/publish/prepare-artifacts.proj
@@ -30,6 +30,15 @@
     <GenerateChecksums Items="@(ArtifactsForGeneratingChecksums)" />
   </Target>
 
+  <Target Name="SignPackages"
+          Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'public'">
+    <Message Importance="High" Text="Signing final packages" />
+    <MSBuild
+      Projects="$(SigningToolsDir)\SignFinalPackages.proj"
+      Targets="Build"
+      Properties="DownloadDirectory=$(DownloadDirectory)" />
+  </Target>
+
   <Target Name="UploadPreparedArtifactsToPipeline"
           DependsOnTargets="
             FindDownloadedArtifacts;
@@ -150,6 +159,7 @@
   -->
   <Target Name="Build"
           DependsOnTargets="
+            SignPackages;
             CreateChecksums;
             UploadPreparedArtifactsToPipeline;
             PreparePublishToAzureBlobFeed">

--- a/src/installer/publish/prepare-artifacts.proj
+++ b/src/installer/publish/prepare-artifacts.proj
@@ -1,16 +1,5 @@
-<Project>
+<Project DefaultTargets="Build">
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-  <PropertyGroup>
-    <PrepareArtifacts>true</PrepareArtifacts>
-  </PropertyGroup>
-  <Import Project="../tools/Sign.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
-
-  <!-- Since this repo doesn't use publish.proj, update the incoming arcade defaults to use MicrosoftDotNet500 -->
-  <ItemGroup>
-    <FileExtensionSignInfo Update="@(FileExtensionSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="$(DotNetCertificateName)" />
-    <StrongNameSignInfo Update="@(StrongNameSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="$(DotNetCertificateName)" />
-    <FileSignInfo Update="@(FileSignInfo->WithMetadataValue('CertificateName','Microsoft400'))" CertificateName="$(DotNetCertificateName)" />
-  </ItemGroup>
 
   <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(InstallerTasksAssemblyPath)" />
 
@@ -159,6 +148,7 @@
   -->
   <Target Name="Build"
           DependsOnTargets="
+            FindDownloadedArtifacts;
             SignPackages;
             CreateChecksums;
             UploadPreparedArtifactsToPipeline;


### PR DESCRIPTION
Switching back to sign binaries during build and publishing, instead of during post-build.