### PR TITLE
Allow apps to access ClickOnce deployment properties

### DIFF
--- a/Documentation/dotnet-mage/ApplicationDeployment.cs
+++ b/Documentation/dotnet-mage/ApplicationDeployment.cs
@@ -16,14 +16,7 @@ namespace ClickOnceHelper
             {
                 if (!isNetworkDeployedInitialized)
                 {
-                    ApplicationDeployment.isNetworkDeployed = false;
-
-                    string value = Environment.GetEnvironmentVariable("ClickOnce_IsNetworkDeployed");
-                    if (value?.ToLower() == "true")
-                    {
-                        ApplicationDeployment.isNetworkDeployed = true;
-                    }
-
+                    bool.TryParse(Environment.GetEnvironmentVariable("ClickOnce_IsNetworkDeployed"), out ApplicationDeployment.isNetworkDeployed);
                     ApplicationDeployment.isNetworkDeployedInitialized = true;
                 }
 

--- a/Documentation/dotnet-mage/ApplicationDeployment.cs
+++ b/Documentation/dotnet-mage/ApplicationDeployment.cs
@@ -1,0 +1,129 @@
+﻿using System;
+
+namespace ClickOnceHelper
+{
+    public class ApplicationDeployment
+    {
+        private static ApplicationDeployment currentDeployment = null;
+        private static bool currentDeploymentInitialized = false;
+
+        private static bool isNetworkDeployed = false;
+        private static bool isNetworkDeployedInitialized = false;
+
+        public static bool IsNetworkDeployed
+        {
+            get
+            {
+                if (!isNetworkDeployedInitialized)
+                {
+                    ApplicationDeployment.isNetworkDeployed = false;
+
+                    string value = Environment.GetEnvironmentVariable("ClickOnce_IsNetworkDeployed");
+                    if (value?.ToLower() == "true")
+                    {
+                        ApplicationDeployment.isNetworkDeployed = true;
+                    }
+
+                    ApplicationDeployment.isNetworkDeployedInitialized = true;
+                }
+
+                return ApplicationDeployment.isNetworkDeployed;
+            }
+        }
+
+        public static ApplicationDeployment CurrentDeployment
+        {
+            get
+            {
+                if (!currentDeploymentInitialized)
+                {
+                    ApplicationDeployment.currentDeployment = IsNetworkDeployed ? new ApplicationDeployment() : null;
+                    ApplicationDeployment.currentDeploymentInitialized = true;
+                }
+
+                return ApplicationDeployment.currentDeployment;
+            }
+        }
+
+        public Uri ActivationUri
+        {
+            get
+            {
+                string value = Environment.GetEnvironmentVariable("ClickOnce_ActivationUri");
+                return string.IsNullOrEmpty(value) ? null : new Uri(value);
+            }
+        }
+
+        public Version CurrentVersion
+        {
+            get
+            {
+                string value = Environment.GetEnvironmentVariable("ClickOnce_CurrentVersion");
+                return string.IsNullOrEmpty(value) ? null : new Version(value);
+            }
+        }
+        public string DataDirectory
+        {
+            get { return Environment.GetEnvironmentVariable("ClickOnce_DataDirectory");  }
+        }
+
+        public bool IsFirstRun
+        {
+            get
+            {
+                bool val;
+                bool.TryParse(Environment.GetEnvironmentVariable("ClickOnce_IsFirstRun"), out val);
+                return val;
+            }
+        }
+
+        public DateTime TimeOfLastUpdateCheck
+        {
+            get
+            {
+                DateTime value;
+                DateTime.TryParse(Environment.GetEnvironmentVariable("ClickOnce_TimeOfLastUpdateCheck"), out value);
+                return value;
+            }
+        }
+        public string UpdatedApplicationFullName
+        {
+            get
+            {
+                return Environment.GetEnvironmentVariable("ClickOnce_UpdatedApplicationFullName");
+            }
+        }
+
+        public Version UpdatedVersion
+        {
+            get
+            {
+                string value = Environment.GetEnvironmentVariable("ClickOnce_UpdatedVersion");
+                return string.IsNullOrEmpty(value) ? null : new Version(value);
+            }
+        }
+
+        public Uri UpdateLocation
+        {
+            get
+            {
+                string value = Environment.GetEnvironmentVariable("ClickOnce_UpdateLocation");
+                return string.IsNullOrEmpty(value) ? null : new Uri(value);
+            }
+        }
+
+        public Version LauncherVersion
+        {
+            get
+            {
+                string value = Environment.GetEnvironmentVariable("ClickOnce_LauncherVersion");
+                return string.IsNullOrEmpty(value) ? null : new Version(value);
+            }
+        }
+
+        private ApplicationDeployment()
+        {
+            // As an alternative solution, we could initialize all properties here
+        }
+    }
+}

--- a/Documentation/dotnet-mage/ApplicationDeployment.cs
+++ b/Documentation/dotnet-mage/ApplicationDeployment.cs
@@ -49,8 +49,8 @@ namespace ClickOnceHelper
         {
             get
             {
-                string value = Environment.GetEnvironmentVariable("ClickOnce_ActivationUri");
-                return string.IsNullOrEmpty(value) ? null : new Uri(value);
+                Uri.TryCreate(Environment.GetEnvironmentVariable("ClickOnce_ActivationUri"), UriKind.Absolute, out Uri val);
+                return val;
             }
         }
 
@@ -58,8 +58,8 @@ namespace ClickOnceHelper
         {
             get
             {
-                string value = Environment.GetEnvironmentVariable("ClickOnce_CurrentVersion");
-                return string.IsNullOrEmpty(value) ? null : new Version(value);
+                Version.TryParse(Environment.GetEnvironmentVariable("ClickOnce_CurrentVersion"), out Version val);
+                return val;
             }
         }
         public string DataDirectory
@@ -71,8 +71,7 @@ namespace ClickOnceHelper
         {
             get
             {
-                bool val;
-                bool.TryParse(Environment.GetEnvironmentVariable("ClickOnce_IsFirstRun"), out val);
+                bool.TryParse(Environment.GetEnvironmentVariable("ClickOnce_IsFirstRun"), out bool val);
                 return val;
             }
         }
@@ -81,8 +80,7 @@ namespace ClickOnceHelper
         {
             get
             {
-                DateTime value;
-                DateTime.TryParse(Environment.GetEnvironmentVariable("ClickOnce_TimeOfLastUpdateCheck"), out value);
+                DateTime.TryParse(Environment.GetEnvironmentVariable("ClickOnce_TimeOfLastUpdateCheck"), out DateTime value);
                 return value;
             }
         }
@@ -98,8 +96,8 @@ namespace ClickOnceHelper
         {
             get
             {
-                string value = Environment.GetEnvironmentVariable("ClickOnce_UpdatedVersion");
-                return string.IsNullOrEmpty(value) ? null : new Version(value);
+                Version.TryParse(Environment.GetEnvironmentVariable("ClickOnce_UpdatedVersion"), out Version val);
+                return val;
             }
         }
 
@@ -107,8 +105,8 @@ namespace ClickOnceHelper
         {
             get
             {
-                string value = Environment.GetEnvironmentVariable("ClickOnce_UpdateLocation");
-                return string.IsNullOrEmpty(value) ? null : new Uri(value);
+                Uri.TryCreate(Environment.GetEnvironmentVariable("ClickOnce_UpdateLocation"), UriKind.Absolute, out Uri val);
+                return val;
             }
         }
 
@@ -116,8 +114,9 @@ namespace ClickOnceHelper
         {
             get
             {
-                string value = Environment.GetEnvironmentVariable("ClickOnce_LauncherVersion");
-                return string.IsNullOrEmpty(value) ? null : new Version(value);
+
+                Version.TryParse(Environment.GetEnvironmentVariable("ClickOnce_LauncherVersion"), out Version val);
+                return val;
             }
         }
 

--- a/src/clickonce/MageCLI/Application.cs
+++ b/src/clickonce/MageCLI/Application.cs
@@ -451,6 +451,11 @@ namespace Microsoft.Deployment.MageCLI
         InvalidUseManifestForTrust,
 
         /// <summary>
+        /// The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"
+        /// </summary>
+        InvalidTrustURLParameters,
+
+        /// <summary>
         /// The IncludeProviderURL option is set to true, but no deployment provider Url is provided.
         /// </summary>
         MissingDeploymentProviderUrl,

--- a/src/clickonce/MageCLI/Application.resx
+++ b/src/clickonce/MageCLI/Application.resx
@@ -167,6 +167,7 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
@@ -344,6 +345,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -436,6 +440,9 @@ Options:
   </data>
   <data name="InvalidUrl" xml:space="preserve">
     <value>The URL is not of the proper format - "{0}"</value>
+  </data>
+  <data name="InvalidTrustURLParameters" xml:space="preserve">
+    <value>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</value>
   </data>
   <data name="InvalidUseManifestForTrust" xml:space="preserve">
     <value>The -UseManifestForTrust option must be "true", "false", "t", or "f" - "{0}"</value>

--- a/src/clickonce/MageCLI/Command.cs
+++ b/src/clickonce/MageCLI/Command.cs
@@ -147,6 +147,9 @@ namespace Microsoft.Deployment.MageCLI
         [CommandLineArgument(LongName = "CryptoProvider", ShortName = "csp")]
         public string cryptoProviderName = null;
 
+        [CommandLineArgument(LongName = "TrustURLParameters", ShortName = "tu")]
+        public string trustUrlParametersString = null;
+
         [CommandLineArgument(LongName = "UseManifestForTrust", ShortName = "um")]
         public string useApplicationManifestForTrustInfoString = null;
 
@@ -207,6 +210,11 @@ namespace Microsoft.Deployment.MageCLI
         /// UseManifestForTrust, in boolean form, parsed from the useApplicationManifestForTrustInfoString member
         /// </summary>
         private TriStateBool useApplicationManifestForTrustInfo = TriStateBool.Undefined;
+
+        /// <summary>
+        /// TrustURLParameters, in boolean form, parsed from the trustUrlParametersString member
+        /// </summary>
+        private TriStateBool trustUrlParameters = TriStateBool.Undefined;
 
         /// <summary>
         /// This object is cached between CanExecute(), where it is opened and
@@ -793,6 +801,28 @@ namespace Microsoft.Deployment.MageCLI
                 }
             }
 
+            // Validate the TrustUrlParameters option, if given
+            if (trustUrlParametersString != null)
+            {
+                switch (trustUrlParametersString.ToLower(CultureInfo.InvariantCulture))
+                {
+                    case "true":
+                    case "t":
+                        trustUrlParameters = TriStateBool.True;
+                        break;
+
+                    case "false":
+                    case "f":
+                        trustUrlParameters = TriStateBool.False;
+                        break;
+
+                    default:
+                        result = false;
+                        Application.PrintErrorMessage(ErrorMessages.InvalidTrustURLParameters, trustUrlParametersString);
+                        break;
+                }
+            }
+
             if ((Requested(Operations.GenerateApplicationManifest) || Requested(Operations.UpdateApplicationManifest)) &&
                 useApplicationManifestForTrustInfo != TriStateBool.True)
             {
@@ -860,7 +890,8 @@ namespace Microsoft.Deployment.MageCLI
                 errors += CheckForFileTypeSpecificOption("Deployment", "AppProviderUrl", applicationProviderUrl);
                 errors += CheckForFileTypeSpecificOption("Deployment", "RequiredUpdate", isRequiredUpdateString);
                 errors += CheckForFileTypeSpecificOption("Deployment", "Install", installString);
-                errors += CheckForFileTypeSpecificOption("Deployment", "IncludeProviderURL", includeDeploymentProviderUrlString);
+                errors += CheckForFileTypeSpecificOption("Deployment", "IncludeProviderUrl", includeDeploymentProviderUrlString);
+                errors += CheckForFileTypeSpecificOption("Deployment", "TrustUrlParameters", trustUrlParametersString);
             }
 
             if (Requested(Operations.GenerateDeploymentManifest) ||
@@ -903,6 +934,7 @@ namespace Microsoft.Deployment.MageCLI
                 errors += CheckForInvalidNonManifestOption("RequiredUpdate", isRequiredUpdateString);
                 errors += CheckForInvalidNonManifestOption("IncludeProviderURL", includeDeploymentProviderUrlString);
                 errors += CheckForInvalidNonManifestOption("UseManifestForTrust", useApplicationManifestForTrustInfoString);
+                errors += CheckForInvalidNonManifestOption("TrustUrlParameters", trustUrlParametersString);
                 errors += CheckForInvalidNonManifestOption("IconFile", iconFile);
             }
 
@@ -1321,7 +1353,7 @@ namespace Microsoft.Deployment.MageCLI
             else if (Requested(Operations.GenerateDeploymentManifest))
             {
                 applicationName += ".app";
-                manifest = Mage.GenerateDeploymentManifest(outputPath, applicationName, applicationVersion, processor, cachedAppManifest, applicationManifestPath, applicationCodeBase, applicationProviderUrl, minVersion, install, includeDeploymentProviderUrl, publisherName, supportUrl, targetFrameworkVersion);
+                manifest = Mage.GenerateDeploymentManifest(outputPath, applicationName, applicationVersion, processor, cachedAppManifest, applicationManifestPath, applicationCodeBase, applicationProviderUrl, minVersion, install, includeDeploymentProviderUrl, publisherName, supportUrl, targetFrameworkVersion, trustUrlParameters);
             }
 
             // Update operations
@@ -1332,7 +1364,7 @@ namespace Microsoft.Deployment.MageCLI
             }
             else if (Requested(Operations.UpdateDeploymentManifest))
             {
-                Mage.UpdateDeploymentManifest(cachedDepManifest, outputPath, applicationName, applicationVersion, processor, cachedAppManifest, applicationManifestPath, applicationCodeBase, applicationProviderUrl, minVersion, install, includeDeploymentProviderUrl, publisherName, supportUrl, targetFrameworkVersion);
+                Mage.UpdateDeploymentManifest(cachedDepManifest, outputPath, applicationName, applicationVersion, processor, cachedAppManifest, applicationManifestPath, applicationCodeBase, applicationProviderUrl, minVersion, install, includeDeploymentProviderUrl, publisherName, supportUrl, targetFrameworkVersion, trustUrlParameters);
                 manifest = cachedDepManifest;
             }
 

--- a/src/clickonce/MageCLI/Mage.cs
+++ b/src/clickonce/MageCLI/Mage.cs
@@ -110,12 +110,13 @@ namespace Microsoft.Deployment.MageCLI
         /// <param name="publisherName">Publisher name</param>
         /// <param name="supportUrl">Support URL</param>
         /// <param name="targetFrameworkVersion">Target Framework version</param>
+        /// <param name="trustUrlParameters">Specifies if URL parameters should be trusted</param>
         /// <returns>DeploymentManifest object</returns>
         public static DeployManifest GenerateDeploymentManifest(string deploymentManifestPath,
             string appName, Version version, Processors processor,
             ApplicationManifest applicationManifest, string applicationManifestPath, string appCodeBase,
             string appProviderUrl, string minVersion, TriStateBool install, TriStateBool includeDeploymentProviderUrl,
-            string publisherName, string supportUrl, string targetFrameworkVersion)
+            string publisherName, string supportUrl, string targetFrameworkVersion, TriStateBool trustUrlParameters)
         {
             /*
               Mage running on Core cannot obtain .NET FX version for targeting.
@@ -167,7 +168,7 @@ namespace Microsoft.Deployment.MageCLI
 
             UpdateDeploymentManifest(manifest, deploymentManifestPath, appName, version, processor,
                 applicationManifest, applicationManifestPath, appCodeBase,
-                appProviderUrl, minVersion, install, includeDeploymentProviderUrl, publisherName, supportUrl, targetFrameworkVersion);
+                appProviderUrl, minVersion, install, includeDeploymentProviderUrl, publisherName, supportUrl, targetFrameworkVersion, trustUrlParameters);
 
             return manifest;
         }
@@ -317,13 +318,15 @@ namespace Microsoft.Deployment.MageCLI
         /// <param name="publisherName">Publisher name</param>
         /// <param name="supportUrl">Support URL</param>
         /// <param name="targetFrameworkVersion">Target Framework version</param>
+        /// <param name="trustUrlParameters">Specifies if URL parameters should be trusted</param>
         public static void UpdateDeploymentManifest(DeployManifest manifest, string deploymentManifestPath,
             string appName, Version version, Processors processor,
             ApplicationManifest applicationManifest, string applicationManifestPath,
             string appCodeBase, string appProviderUrl, string minVersion,
             TriStateBool install,
             TriStateBool includeDeploymentProviderUrl,
-            string publisherName, string supportUrl, string targetFrameworkVersion)
+            string publisherName, string supportUrl, string targetFrameworkVersion,
+            TriStateBool trustUrlParameters)
         {
             if (install != TriStateBool.Undefined)
             {
@@ -429,6 +432,11 @@ namespace Microsoft.Deployment.MageCLI
             if (appCodeBase != null)
             {
                 SetApplicationCodeBase(manifest, appCodeBase);
+            }
+
+            if (trustUrlParameters == TriStateBool.True)
+            {
+                manifest.TrustUrlParameters = true;
             }
         }
 

--- a/src/clickonce/MageCLI/xlf/Application.cs.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.cs.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">Příkazy
+        <target state="needs-review-translation">Příkazy
   -New &lt;typ_souboru&gt;	          -n
   -Update &lt;název_souboru&gt;	          -u
   -Sign &lt;název_souboru&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">Příkazy:
+        <target state="needs-review-translation">Příkazy:
 
   -New &lt;typ_souboru&gt;        -n
       Vygeneruje nový manifest aplikace, manifest nasazení nebo
@@ -652,6 +656,11 @@ Možnosti:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">Neplatná úroveň důvěryhodnosti, je třeba zadat hodnotu LocalIntranet, Internet nebo FullTrust – {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.de.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.de.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">Befehle
+        <target state="needs-review-translation">Befehle
   -New &lt;Dateiname&gt;	          -n
   -Update &lt;Dateiname&gt;	          -u
   -Sign &lt;Dateiname&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">Befehle:
+        <target state="needs-review-translation">Befehle:
 
   -New &lt;Dateityp&gt;        -n
       Hiermit wird unter Verwendung der nachstehend aufgeführten Optionen ein neues Anwendungsmanifest,
@@ -652,6 +656,11 @@ Optionen:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">Ungültige Vertrauensebene, muss "LocalIntranet", "Internet" oder "FullTrust" lauten: "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.es.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.es.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">Comandos
+        <target state="needs-review-translation">Comandos
   -New &lt;tipo_de_archivo&gt;	          -n
   -Update &lt;nombre_de_archivo&gt;	          -u
   -Sign &lt;nombre_de_archivo&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">Comandos:
+        <target state="needs-review-translation">Comandos:
 
   -New &lt;tipo_de_archivo&gt;        -n
       Genera un nuevo manifiesto de aplicación, un manifiesto de implementación o una
@@ -652,6 +656,11 @@ Opciones:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">Nivel de confianza no válido; debe ser "LocalIntranet", "Internet" o "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.fr.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.fr.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">Commandes
+        <target state="needs-review-translation">Commandes
   -New &lt;file_type&gt;	          -n
   -Update &lt;file_name&gt;	          -u
   -Sign &lt;file_name&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">Commandes :
+        <target state="needs-review-translation">Commandes :
 
   -New &lt;file_type&gt;        -n
       Permet de générer un nouveau manifeste de l'application, un nouveau manifeste de déploiement ou une
@@ -652,6 +656,11 @@ Options :
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">Niveau de confiance non valide ; doit être "LocalIntranet", "Internet" ou "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.it.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.it.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">Comandi
+        <target state="needs-review-translation">Comandi
   -New &lt;tipo_file&gt;	          -n
   -Update &lt;nome_file&gt;	          -u
   -Sign &lt;nome_file&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">Comandi:
+        <target state="needs-review-translation">Comandi:
 
   -New &lt;tipo_file&gt;        -n
       Genera un nuovo manifesto dell'applicazione, manifesto di distribuzione o licenza di
@@ -652,6 +656,11 @@ Opzioni:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">Livello di attendibilità non valido. Deve essere "LocalIntranet", "Internet" o "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.ja.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ja.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">コマンド
+        <target state="needs-review-translation">コマンド
   -New &lt;file_type&gt;	          -n
   -Update &lt;file_name&gt;	          -u
   -Sign &lt;file_name&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">コマンド:
+        <target state="needs-review-translation">コマンド:
 
   -New &lt;file_type&gt;        -n
       以下に一覧表示されているオプションを使用して、新しいアプリケーション マニフェスト、配置
@@ -652,6 +656,11 @@ Options:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">無効な信頼レベルです。信頼レベルは、"LocalIntranet"、"Internet"、"FullTrust" のいずれかでなければなりません - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.ko.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ko.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">명령
+        <target state="needs-review-translation">명령
   -New &lt;file_type&gt;	          -n
   -Update &lt;file_name&gt;	          -u
   -Sign &lt;file_name&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">명령:
+        <target state="needs-review-translation">명령:
 
   -New &lt;file_type&gt;        -n
       아래 나열된 옵션을 사용하여 새 애플리케이션 매니페스트, 배포 매니페스트 또는 트러스트
@@ -652,6 +656,11 @@ Options:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">신뢰 수준이 잘못되었습니다. 신뢰 수준은 "LocalIntranet", "Internet" 또는 "FullTrust"여야 합니다. "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.pl.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.pl.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">Polecenia
+        <target state="needs-review-translation">Polecenia
   -New &lt;typ_pliku&gt;	          -n
   -Update &lt;nazwa_pliku&gt;	          -u
   -Sign &lt;nazwa_pliku&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">Polecenia:
+        <target state="needs-review-translation">Polecenia:
 
   -New &lt;typ_pliku&gt;        -n
       Wygeneruj nowy manifest aplikacji, manifest wdrożenia lub licencję
@@ -652,6 +656,11 @@ Opcje:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">Nieprawidłowy poziom zaufania; poziom musi mieć wartość „LocalIntranet”, „Internet” lub „FullTrust” — „{0}”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.pt-BR.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.pt-BR.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">Comandos
+        <target state="needs-review-translation">Comandos
   -New &lt;file_type&gt;	          -n
   -Update &lt;file_name&gt;	          -u
   -Sign &lt;file_name&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">Comandos:
+        <target state="needs-review-translation">Comandos:
 
   -New &lt;file_type&gt;        -n
       Gera um novo manifesto do aplicativo, manifesto de implantação ou licença
@@ -652,6 +656,11 @@ Opções:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">Nível de confiança inválido. Ele precisa ser "LocalIntranet", "Internet" ou "FullTrust" – "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.ru.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ru.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">Команды
+        <target state="needs-review-translation">Команды
   -New &lt;file_type&gt;	          -n
   -Update &lt;file_name&gt;	          -u
   -Sign &lt;file_name&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">Команды:
+        <target state="needs-review-translation">Команды:
 
   -New &lt;file_type&gt;        -n
       Создание манифеста приложения, манифеста развертывания или лицензии
@@ -652,6 +656,11 @@ Options:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">Недопустимый уровень доверия. Должен быть: "LocalIntranet", "Internet" или "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.tr.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.tr.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">Komutlar
+        <target state="needs-review-translation">Komutlar
   -New &lt;dosya_türü&gt;	          -n
   -Update &lt;dosya_adı&gt;	          -u
   -Sign &lt;dosya_adı&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">Komutlar:
+        <target state="needs-review-translation">Komutlar:
 
   -New &lt;dosya_türü&gt;        -n
       Aşağıda listelenen seçenekleri kullanarak yeni bir uygulama bildirimi, dağıtım bildirimi veya güven
@@ -652,6 +656,11 @@ Seçenekler:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">Güven düzeyi geçersiz. "LocalIntranet", "Internet" veya "FullTrust" olmalıdır: "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.zh-Hans.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.zh-Hans.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">命令
+        <target state="needs-review-translation">命令
   -New &lt;file_type&gt;	          -n
   -Update &lt;file_name&gt;	          -u
   -Sign &lt;file_name&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">命令:
+        <target state="needs-review-translation">命令:
 
   -New &lt;file_type&gt;        -n
       使用下面列出的选项生成新的应用程序清单、部署清单或
@@ -652,6 +656,11 @@ Options:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">信任级别无效，必须为“LocalIntranet”、“Internet”或“FullTrust”-“{0}”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/MageCLI/xlf/Application.zh-Hant.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.zh-Hant.xlf
@@ -117,11 +117,12 @@ Options
   -TimeStampUri &lt;uri&gt;               -ti
   -ToFile	&lt;file_name&gt;	    -t
   -TrustLevel &lt;level&gt;	            -tr
+  -TrustURLParameters &lt;true|false&gt;  -tu
   -UseManifestForTrust &lt;true|false&gt; -um
   -Version &lt;version&gt;	            -v
 
 Use "mage -help verbose" for more detailed help</source>
-        <target state="translated">命令
+        <target state="needs-review-translation">命令
   -New &lt;file_type&gt;	          -n
   -Update &lt;file_name&gt;	          -u
   -Sign &lt;file_name&gt;	          -s
@@ -333,6 +334,9 @@ Options:
       Example:
         -TrustLevel FullTrust
 
+  -TrustURLParameters &lt;true|false&gt;  -tu
+      Specifies if URL parameters will be trusted and passed to the application.
+            
   -UseManifestForTrust &lt;true|false&gt; -um
       Specifies if the application manifest will be used for certification and
       branding information.
@@ -342,7 +346,7 @@ Options:
       generated or updated.  Must be of the form "0.0.0.0".
       Example:
         -Version 1.2.3.2112</source>
-        <target state="translated">命令:
+        <target state="needs-review-translation">命令:
 
   -New &lt;file_type&gt;        -n
       使用下列選項產生新應用程式資訊清單、部署資訊清單，或信任
@@ -652,6 +656,11 @@ Options:
       <trans-unit id="InvalidTrustLevel">
         <source>Invalid trust level, must be either "LocalIntranet", "Internet", or "FullTrust" - "{0}"</source>
         <target state="translated">無效的信任層級，必須是 "LocalIntranet"、"Internet" 或 "FullTrust" - "{0}"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidTrustURLParameters">
+        <source>The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</source>
+        <target state="new">The -TrustURLParameters option must be "true", "false", "t", or "f" - "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUrl">

--- a/src/clickonce/launcher/Program.cs
+++ b/src/clickonce/launcher/Program.cs
@@ -65,6 +65,10 @@ namespace Microsoft.Deployment.Launcher
                 throw new LauncherException(Constants.ErrorUnsupportedExtension, appToLaunchFullPath);
             }
 
+            // Add ClickOnce properties from ApplicationDeployment object
+            // as environment variables, to be passed to child process.
+            AddClickOnceEnvironmentVariables();
+
             ProcessHelper ph = new ProcessHelper(exe, args);
             ph.StartProcessWithRetries();
         }
@@ -124,6 +128,32 @@ namespace Microsoft.Deployment.Launcher
             {
                 Logger.StartLogging(path);
             }
+        }
+
+        /// <summary>
+        /// Add ClickOnce properties from ApplicationDeployment object
+        /// as environment variables, to be passed to child process.
+        /// 
+        /// Add some extra variables, like Launcher version.
+        /// </summary>
+        private static void AddClickOnceEnvironmentVariables()
+        {
+            if (ApplicationDeployment.IsNetworkDeployed)
+            {
+                ApplicationDeployment ad = ApplicationDeployment.CurrentDeployment;
+
+                Environment.SetEnvironmentVariable("ClickOnce_ActivationUri", ad.ActivationUri?.ToString());
+                Environment.SetEnvironmentVariable("ClickOnce_CurrentVersion", ad.CurrentVersion?.ToString());
+                Environment.SetEnvironmentVariable("ClickOnce_DataDirectory", ad.DataDirectory?.ToString());
+                Environment.SetEnvironmentVariable("ClickOnce_IsFirstRun", ad.IsFirstRun.ToString());
+                Environment.SetEnvironmentVariable("ClickOnce_TimeOfLastUpdateCheck", ad.TimeOfLastUpdateCheck.ToString());
+                Environment.SetEnvironmentVariable("ClickOnce_UpdatedApplicationFullName", ad.UpdatedApplicationFullName?.ToString());
+                Environment.SetEnvironmentVariable("ClickOnce_UpdatedVersion", ad.UpdatedVersion?.ToString());
+                Environment.SetEnvironmentVariable("ClickOnce_UpdateLocation", ad.UpdateLocation?.ToString());
+            }
+
+            Environment.SetEnvironmentVariable("ClickOnce_IsNetworkDeployed", ApplicationDeployment.IsNetworkDeployed.ToString());
+            Environment.SetEnvironmentVariable("ClickOnce_LauncherVersion", System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/deployment-tools/issues/53

Launcher is being extended to share ClickOnce ApplicationDeployment properties with the application being launched (.NET based). Properties are shared via Environment variables.

Variable names closely match old ClickOnce ApplicationDeployment class: https://docs.microsoft.com/en-us/dotnet/api/system.deployment.application.applicationdeployment?view=netframework-4.8

New environment variables use the same name as old ones, with addition of `ClickOnce_` prefix:
```
ClickOnce_IsNetworkDeployed
ClickOnce_ActivationUri
ClickOnce_CurrentVersion
ClickOnce_DataDirectory
ClickOnce_IsFirstRun
ClickOnce_TimeOfLastUpdateCheck
ClickOnce_UpdatedApplicationFullName
ClickOnce_UpdatedVersion
ClickOnce_UpdateLocation
```

New property is being added, for Launcher version:
```
ClickOnce_LauncherVersion
```

.NET application, launched by new Launcher, can use these properties directly, or indirectly.

Direct use would look like the following:

```
NameValueCollection nameValueTable = new NameValueCollection();
if (Environment.GetEnvironmentVariable("ClickOnce_IsNetworkDeployed")?.ToLower() == "true")
{
    string value = Environment.GetEnvironmentVariable("ClickOnce_ActivationUri");
    Uri activationUri = string.IsNullOrEmpty(value) ? null : new Uri(value);
    if (activationUri != null)
    {
        nameValueTable = HttpUtility.ParseQueryString(activationUri.Query);
        Console.WriteLine("Query string: " + activationUri.Query);
        Console.ReadKey();
    }
}
```

Indirect usage would require implementation of a new ApplicationDeployment class, at application level, that could abstract reading of environment variables and provide experience that is very similar to old .NET FX class.

A sample implementation of this class is shared as `ApplicationDeployment.cs` in this PR (under `Documentation/dotnet-mage` folder).

With addition of this class, sample usage becomes:

```
NameValueCollection nameValueTable = new NameValueCollection();
if (ApplicationDeployment.IsNetworkDeployed)
{
    ApplicationDeployment ad = ApplicationDeployment.CurrentDeployment;
    if (ad.ActivationUri != null)
    {
        nameValueTable = HttpUtility.ParseQueryString(ad.ActivationUri.Query);
    }
}
```

This PR also adds a new switch to dotnet-mage, `-TrustURLParameters` (or (`-tu`). This allows developer to set the required deployment attribute using dotnet-mage tool. This is an improvement over old Mage tool, which did not support this functionality and required developer to manually modify application manifest to add trustURLParameters attribute, like this: `<deployment install="true" trustURLParameters="true">`

`trustURLParameters` need to be set to `true` in order for application to have access to ActivationUri and the URL parameters.

