### PR TITLE
Convert to System.Text.Json

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,7 +70,7 @@
     <MicrosoftNETCoreILAsmVersion>6.0.0-rc.2.21451.6</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETSdkILVersion>6.0.0-rc.2.21451.6</MicrosoftNETSdkILVersion>
     <!-- Libraries dependencies -->
-    <SystemTextJsonVersion>6.0.6</SystemTextJsonVersion>
+    <SystemTextJsonVersion>7.0.0-rc.1.22426.10</SystemTextJsonVersion>
     <runtimenativeSystemIOPortsVersion>6.0.0-rc.2.21451.6</runtimenativeSystemIOPortsVersion>
     <!-- Runtime-Assets dependencies -->
     <SystemComponentModelTypeConverterTestDataVersion>6.0.0-beta.21430.1</SystemComponentModelTypeConverterTestDataVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,7 +70,7 @@
     <MicrosoftNETCoreILAsmVersion>6.0.0-rc.2.21451.6</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETSdkILVersion>6.0.0-rc.2.21451.6</MicrosoftNETSdkILVersion>
     <!-- Libraries dependencies -->
-    <SystemTextJsonVersion>6.0.0-rc.2.21451.6</SystemTextJsonVersion>
+    <SystemTextJsonVersion>6.0.6</SystemTextJsonVersion>
     <runtimenativeSystemIOPortsVersion>6.0.0-rc.2.21451.6</runtimenativeSystemIOPortsVersion>
     <!-- Runtime-Assets dependencies -->
     <SystemComponentModelTypeConverterTestDataVersion>6.0.0-beta.21430.1</SystemComponentModelTypeConverterTestDataVersion>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/AspNetCoreReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/AspNetCoreReleaseComponent.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         internal AspNetCoreReleaseComponent(JsonElement element, ProductRelease release) : base(element, release)
         {
             AspNetCoreModuleVersions = element.TryGetProperty("version-aspnetcoremodule", out JsonElement ancmVersionValue) && ancmVersionValue.ValueKind != JsonValueKind.Null ?
-                new ReadOnlyCollection<Version>(JsonSerializer.Deserialize<Version[]>(ancmVersionValue)) : new ReadOnlyCollection<Version>(new List<Version>());
+                new ReadOnlyCollection<Version>(JsonSerializer.Deserialize<Version[]>(ancmVersionValue, SerializerOptions.Default)) : new ReadOnlyCollection<Version>(new List<Version>());
             VisualStudioVersion = element.GetStringOrDefault("vs-version");
         }
     }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/AspNetCoreReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/AspNetCoreReleaseComponent.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
@@ -34,10 +35,16 @@ namespace Microsoft.Deployment.DotNet.Releases
             get;
         }
 
-        internal AspNetCoreReleaseComponent(JToken token, ProductRelease release) : base(token, release)
+        /// <summary>
+        /// Creates a new <see cref="AspNetCoreReleaseComponent"/> instance.
+        /// </summary>
+        /// <param name="element">The JSON element of the component.</param>
+        /// <param name="release">The release to which the component belongs.</param>
+        internal AspNetCoreReleaseComponent(JsonElement element, ProductRelease release) : base(element, release)
         {
-            AspNetCoreModuleVersions = new ReadOnlyCollection<Version>(token["version-aspnetcoremodule"]?.ToObject<Version[]>(Utils.DefaultSerializer) ?? new Version[] { });
-            VisualStudioVersion = (string)token["vs-version"];
+            AspNetCoreModuleVersions = element.TryGetProperty("version-aspnetcoremodule", out JsonElement ancmVersionValue) && ancmVersionValue.ValueKind != JsonValueKind.Null ?
+                new ReadOnlyCollection<Version>(JsonSerializer.Deserialize<Version[]>(ancmVersionValue)) : new ReadOnlyCollection<Version>(new List<Version>());
+            VisualStudioVersion = element.GetStringOrDefault("vs-version");
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Cve.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Cve.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
@@ -16,6 +14,8 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <summary>
         /// The identifier of the CVE.
         /// </summary>
+        [JsonPropertyName("cve-id")]
+        [JsonInclude]
         public string Id
         {
             get;
@@ -25,17 +25,12 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <summary>
         /// The URI pointing to a description of the vulnerability.
         /// </summary>
+        [JsonPropertyName("cve-url")]
+        [JsonInclude]
         public Uri DescriptionLink
         {
             get;
             private set;
-        }
-
-        [JsonConstructor]
-        internal Cve([JsonProperty(PropertyName = "cve-id")] string id, [JsonProperty(PropertyName = "cve-url")] string address)
-        {
-            Id = id;
-            DescriptionLink = new Uri(address);
         }
 
         /// <summary>
@@ -60,15 +55,12 @@ namespace Microsoft.Deployment.DotNet.Releases
         }
 
         /// <summary>
-        /// The default hash function.
+        /// Returns the hash code for this CVE.
         /// </summary>
         /// <returns>A hash code for the current object.</returns>
-        public override int GetHashCode()
-        {
-            int hashCode = 315393214;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
-            hashCode = hashCode * -1521134295 + EqualityComparer<Uri>.Default.GetHashCode(DescriptionLink);
-            return hashCode;
-        }
+        public override int GetHashCode() => Id.GetHashCode() ^ DescriptionLink.GetHashCode();
+
+        internal static Cve Create(string id, string address) =>
+            new Cve { Id = id, DescriptionLink = new Uri(address) };
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/JsonExtensions.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/JsonExtensions.cs
@@ -1,15 +1,62 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Newtonsoft.Json.Linq;
+using System;
+using System.Text.Json;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
     internal static class JsonExtensions
     {
-        internal static bool IsNullOrEmpty(this JToken token)
+        /// <summary>
+        /// Looks for a property named <paramref name="propertyName"/> and creates a <see cref="ReleaseVersion"/>
+        /// using its value.
+        /// </summary>
+        /// <param name="value">The <see cref="JsonElement"/> to query.</param>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <returns>A <see cref="ReleaseVersion"/> or <see langword="null"/> if the property does not exist or contains a null value.</returns>
+        internal static ReleaseVersion GetReleaseVersionOrDefault(this JsonElement value, string propertyName)
         {
-            return token is null || token is { Type: JTokenType.Null } || !token.HasValues;
+            if (value.TryGetProperty(propertyName, out JsonElement p) && p.ValueKind != JsonValueKind.Null)
+            {
+                return new ReleaseVersion(p.GetString());
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Looks for a property named <paramref name="propertyName"/> and creates a string
+        /// using its value.
+        /// </summary>
+        /// <param name="value">The <see cref="JsonElement"/> to query.</param>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <returns>A string or <see langword="null"/> if the property does not exist or contains a null value.</returns>
+        internal static string GetStringOrDefault(this JsonElement value, string propertyName)
+        {
+            if (value.TryGetProperty(propertyName, out JsonElement p) && p.ValueKind == JsonValueKind.String)
+            {
+                return p.GetString();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Looks for a property named <paramref name="propertyName"/> and creates a <see cref="Uri"/>
+        /// using its value.
+        /// </summary>
+        /// <param name="value">The <see cref="JsonElement"/> to query.</param>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <returns>A <see cref="Uri"/> or <see langword="null"/> if the property does not exist or contains a null value.</returns>
+        internal static Uri GetUriOrDefault(this JsonElement value, string propertyName)
+        {
+            if (value.TryGetProperty(propertyName, out JsonElement p) && p.ValueKind != JsonValueKind.Null)
+            {
+                return new Uri(p.GetString());
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -10,7 +10,7 @@
     <IsPackable Condition="'$(TargetArchitecture)' == 'x86' OR '$(DotNetBuildFromSource)' == 'true'">true</IsPackable>
     <IsShipping>true</IsShipping>
     <PackageId>Microsoft.Deployment.DotNet.Releases</PackageId>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <RootNamespace>Microsoft.Deployment.DotNet.Releases</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -26,13 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ProductRelease.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ProductRelease.cs
@@ -6,8 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
@@ -17,16 +16,8 @@ namespace Microsoft.Deployment.DotNet.Releases
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ProductRelease
     {
-        private string DebuggerDisplay => $"Release {Version} (SDKs: {Sdks.Count}, Runtimes: {AllRuntimes.Count})";
+        private string DebuggerDisplay => $"Release {Version} (SDKs: {Sdks.Count}, Runtimes: {Runtimes.Count})";
 
-        /// <summary>
-        /// A collection of all the runtime components (.NET Core, ASP.NET Core, Windows Desktop, etc.) included in this <see cref="ProductRelease"/>.
-        /// </summary>
-        [JsonIgnore]
-        public ReadOnlyCollection<ReleaseComponent> AllRuntimes
-        {
-            get;
-        }
 
         /// <summary>
         /// The ASP.NET Core runtime included in this release, or <see langword="null"/> if the component is absent."/>
@@ -45,8 +36,8 @@ namespace Microsoft.Deployment.DotNet.Releases
         }
 
         /// <summary>
-        /// The collection CVEs addressed by this release. The collection may be empty if no CVEs are associated with
-        /// the release.
+        /// The collection of CVEs addressed by this release. The collection may be empty if no CVEs are associated with
+        /// it, typically when the release does not contain any security fixes.
         /// </summary>
         public ReadOnlyCollection<Cve> Cves
         {
@@ -64,7 +55,6 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <summary>
         /// <see langword="true"/> if the release version describes a prerelease; <see langword="false"/> otherwise.
         /// </summary>
-        [JsonIgnore]
         public bool IsPreview => !string.IsNullOrWhiteSpace(Version.Prerelease);
 
         /// <summary>
@@ -101,9 +91,17 @@ namespace Microsoft.Deployment.DotNet.Releases
         }
 
         /// <summary>
-        /// The .NET Core Runtime included with this <see cref="ProductRelease"/>.
+        /// The .NET runtime included with this <see cref="ProductRelease"/>.
         /// </summary>
         public RuntimeReleaseComponent Runtime
+        {
+            get;
+        }
+
+        /// <summary>
+        /// A collection of all the runtime components (.NET, ASP.NET Core, Windows Desktop, etc.) included in this <see cref="ProductRelease"/>.
+        /// </summary>
+        public ReadOnlyCollection<ReleaseComponent> Runtimes
         {
             get;
         }
@@ -125,80 +123,88 @@ namespace Microsoft.Deployment.DotNet.Releases
         }
 
         /// <summary>
-        /// The Windows Desktop runtime associated with this release or <see langword="null"/> if the component is absent.
+        /// The Windows desktop runtime associated with this release or <see langword="null"/> if the component is absent.
         /// </summary>
         public WindowsDesktopReleaseComponent WindowsDesktopRuntime
         {
             get;
         }
 
-        internal ProductRelease(JToken jtoken, Product product)
+        /// <summary>
+        /// Creates a new <see cref="ProductRelease"/> instance.
+        /// </summary>
+        /// <param name="element">The JSON element of the release.</param>
+        /// <param name="product">The product to which the release belongs.</param>
+        internal ProductRelease(JsonElement element, Product product)
         {
-            var js = JsonSerializer.CreateDefault(Utils.DefaultSerializerSettings);
+            ReleaseDate = element.GetProperty("release-date").GetDateTime();
+            Version = element.GetReleaseVersionOrDefault("release-version");
+            IsSecurityUpdate = element.GetProperty("security").GetBoolean();
+            ReleaseNotes = element.GetUriOrDefault("release-notes");
+            Product = product;
 
-            List<SdkReleaseComponent> sdkList = new List<SdkReleaseComponent>();
-            var componentList = new List<ReleaseComponent>();
-            var runtimeList = new List<ReleaseComponent>();
+            var cves = new List<Cve>();
 
-            ReleaseDate = jtoken["release-date"].ToObject<DateTime>(js);
-            Version = jtoken["release-version"].ToObject<ReleaseVersion>(js);
-
-            var cveListToken = jtoken["cve-list"];
-            var cveList = cveListToken.IsNullOrEmpty()
-                ? new List<Cve>()
-                : JsonConvert.DeserializeObject<List<Cve>>(cveListToken.ToString(), Utils.DefaultSerializerSettings);
-            Cves = new ReadOnlyCollection<Cve>(cveList);
-            IsSecurityUpdate = jtoken["security"].ToObject<bool>(js);
-            ReleaseNotes = jtoken["release-notes"]?.ToObject<Uri>(js);
-
-            var aspNetCoreRuntimeToken = jtoken["aspnetcore-runtime"];
-            var runtimeToken = jtoken["runtime"];
-            var winDesktopToken = jtoken["windowsdesktop"];
-
-            if (!aspNetCoreRuntimeToken.IsNullOrEmpty())
+            if (element.TryGetProperty("cve-list", out JsonElement cveListElement) && cveListElement.ValueKind == JsonValueKind.Array)
             {
-                AspNetCoreRuntime = new AspNetCoreReleaseComponent(aspNetCoreRuntimeToken, this);
-                runtimeList.Add(AspNetCoreRuntime);
-            }
+                var enumerator = cveListElement.EnumerateArray();
 
-            if (!runtimeToken.IsNullOrEmpty())
-            {
-                Runtime = new RuntimeReleaseComponent(runtimeToken, this);
-                runtimeList.Add(Runtime);
-            }
-
-            if (!winDesktopToken.IsNullOrEmpty())
-            {
-                WindowsDesktopRuntime = new WindowsDesktopReleaseComponent(winDesktopToken, this);
-                runtimeList.Add(WindowsDesktopRuntime);
-            }
-
-            var sdkToken = jtoken["sdk"];
-            var sdksToken = jtoken["sdks"];
-
-            if (!sdksToken.IsNullOrEmpty())
-            {
-                foreach (var token in sdksToken)
+                while (enumerator.MoveNext())
                 {
-                    sdkList.Add(new SdkReleaseComponent(token, this));
+                    cves.Add(JsonSerializer.Deserialize<Cve>(enumerator.Current));
                 }
             }
-            else if (!sdkToken.IsNullOrEmpty())
+
+            Cves = new ReadOnlyCollection<Cve>(cves);
+
+            var runtimes = new List<ReleaseComponent>();
+
+            if (element.TryGetProperty("aspnetcore-runtime", out JsonElement aspNetCoreValue) && aspNetCoreValue.ValueKind != JsonValueKind.Null)
             {
-                sdkList.Add(new SdkReleaseComponent(sdkToken, this));
+                AspNetCoreRuntime = new AspNetCoreReleaseComponent(aspNetCoreValue, this);
+                runtimes.Add(AspNetCoreRuntime);
             }
 
-            componentList.AddRange(runtimeList);
-            componentList.AddRange(sdkList);
+            if (element.TryGetProperty("runtime", out JsonElement runtimeValue) && runtimeValue.ValueKind != JsonValueKind.Null)
+            {
+                Runtime = new RuntimeReleaseComponent(runtimeValue, this);
+                runtimes.Add(Runtime);
+            }
 
-            Sdks = new ReadOnlyCollection<SdkReleaseComponent>(sdkList);
-            Components = new ReadOnlyCollection<ReleaseComponent>(componentList);
-            AllRuntimes = new ReadOnlyCollection<ReleaseComponent>(runtimeList);
+            if (element.TryGetProperty("windowsdesktop", out JsonElement desktopValue) && desktopValue.ValueKind != JsonValueKind.Null)
+            {
+                WindowsDesktopRuntime = new WindowsDesktopReleaseComponent(desktopValue, this);
+                runtimes.Add(WindowsDesktopRuntime);
+            }
 
+            Runtimes = new ReadOnlyCollection<ReleaseComponent>(runtimes);
+
+            var sdks = new List<SdkReleaseComponent>();
+
+            if (element.TryGetProperty("sdks", out JsonElement sdksValue) && sdksValue.ValueKind == JsonValueKind.Array)
+            {
+                var enumerator = sdksValue.EnumerateArray();
+
+                while (enumerator.MoveNext())
+                {
+                    sdks.Add(new SdkReleaseComponent(enumerator.Current, this));
+                }
+            }
+            else if (element.TryGetProperty("sdk", out JsonElement sdkValue) && sdkValue.ValueKind != JsonValueKind.Null)
+            {
+                sdks.Add(new SdkReleaseComponent(sdkValue, this));
+            }
+
+            Sdks = new ReadOnlyCollection<SdkReleaseComponent>(sdks);
+
+            var components = new List<ReleaseComponent>();
+            components.AddRange(runtimes);
+            components.AddRange(sdks);
+            Components = new ReadOnlyCollection<ReleaseComponent>(components);
+
+            // Distinct is necessary because some releases have overlapping files.
             Files = new ReadOnlyCollection<ReleaseFile>(
                 Components.SelectMany(c => c.Files).Distinct().ToList());
-
-            Product = product;
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseFile.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseFile.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
@@ -15,11 +14,13 @@ namespace Microsoft.Deployment.DotNet.Releases
     /// </summary>
     public class ReleaseFile : IEquatable<ReleaseFile>
     {
-        private static readonly SHA512 s_defaultHashAlgorithm = SHA512Managed.Create();
+        private static readonly SHA512 s_defaultHashAlgorithm = SHA512.Create();
 
         /// <summary>
         /// The URL from where to download the file.
         /// </summary>
+        [JsonPropertyName("url")]
+        [JsonInclude]
         public Uri Address
         {
             get;
@@ -29,12 +30,13 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <summary>
         /// The filename and extension of this <see cref="ReleaseFile"/>.
         /// </summary>
-        [JsonIgnore]
         public string FileName => Path.GetFileName(Address.LocalPath);
 
         /// <summary>
         /// The <see cref="SHA512"/> hash of the file.
         /// </summary>
+        [JsonPropertyName("hash")]
+        [JsonInclude]
         public string Hash
         {
             get;
@@ -44,6 +46,8 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <summary>
         /// The version agnostic name and extension of the file.
         /// </summary>
+        [JsonPropertyName("name")]
+        [JsonInclude]
         public string Name
         {
             get;
@@ -53,23 +57,12 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <summary>
         /// The runtime identifier associated with the file.
         /// </summary>
+        [JsonPropertyName("rid")]
+        [JsonInclude]
         public string Rid
         {
             get;
             private set;
-        }
-
-        [JsonConstructor]
-        internal ReleaseFile(
-            [JsonProperty(PropertyName = "hash")] string hash,
-            [JsonProperty(PropertyName = "name")] string name,
-            [JsonProperty(PropertyName = "rid")] string rid,
-            [JsonProperty(PropertyName = "url")] string address)
-        {
-            Hash = hash;
-            Name = name;
-            Rid = rid;
-            Address = new Uri(address);
         }
 
         /// <summary>
@@ -141,17 +134,13 @@ namespace Microsoft.Deployment.DotNet.Releases
         }
 
         /// <summary>
-        /// The default hash function.
+        /// Returns the hash code for this release file.
         /// </summary>
         /// <returns>A hash code for the current object.</returns>
-        public override int GetHashCode()
-        {
-            int hashCode = -28983843;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Hash);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Name);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Rid);
-            hashCode = hashCode * -1521134295 + EqualityComparer<Uri>.Default.GetHashCode(Address);
-            return hashCode;
-        }
+        public override int GetHashCode() =>
+            Hash.GetHashCode() ^ Name.GetHashCode() ^ Rid.GetHashCode() ^ Address.GetHashCode();
+
+        internal static ReleaseFile Create(string hash, string name, string rid, string address) =>
+            new ReleaseFile { Hash = hash, Name = name, Rid = rid, Address = new Uri(address) };
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseVersionConverter.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseVersionConverter.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
@@ -11,29 +12,13 @@ namespace Microsoft.Deployment.DotNet.Releases
     /// </summary>
     internal class ReleaseVersionConverter : JsonConverter<ReleaseVersion>
     {
-        /// <summary>
-        /// Converts the specified <see cref="ReleaseVersion"/> to a string 
-        /// </summary>
-        /// <param name="writer">The <see cref="JsonWriter"/> to use for writing the value.</param>
-        /// <param name="value">The <see cref="ReleaseVersion"/> to write.</param>
-        /// <param name="serializer">The calling serializer</param>
-        public override void WriteJson(JsonWriter writer, ReleaseVersion value, JsonSerializer serializer) =>
-            writer.WriteValue(value.ToString());
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ReleaseVersion value, JsonSerializerOptions options) =>
+            writer.WriteStringValue(value.ToString());
 
-        /// <summary>
-        /// Reads a string value and converts it into a <see cref="ReleaseVersion"/> object.
-        /// </summary>
-        /// <param name="reader">The <see cref="JsonReader"/> to use for reading the object value.</param>
-        /// <param name="objectType">The type of the object.</param>
-        /// <param name="existingValue">The existing value of the object.</param>
-        /// <param name="hasExistingValue">The existing value of the object being read.</param>
-        /// <param name="serializer">The calling serializer.</param>
-        /// <returns>A <see cref="ReleaseVersion"/> created from the object value.</returns>
-        public override ReleaseVersion ReadJson(
-            JsonReader reader, Type objectType, ReleaseVersion existingValue, bool hasExistingValue, JsonSerializer serializer)
-        {
-            var stringValue = (string)reader.Value;
-            return string.IsNullOrWhiteSpace(stringValue) ? null : new ReleaseVersion(stringValue);
-        }
+        /// <inheritdoc />
+        public override ReleaseVersion Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            ReleaseVersion.Parse(reader.GetString());
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/RuntimeReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/RuntimeReleaseComponent.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
@@ -20,7 +19,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <summary>
         /// The versions of Visual Studio for Mac that includes this runtime.
         /// </summary>
-        [JsonProperty(PropertyName = "vs-mac-version")]
+        [JsonPropertyName("vs-mac-version")]
         public string VisualStudioMacVersion
         {
             get;
@@ -31,15 +30,22 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// The versions of Visual Studio that includes this runtime. Multiple versions may be listed, e.g.
         /// &quot;15.9.25, 16.0.16, 16.4.11, 16.6.4&quot;
         /// </summary>
-        [JsonProperty(PropertyName = "vs-version")]
+        [JsonPropertyName("vs-version")]
         public string VisualStudioVersion
         {
             get;
             private set;
         }
 
-        internal RuntimeReleaseComponent(JToken token, ProductRelease release) : base(token, release)
+        /// <summary>
+        /// Creates a new <see cref="RuntimeReleaseComponent"/> instance.
+        /// </summary>
+        /// <param name="element">The JSON element of the component.</param>
+        /// <param name="release">The release to which the component belongs.</param>
+        internal RuntimeReleaseComponent(JsonElement element, ProductRelease release) : base(element, release)
         {
+            VisualStudioMacVersion = element.GetStringOrDefault("vs-mac-version");
+            VisualStudioVersion = element.GetStringOrDefault("vs-version");
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/SdkReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/SdkReleaseComponent.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
@@ -13,7 +11,7 @@ namespace Microsoft.Deployment.DotNet.Releases
     public class SdkReleaseComponent : ReleaseComponent
     {
         /// <summary>
-        /// The version of C# supported by this SDK or <see langword="null"/>.
+        /// The C# language version supported by this SDK.
         /// </summary>
         public string CSharpVersion
         {
@@ -21,7 +19,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         }
 
         /// <summary>
-        /// The F# version supported by this SDK or <see langword="null"/>.
+        /// The F# language version supported by this SDK.
         /// </summary>
         public string FSharpVersion
         {
@@ -75,23 +73,28 @@ namespace Microsoft.Deployment.DotNet.Releases
         }
 
         /// <summary>
-        /// The Visual Basic version supported by this SDK or <see langword="null"/>.
+        /// The Visual Basic language version supported by this SDK.
         /// </summary>
         public string VisualBasicVersion
         {
             get;
         }
 
-        internal SdkReleaseComponent(JToken token, ProductRelease release) : base(token, release)
+        /// <summary>
+        /// Creates a new <see cref="SdkReleaseComponent"/> instance.
+        /// </summary>
+        /// <param name="element">The JSON element of the component.</param>
+        /// <param name="release">The release to which the component belongs.</param>
+        internal SdkReleaseComponent(JsonElement element, ProductRelease release) : base(element, release)
         {
-            CSharpVersion = (string)token["csharp-version"];
-            FSharpVersion = (string)token["fsharp-version"]; 
-            VisualBasicVersion = (string)token["vb-version"];
-            RuntimeVersion = token["runtime-version"]?.ToObject<ReleaseVersion>(Utils.DefaultSerializer);
-            VisualStudioMacSupport = (string)token["vs-mac-support"];
-            VisualStudioMacVersion = (string)token["vs-mac-version"];
-            VisualStudioSupport = (string)token["vs-support"];
-            VisualStudioVersion = (string)token["vs-version"];
+            CSharpVersion = element.GetStringOrDefault("csharp-version");
+            FSharpVersion = element.GetStringOrDefault("fsharp-version");
+            VisualBasicVersion = element.GetStringOrDefault("vb-version");
+            RuntimeVersion = element.GetReleaseVersionOrDefault("runtime-version");
+            VisualStudioMacSupport = element.GetStringOrDefault("vs-mac-support");
+            VisualStudioMacVersion = element.GetStringOrDefault("vs-mac-version");
+            VisualStudioSupport = element.GetStringOrDefault("vs-support");
+            VisualStudioVersion = element.GetStringOrDefault("vs-version");
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/SerializerOptions.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/SerializerOptions.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Deployment.DotNet.Releases
             Converters =
             {
                 new ReleaseVersionConverter(),
-                new SupportPhaseConverter()
+                new SupportPhaseConverter(),
+                new VersionConverter()
             }
         };
     }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/SerializerOptions.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/SerializerOptions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Microsoft.Deployment.DotNet.Releases
+{
+    /// <summary>
+    /// Options used to deserialize the release JSON files.
+    /// </summary>
+    internal static class SerializerOptions
+    {
+        /// <summary>
+        /// The default deserialization options.
+        /// </summary>
+        public static readonly JsonSerializerOptions Default = new JsonSerializerOptions
+        {
+            Converters =
+            {
+                new ReleaseVersionConverter(),
+                new SupportPhaseConverter()
+            }
+        };
+    }
+}

--- a/src/Microsoft.Deployment.DotNet.Releases/src/SupportPhase.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/SupportPhase.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Newtonsoft.Json;
-
 namespace Microsoft.Deployment.DotNet.Releases
 {
     /// <summary>
     /// An enumeration describing the different support phases of a <see cref="Product"/>.
     /// </summary>
-    [JsonConverter(typeof(SupportPhaseConverter))]
     public enum SupportPhase
     {
         /// <summary>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/SupportPhaseConverter.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/SupportPhaseConverter.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
@@ -11,39 +12,12 @@ namespace Microsoft.Deployment.DotNet.Releases
     /// </summary>
     internal class SupportPhaseConverter : JsonConverter<SupportPhase>
     {
-        /// <summary>
-        /// Reads a string value and converts it into a <see cref="SupportPhase"/> enumeration.
-        /// </summary>
-        /// <param name="reader">The <see cref="JsonReader"/> to use for reading the object value.</param>
-        /// <param name="objectType">The type of the object.</param>
-        /// <param name="existingValue">The existing value of the object.</param>
-        /// <param name="hasExistingValue">The existing value of the object being read.</param>
-        /// <param name="serializer">The calling serializer.</param>
-        /// <returns>A <see cref="SupportPhase"/> created from the object value.</returns>
-        public override SupportPhase ReadJson(
-            JsonReader reader, Type objectType, SupportPhase existingValue, bool hasExistingValue, JsonSerializer serializer)
-        {
-            if (reader.TokenType == JsonToken.String)
-            {
-                var tokenValue = reader.Value.ToString();
-                if (!string.IsNullOrWhiteSpace(tokenValue))
-                {
-                    return Enum.TryParse(tokenValue, ignoreCase: true, out SupportPhase result)
-                        ? result
-                        : SupportPhase.Unknown;
-                }
-            }
+        /// <inheritdoc />
+        public override SupportPhase Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            Enum.TryParse(reader.GetString(), ignoreCase: true, out SupportPhase result) ? result : SupportPhase.Unknown;
 
-            return SupportPhase.Unknown;
-        }
-
-        /// <summary>
-        /// Converts the specified <see cref="SupportPhase"/> to a string 
-        /// </summary>
-        /// <param name="writer">The <see cref="JsonWriter"/> to use for writing the value.</param>
-        /// <param name="value">The <see cref="SupportPhase"/> to write.</param>
-        /// <param name="serializer">The calling serializer</param>
-        public override void WriteJson(JsonWriter writer, SupportPhase value, JsonSerializer serializer) =>
-            throw new NotImplementedException();
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, SupportPhase value, JsonSerializerOptions options) =>
+            writer.WriteStringValue($"{value}");
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Utils.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Utils.cs
@@ -6,31 +6,14 @@ using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
     /// <summary>
-    /// Utitlity and help methods.
+    /// Utility and helper methods.
     /// </summary>
     internal class Utils
     {
-        /// <summary>
-        /// Gets the default <see cref="JsonSerializerSettings"/> to use.
-        /// </summary>
-        internal static JsonSerializerSettings DefaultSerializerSettings
-        {
-            get;
-        }
-
-        /// <summary>
-        /// Gets the default <see cref="JsonSerializer"/> to use.
-        /// </summary>
-        internal static JsonSerializer DefaultSerializer
-        {
-            get;
-        }
-
         /// <summary>
         /// Determines if a local file is the latest version compared to an online copy.
         /// </summary>
@@ -79,8 +62,8 @@ namespace Microsoft.Deployment.DotNet.Releases
                 HttpResponseMessage httpResponse = await httpClient.GetAsync(address);
                 httpResponse.EnsureSuccessStatusCode();
 
-                using var fileStream = File.Create(fileName);
-                await httpResponse.Content.CopyToAsync(fileStream);
+                using FileStream stream = File.Create(fileName);
+                await httpResponse.Content.CopyToAsync(stream);
             }
         }
 
@@ -115,7 +98,7 @@ namespace Microsoft.Deployment.DotNet.Releases
                 throw new FileNotFoundException(string.Format(ReleasesResources.FileNotFound, fileName));
             }
 
-            using var stream = File.OpenRead(fileName);
+            using FileStream stream = File.OpenRead(fileName);
             byte[] checksum = hashAlgorithm.ComputeHash(stream);
 
             return BitConverter.ToString(checksum).Replace("-", "").ToLowerInvariant();
@@ -160,21 +143,6 @@ namespace Microsoft.Deployment.DotNet.Releases
             {
                 await DownloadFileAsync(address, path);
             }
-        }
-
-        static Utils()
-        {
-            DefaultSerializerSettings = new JsonSerializerSettings
-            {
-                DateFormatHandling = DateFormatHandling.MicrosoftDateFormat,
-                NullValueHandling = NullValueHandling.Ignore,
-                Converters =
-                {
-                    new ReleaseVersionConverter()
-                }
-            };
-
-            DefaultSerializer = JsonSerializer.CreateDefault(DefaultSerializerSettings);
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/src/VersionConverter.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/VersionConverter.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Deployment.DotNet.Releases
+{
+    /// <summary>
+    /// Fault tolerant version converter that trims out leading and trailing white-space before parsing version numbers.
+    /// </summary>
+    internal class VersionConverter : JsonConverter<Version>
+    {
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, Version value, JsonSerializerOptions options) =>
+            writer.WriteStringValue(value.ToString());
+
+        /// <inheritdoc />
+        public override Version Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            Version.Parse(reader.GetString().Trim());
+    }
+}

--- a/src/Microsoft.Deployment.DotNet.Releases/src/WindowsDesktopReleaseComponent.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/WindowsDesktopReleaseComponent.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Microsoft.Deployment.DotNet.Releases
 {
@@ -15,7 +15,12 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// </summary>
         public override string Name => ReleasesResources.WindowsDesktopReleaseName;
 
-        internal WindowsDesktopReleaseComponent(JToken token, ProductRelease release) : base(token, release)
+        /// <summary>
+        /// Creates a new <see cref="WindowsDesktopReleaseComponent"/> instance.
+        /// </summary>
+        /// <param name="element">The JSON element of the component.</param>
+        /// <param name="release">The release to which the component belongs.</param>
+        internal WindowsDesktopReleaseComponent(JsonElement element, ProductRelease release) : base(element, release)
         {
         }
     }

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/CveTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/CveTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using Xunit;
 
 namespace Microsoft.Deployment.DotNet.Releases.Tests
@@ -13,10 +14,10 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         public void ItImplementsIEquatable()
         {
             List<Cve> cves = new List<Cve>();
-            var cve1 = new Cve("cve-1", "https://cve.com");
-            var cve2 = new Cve("cve-1", "https://cve.com");
+            var cve1 = Cve.Create("cve-1", "https://cve.com");
+            var cve2 = Cve.Create("cve-1", "https://cve.com");
 
-            cves.Add(new Cve("cve-2", "https://cve.com"));
+            cves.Add(Cve.Create("cve-2", "https://cve.com"));
             cves.Add(cve1);
             cves.Add(cve2);
 
@@ -27,10 +28,19 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public void GetHashCodeReturnsTheSameValueIfObjectsAreEqual()
         {
-            var a = new Cve("cve-1", "https://cve.com");
-            var b = new Cve("cve-1", "https://cve.com");
+            var a = Cve.Create("cve-1", "https://cve.com");
+            var b = Cve.Create("cve-1", "https://cve.com");
 
             Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Fact]
+        public void ItCanDeserializeACveEntry()
+        {
+            Cve cve = JsonSerializer.Deserialize<Cve>(@"{""cve-id"": ""CVE-2020-1147"", ""cve-url"": ""https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1147""}");
+
+            Assert.Equal("CVE-2020-1147", cve.Id);
+            Assert.Equal("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1147", cve.DescriptionLink.ToString());
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/Microsoft.Deployment.DotNet.Releases.Tests.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/Microsoft.Deployment.DotNet.Releases.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.Deployment.DotNet.Releases.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ProductCollectionTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ProductCollectionTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public async Task ItReturnsAllSupportPhases()
         {
-            ProductCollection products = await ProductCollection.GetFromFileAsync(@"data\\releases-index.json", false);
+            ProductCollection products = await ProductCollection.GetFromFileAsync(@"data\\releases-index.json", false).ConfigureAwait(false);
             IEnumerable<SupportPhase> supportPhases = products.GetSupportPhases();
 
             Assert.Equal(4, supportPhases.Count());
@@ -28,26 +28,26 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public async Task ItThrowsIfPathIsNull()
         {
-            Func<Task> f = async () => await ProductCollection.GetFromFileAsync((string)null, false);
+            Func<Task> f = async () => await ProductCollection.GetFromFileAsync((string)null, false).ConfigureAwait(false); ;
 
-            _ = await Assert.ThrowsAsync<ArgumentNullException>(f);
+            _ = await Assert.ThrowsAsync<ArgumentNullException>(f).ConfigureAwait(false); 
         }
 
         [Fact]
         public async Task ItThrowsIfPathIsEmpty()
         {
-            Func<Task> f = async () => await ProductCollection.GetFromFileAsync("", false);
+            Func<Task> f = async () => await ProductCollection.GetFromFileAsync("", false).ConfigureAwait(false); 
 
-            ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(f);
-            Assert.Equal($"Value cannot be empty.{Environment.NewLine}Parameter name: path", exception.Message);
+            ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(f).ConfigureAwait(false);
+            Assert.Equal($"Value cannot be empty. (Parameter 'path')", exception.Message);
         }
 
         [Fact]
         public async Task ItThrowsIfFileDoesNotExitAndCannotBeDownloaded()
         {
-            Func<Task> f = async () => await ProductCollection.GetFromFileAsync("data.json", false);
+            Func<Task> f = async () => await ProductCollection.GetFromFileAsync("data.json", false).ConfigureAwait(false);
 
-            FileNotFoundException exception = await Assert.ThrowsAsync<FileNotFoundException>(f);
+            FileNotFoundException exception = await Assert.ThrowsAsync<FileNotFoundException>(f).ConfigureAwait(false);
 
             Assert.Equal("Could not find the specified file: data.json", exception.Message);
         }
@@ -55,18 +55,18 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public async Task ItThrowsIfReleasesUriIsNull()
         {
-            Func<Task> f = async () => await ProductCollection.GetAsync((string)null);
+            Func<Task> f = async () => await ProductCollection.GetAsync((string)null).ConfigureAwait(false);
 
-            ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(f);
+            ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(f).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task ItThrowsIfReleasesUriIsEmpty()
         {
-            Func<Task> f = async () => await ProductCollection.GetAsync("");
+            Func<Task> f = async () => await ProductCollection.GetAsync("").ConfigureAwait(false);
 
-            ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(f);
-            Assert.Equal($"Value cannot be empty.{Environment.NewLine}Parameter name: releasesIndexUri", exception.Message);
+            ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(f).ConfigureAwait(false);
+            Assert.Equal($"Value cannot be empty. (Parameter 'releasesIndexUri')", exception.Message);
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ProductReleaseTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ProductReleaseTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public async Task ItCanCreateASingleRelease()
         {
-            var releases = await Product.GetReleasesAsync(@"data\5.0\releases.json");
+            var releases = await Product.GetReleasesAsync(@"data\5.0\releases.json").ConfigureAwait(false);
 
             Assert.Equal(new ReleaseVersion("5.0.0-preview.7"), releases[0].Version);
             Assert.Null(releases[0].Product);

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ProductReleaseTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ProductReleaseTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Linq;
 using Xunit;
 using System.Threading.Tasks;
@@ -51,6 +52,23 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
 
             Assert.Equal(new ReleaseVersion("5.0.0-preview.7"), releases[0].Version);
             Assert.Null(releases[0].Product);
+        }
+
+        [Fact]
+        public async Task ItCanParseTheLatestPublishedJson()
+        {
+            string tempPath = Path.GetRandomFileName();
+            var products = await ProductCollection.GetFromFileAsync(
+                Path.Combine(tempPath, "releases-index.json"), downloadLatest: true).ConfigureAwait(false);
+
+            foreach (var product in products)
+            {
+                await product.GetReleasesAsync(Path.Combine(tempPath, product.ProductVersion, "releases.json"), downloadLatest: true).ConfigureAwait(false);
+            }
+
+            // Nothing to assert, but we want to ensure there are no exceptions parsing all the latest data from the CDN
+
+            Directory.Delete(tempPath, recursive: true);
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ProductTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ProductTests.cs
@@ -8,22 +8,22 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
 {
     public class ProductsTests : TestBase
     {
-        private static readonly string ProductWithEolSupportPhaseJson = @"{""channel-version"": ""2.2"", ""latest-release"": ""2.2.8"", ""latest-release-date"": ""2019-11-19"",
+        private const string s_productWithEolSupportPhaseJson = @"{""channel-version"": ""2.2"", ""latest-release"": ""2.2.8"", ""latest-release-date"": ""2019-11-19"",
 ""security"": true, ""latest-runtime"": ""2.2.8"", ""latest-sdk"": ""2.2.207"", ""product"": "".NET Core"", ""support-phase"": ""eol"",
 ""eol-date"": ""2019-12-23"", ""releases.json"": ""https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json""}";
 
-        private static readonly string ProductWithEolDateJson = @"{""channel-version"": ""2.2"", ""latest-release"": ""2.2.8"", ""latest-release-date"": ""2019-11-19"",
+        private const string s_productWithEolDateJson = @"{""channel-version"": ""2.2"", ""latest-release"": ""2.2.8"", ""latest-release-date"": ""2019-11-19"",
 ""security"": true, ""latest-runtime"": ""2.2.8"", ""latest-sdk"": ""2.2.207"", ""product"": "".NET Core"", ""support-phase"": ""current"",
 ""eol-date"": ""2019-12-23"", ""releases.json"": ""https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json""}";
 
-        private static readonly string ProductWithNullEolDateJson = @"{""channel-version"": ""2.2"", ""latest-release"": ""2.2.8"", ""latest-release-date"": ""2019-11-19"",
+        private const string s_productWithNullEolDateJson = @"{""channel-version"": ""2.2"", ""latest-release"": ""2.2.8"", ""latest-release-date"": ""2019-11-19"",
 ""security"": true, ""latest-runtime"": ""2.2.8"", ""latest-sdk"": ""2.2.207"", ""product"": "".NET Core"", ""support-phase"": ""current"",
 ""eol-date"": null, ""releases.json"": ""https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json""}";
 
         [Fact]
         public void IsOutOfSupportChecksEolDateIfSupportPhaseIsNotEol()
         {
-            var product = CreateProduct(ProductWithEolDateJson);
+            Product product = CreateProduct(s_productWithEolDateJson);
 
             Assert.True(product.IsOutOfSupport());
         }
@@ -31,7 +31,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public void IsOutOfSupportChecksSupportPhaseFirst()
         {
-            var product = CreateProduct(ProductWithEolSupportPhaseJson);
+            Product product = CreateProduct(s_productWithEolSupportPhaseJson);
 
             Assert.True(product.IsOutOfSupport());
         }
@@ -39,7 +39,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public void IsOutOfSupportReturnsFalseIfEolDateIsNull()
         {
-            var product = CreateProduct(ProductWithNullEolDateJson);
+            Product product = CreateProduct(s_productWithNullEolDateJson);
 
             Assert.False(product.IsOutOfSupport());
         }

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/ReleaseFileTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/ReleaseFileTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public void ItReturnsTrueIfReferenceEquals()
         {
-            ReleaseFile f1 = new ReleaseFile("abcdef", "foo", "win-x86", "https://here.there.com");
+            ReleaseFile f1 = ReleaseFile.Create("abcdef", "foo", "win-x86", "https://here.there.com");
             ReleaseFile f2 = f1;
 
             Assert.Equal(f1, f2);
@@ -22,8 +22,8 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public void ItReturnsTrueIfValuesAreEquals()
         {
-            ReleaseFile f1 = new ReleaseFile("abcdef", "foo", "win-x86", "https://here.there.com");
-            ReleaseFile f2 = new ReleaseFile("abcdef", "foo", "win-x86", "https://here.there.com");
+            ReleaseFile f1 = ReleaseFile.Create("abcdef", "foo", "win-x86", "https://here.there.com");
+            ReleaseFile f2 = ReleaseFile.Create("abcdef", "foo", "win-x86", "https://here.there.com");
 
             Assert.Equal(f1, f2);
         }
@@ -31,8 +31,8 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public void ItReturnsFalseIfReferenceEquals2()
         {
-            ReleaseFile f1 = new ReleaseFile("abcdef", "Foo", "win-x86", "https://here.there.com");
-            ReleaseFile f2 = new ReleaseFile("abcdef", "foo", "win-x86", "https://here.there.com");
+            ReleaseFile f1 = ReleaseFile.Create("abcdef", "Foo", "win-x86", "https://here.there.com");
+            ReleaseFile f2 = ReleaseFile.Create("abcdef", "foo", "win-x86", "https://here.there.com");
 
             Assert.NotEqual(f1, f2);
         }
@@ -40,9 +40,22 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         [Fact]
         public void ItComputesTheFileNameFromTheUrl()
         {
-            ReleaseFile f1 = new ReleaseFile("abcdef", "Foo", "win-x86", "https://here.there.com/foo-win-x86.exe");
+            ReleaseFile f1 = ReleaseFile.Create("abcdef", "Foo", "win-x86", "https://here.there.com/foo-win-x86.exe");
 
             Assert.Equal("foo-win-x86.exe", f1.FileName);
+        }
+
+        [Fact]
+        public void ItCreatesReleaseComponents()
+        {
+            ProductRelease release = GetProductRelease("3.1", "3.1.6");
+
+            Assert.Equal("16.4.11, 16.6.3", release.AspNetCoreRuntime.VisualStudioVersion);
+            Assert.Equal(new Version("13.1.20169.6"), release.AspNetCoreRuntime.AspNetCoreModuleVersions[0]);
+
+            // This is technically a typo in the releases data since the vs-version properties should line up.
+            Assert.Equal("16.4.11, 16.6.4", release.Runtime.VisualStudioVersion);
+            Assert.Equal("8.0", release.Sdks[0].CSharpVersion);
         }
 
         [Fact]
@@ -50,9 +63,9 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         {
             ProductRelease release = GetProductRelease("2.1", "2.1.8");
             ReleaseFile file = release.Files.FirstOrDefault();
-            Func<Task> f = async () => await file.DownloadAsync(null);
+            Func<Task> f = async () => await file.DownloadAsync(null).ConfigureAwait(false);
 
-            ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(f);
+            ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(f).ConfigureAwait(false);
         }
 
         [Fact]
@@ -60,11 +73,11 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         {
             ProductRelease release = GetProductRelease("2.1", "2.1.8");
             ReleaseFile file = release.Files.FirstOrDefault();
-            Func<Task> f = async () => await file.DownloadAsync("");
+            Func<Task> f = async () => await file.DownloadAsync("").ConfigureAwait(false);
 
-            ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(f);
+            ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(f).ConfigureAwait(false);
 
-            Assert.Equal($"Value cannot be empty.{Environment.NewLine}Parameter name: destinationPath", exception.Message);
+            Assert.Equal($"Value cannot be empty. (Parameter 'destinationPath')", exception.Message);
         }
     }
 }

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/SupportPhaseConverterTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/SupportPhaseConverterTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using Xunit;
 
 namespace Microsoft.Deployment.DotNet.Releases.Tests
@@ -25,7 +25,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         public void ItIsCaseInsenitive(string supportPhaseValue, SupportPhase expectedSupportPhase)
         {
             var json = $@"{{""SupportPhase"":""{supportPhaseValue}""}}";
-            var testObject = JsonConvert.DeserializeObject<TestObject>(json, new SupportPhaseConverter());
+            var testObject = JsonSerializer.Deserialize<TestObject>(json, SerializerOptions.Default);
 
             Assert.Equal(expectedSupportPhase, testObject.SupportPhase);
         }
@@ -36,7 +36,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         public void ItReturnsUnknownIfParsingFails(string supportPhaseValue)
         {
             var json = $@"{{""SupportPhase"":""{supportPhaseValue}""}}";
-            var testObject = JsonConvert.DeserializeObject<TestObject>(json, new SupportPhaseConverter());
+            var testObject = JsonSerializer.Deserialize<TestObject>(json, SerializerOptions.Default);
 
             Assert.Equal(SupportPhase.Unknown, testObject.SupportPhase);
         }

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/TestBase.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/TestBase.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Xunit;
 
 namespace Microsoft.Deployment.DotNet.Releases.Tests
@@ -50,14 +50,14 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
 
         public async Task InitializeAsync()
         {
-            Products = await ProductCollection.GetFromFileAsync(@"data\\releases-index.json", false);
+            Products = await ProductCollection.GetFromFileAsync(@"data\\releases-index.json", false).ConfigureAwait(false);
             ProductReleases = new Dictionary<string, ReadOnlyCollection<ProductRelease>>();
 
-            foreach (var product in Products)
+            foreach (Product product in Products)
             {
-                var releasesJsonPath = Path.Combine("data", product.ProductVersion, "releases.json");
+                string releasesJsonPath = Path.Combine("data", product.ProductVersion, "releases.json");
 
-                ProductReleases[product.ProductVersion] = await product.GetReleasesAsync(releasesJsonPath, downloadLatest: false);
+                ProductReleases[product.ProductVersion] = await product.GetReleasesAsync(releasesJsonPath, downloadLatest: false).ConfigureAwait(false);
             }
         }
 
@@ -68,7 +68,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         /// <returns></returns>
         protected Product CreateProduct(string json)
         {
-            return JsonConvert.DeserializeObject<Product>(json, Utils.DefaultSerializerSettings);
+            return JsonSerializer.Deserialize<Product>(json, SerializerOptions.Default);
         }
 
         /// <summary>

--- a/src/Microsoft.Deployment.DotNet.Releases/tests/UtilsTests.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/tests/UtilsTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         {
             ArgumentNullException e = Assert.Throws<ArgumentNullException>(() =>
             {
-                Utils.GetFileHash(null, SHA512Managed.Create());
+                Utils.GetFileHash(null, SHA512.Create());
             });
         }
 
@@ -25,10 +25,10 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
         {
             ArgumentException e = Assert.Throws<ArgumentException>(() =>
             {
-                Utils.GetFileHash("", SHA512Managed.Create());
+                Utils.GetFileHash("", SHA512.Create());
             });
 
-            Assert.Equal($"Value cannot be empty.{Environment.NewLine}Parameter name: fileName", e.Message);
+            Assert.Equal($"Value cannot be empty. (Parameter 'fileName')", e.Message);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
                 Utils.GetFileHash("File.txt", null);
             });
 
-            Assert.Equal($"Value cannot be null.{Environment.NewLine}Parameter name: hashAlgorithm", e.Message);
+            Assert.Equal($"Value cannot be null. (Parameter 'hashAlgorithm')", e.Message);
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace Microsoft.Deployment.DotNet.Releases.Tests
 
             Uri sourceAddress = new Uri(Path.GetFullPath(sourceFile));
             string destinationFile = Path.GetFullPath(Path.GetTempFileName());
-            await Utils.DownloadFileAsync(sourceAddress, destinationFile);
+            await Utils.DownloadFileAsync(sourceAddress, destinationFile).ConfigureAwait(false);
 
             HashAlgorithm sha256 = SHA256.Create();
             string sourceHash = Utils.GetFileHash(sourceFile, sha256);


### PR DESCRIPTION
This PR removes the Newtonsoft.Json dependency. Additionally, the library now only support .NET Standard 2.0