### PR TITLE
Find correct x64 host on arm64 machines

### DIFF
--- a/src/clickonce/launcher/HostFinder.cs
+++ b/src/clickonce/launcher/HostFinder.cs
@@ -75,16 +75,20 @@ namespace Microsoft.Deployment.Launcher
         {
             get
             {
-                string proc = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
-                if (!string.IsNullOrEmpty(proc) && proc.ToLower() == ArchArm64)
+                try
                 {
-                    return true;
+                    if (NativeMethods.Kernel32.IsWow64Process2(new IntPtr(-1), out _, out ushort nativeMachine))
+                    {
+                        if (nativeMachine == NativeMethods.Kernel32.IMAGE_FILE_MACHINE_ARM64)
+                        {
+                            return true;
+                        }
+                    }
                 }
-
-                proc = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432");
-                if (!string.IsNullOrEmpty(proc) && proc.ToLower() == ArchArm64)
+                catch (EntryPointNotFoundException)
                 {
-                    return true;
+                    // kernel32.dll does not export IsWow64Process2 on systems before Win10
+                    // API is available on all systems that support arm64.
                 }
 
                 return false;

--- a/src/clickonce/shared/NativeMethods.cs
+++ b/src/clickonce/shared/NativeMethods.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Deployment.Utilities
         {
             public const UInt32 LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
             public const int ERROR_SHARING_VIOLATION = -2147024864;
+            public const ushort IMAGE_FILE_MACHINE_ARM64 = 0xAA64;
+
+            [DllImport(nameof(Kernel32), SetLastError = true, CallingConvention = CallingConvention.Winapi)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool IsWow64Process2([In] IntPtr process, [Out] out ushort processMachine, [Out] out ushort nativeMachine);
 
             [DllImport(nameof(Kernel32), CharSet = CharSet.Unicode, SetLastError = true)]
             public static extern IntPtr BeginUpdateResourceW(String fileName, bool deleteExistingResource);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/deployment-tools/issues/138

Launcher will find proper x64 host location on arm64 machines.

Since .NET 6, x64 .NET, on arm64 systems, is installed to `\Program Files\dotnet\x64`.