### PR TITLE
Add hostpath.exe

### DIFF
--- a/eng/Configurations.props
+++ b/eng/Configurations.props
@@ -8,6 +8,7 @@
     <InstallerProjectRoot>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'installer'))</InstallerProjectRoot>
     <ClickOnceProjectRoot>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'clickonce'))</ClickOnceProjectRoot>
     <DotNetReleasesProjectRoot>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'Microsoft.Deployment.DotNet.Releases'))</DotNetReleasesProjectRoot>
+    <HostPathProjectRoot>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'hostpath'))</HostPathProjectRoot>
     <RepoToolsLocalDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'tools-local'))</RepoToolsLocalDir>
     <RepoTasksDir>$([MSBuild]::NormalizeDirectory('$(RepoToolsLocalDir)', 'tasks'))</RepoTasksDir>
   </PropertyGroup>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -37,7 +37,7 @@
   -->
 
   <PropertyGroup>
-    <DefaultSubsets>clickonce+installer+dotnet_releases</DefaultSubsets>
+    <DefaultSubsets>clickonce+installer+dotnet_releases+hostpath</DefaultSubsets>
     <DefaultSubsets Condition="'$(TargetsMobile)' == 'true'">clickonce+installer</DefaultSubsets>
     <DefaultSubsets Condition="'$(DotNetBuildFromSource)' == 'true'">dotnet_releases</DefaultSubsets>
   </PropertyGroup>
@@ -58,12 +58,14 @@
     <DefaultClickOnceSubsets>clickonce</DefaultClickOnceSubsets>
     <DefaultInstallerSubsets>installer.pkgprojs</DefaultInstallerSubsets>
     <DefaultDotNetReleasesSubsets>dotnet_releases</DefaultDotNetReleasesSubsets>
+    <DefaultHostPathSubsets>hostpath</DefaultHostPathSubsets>
   </PropertyGroup>
 
   <PropertyGroup>
     <_subset>$(_subset.Replace('+clickonce+', '+$(DefaultClickOnceSubsets)+'))</_subset>
     <_subset>$(_subset.Replace('+installer+', '+$(DefaultInstallerSubsets)+'))</_subset>
     <_subset>$(_subset.Replace('+dotnet_releases+', '+$(DefaultDotNetReleasesSubsets)+'))</_subset>
+    <_subset>$(_subset.Replace('+hostpath+', '+$(DefaultHostPathSubsets)+'))</_subset>
 
     <!-- Surround _subset in dashes to simplify checks below -->
     <_subset>+$(_subset.Trim('+'))+</_subset>
@@ -85,6 +87,9 @@
 
     <!-- DotNetReleases -->
     <SubsetName Include="dotnet_releases" Description="Libary for accessing .NET release data." />
+
+    <!-- HostPath -->
+    <SubsetName Include="hostpath" Description=".NET Framework EXE to remove x86 dotnet from PATH." />
   </ItemGroup>
 
   <!-- Default targets, parallelization and configurations. -->
@@ -121,6 +126,12 @@
     <DotNetReleasesProjectToBuild Include="$(DotNetReleasesProjectRoot)src\**\*.csproj" Pack="true" SignPhase="Binaries" />
     <DotNetReleasesProjectToBuild Include="$(DotNetReleasesProjectRoot)tests\**\*.csproj" Test="$(Test)" Condition="'$(DotNetBuildFromSource)' != 'true'"/>
     <ProjectToBuild Include="@(DotNetReleasesProjectToBuild)" BuildInParallel="true" Category="dotnet_releases" />
+  </ItemGroup>
+
+  <!-- HostPath sets -->
+  <ItemGroup Condition="$(_subset.Contains('+hostpath+'))">
+    <HostPathProjectToBuild Include="$(HostPathProjectRoot)src\**\*.csproj" Pack="true" SignPhase="Binaries" />
+    <ProjectToBuild Include="@(HostPathProjectToBuild)" BuildInParallel="true" Category="hostpath" />
   </ItemGroup>
 
   <!-- Set default configurations. -->

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -70,7 +70,7 @@ jobs:
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - script: >-
-          build.cmd -subset clickonce+installer+dotnet_releases -ci -test
+          build.cmd -subset clickonce+installer+dotnet_releases+hostpath -ci -test
           $(CommonMSBuildArgs)
           $(MsbuildSigningArguments)
           /p:Sign=true /p:SignBinaries=true
@@ -79,14 +79,14 @@ jobs:
 
     - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
       - script: >-
-          build.cmd -subset clickonce+installer+dotnet_releases -ci -test
+          build.cmd -subset clickonce+installer+dotnet_releases+hostpath -ci -test
           $(CommonMSBuildArgs)
           $(MsbuildSigningArguments)
           /p:LocalizedBuild=true
         displayName: Build
 
     - script: >-
-        build.cmd -subset clickonce+installer+dotnet_releases -ci -pack
+        build.cmd -subset clickonce+installer+dotnet_releases+hostpath -ci -pack
         $(CommonMSBuildArgs)
         $(MsbuildSigningArguments)
       displayName: Package

--- a/src/hostpath/src/HostPath.csproj
+++ b/src/hostpath/src/HostPath.csproj
@@ -12,7 +12,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <Description>.NET Framework 4.5 executable to remove the x86 dotnet path.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageVersion>6.0.2</PackageVersion>
+    <PackageVersion>6.0.3-preview.1</PackageVersion>
 
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>

--- a/src/hostpath/src/HostPath.csproj
+++ b/src/hostpath/src/HostPath.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net4.5</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <PackageId>VS.Redist.Common.dotnet.host.path</PackageId>
+    <IsShippingPackage>false</IsShippingPackage>
+    <IsPackable>true</IsPackable>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <Description>.NET Framework 4.5 executable to remove the x86 dotnet path.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageVersion>6.0.2</PackageVersion>
+
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="$(TargetPath)" />
+  </ItemGroup>
+</Project>

--- a/src/hostpath/src/Program.cs
+++ b/src/hostpath/src/Program.cs
@@ -23,31 +23,30 @@ namespace HostPath
                     return;
                 }
 
-                using (RegistryKey envKey = Registry.LocalMachine.OpenSubKey(s_EnvironmentKeyName))
+                using RegistryKey envKey = Registry.LocalMachine.OpenSubKey(s_EnvironmentKeyName);
+
+                if (envKey == null)
                 {
-                    if (envKey == null)
-                    {
-                        return;
-                    }
-
-                    // Environment.GetEnvironmentVariable will expand environment variables inside the PATH variable
-                    string path = (string)envKey.GetValue("Path", string.Empty, RegistryValueOptions.DoNotExpandEnvironmentNames);
-
-                    // Check for paths with and without a trailing backslash
-                    string x86DotNetPath1 = Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
-                        "dotnet");
-                    string x86DotNetPath2 = Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
-                        @"dotnet\");
-
-                    List<string> paths = path.Split(';').ToList();
-                    paths.Remove(x86DotNetPath1);
-                    paths.Remove(x86DotNetPath2);
-                    path = string.Join(";", paths);
-
-                    Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Machine);
+                    return;
                 }
+
+                // Environment.GetEnvironmentVariable will expand environment variables inside the PATH variable
+                string path = (string)envKey.GetValue("Path", string.Empty, RegistryValueOptions.DoNotExpandEnvironmentNames);
+
+                // Check for paths with and without a trailing backslash
+                string x86DotNetPath1 = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                    "dotnet");
+                string x86DotNetPath2 = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                    @"dotnet\");
+
+                List<string> paths = path.Split(';').ToList();
+                paths.RemoveAll(s => s.Equals(x86DotNetPath1, StringComparison.OrdinalIgnoreCase) ||
+                    s.Equals(x86DotNetPath2, StringComparison.OrdinalIgnoreCase));
+                path = string.Join(";", paths);
+
+                Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Machine);
             }
             catch
             {

--- a/src/hostpath/src/Program.cs
+++ b/src/hostpath/src/Program.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Win32;
+
+namespace HostPath
+{
+    public class Program
+    {
+        // See https://docs.microsoft.com/en-us/windows/win32/procthread/environment-variables
+        private static readonly string s_EnvironmentKeyName = @"SYSTEM\CurrentControlSet\Control\Session Manager\Environment";
+
+        public static void Main(string[] args)
+        {
+            try
+            {
+                if (!Environment.Is64BitOperatingSystem)
+                {
+                    return;
+                }
+
+                using (RegistryKey envKey = Registry.LocalMachine.OpenSubKey(s_EnvironmentKeyName))
+                {
+                    if (envKey == null)
+                    {
+                        return;
+                    }
+
+                    // Environment.GetEnvironmentVariable will expand environment variables inside the PATH variable
+                    string path = (string)envKey.GetValue("Path", string.Empty, RegistryValueOptions.DoNotExpandEnvironmentNames);
+
+                    // Check for paths with and without a trailing backslash
+                    string x86DotNetPath1 = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                        "dotnet");
+                    string x86DotNetPath2 = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                        @"dotnet\");
+
+                    List<string> paths = path.Split(';').ToList();
+                    paths.Remove(x86DotNetPath1);
+                    paths.Remove(x86DotNetPath2);
+                    path = string.Join(";", paths);
+
+                    Environment.SetEnvironmentVariable("Path", path, EnvironmentVariableTarget.Machine);
+                }
+            }
+            catch
+            {
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
`hostpath.exe` is a .NET 4.5 executable that runs as part of Visual Studio setup on non-x86 machines to remove the an potential x86 dotnet entries from the `PATH`.

The `PATH` variable is read directly from the registry to avoid expanding existing environment variables in the path - (`Environment.GetEnvironmentVariable` always expands). For example, on a clean machine you'd typically see an entry like `%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\;%SYSTEMROOT%\System32\OpenSSH\;` which becomes `C:\Windows\system32;C:\Windows;...` when expanded. We need to avoid writing the expanded value back.

The package is statically versioned at 6.0.2 since VS currently consumes the 6.0.1 redist package.