### PR TITLE
Update package references to resolve warnings

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -102,8 +102,9 @@
     <RefOnlyMicrosoftBuildFrameworkVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildFrameworkVersion>
     <RefOnlyMicrosoftBuildTasksCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildTasksCoreVersion>
     <RefOnlyMicrosoftBuildUtilitiesCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildUtilitiesCoreVersion>
-    <RefOnlyNugetProjectModelVersion>4.9.4</RefOnlyNugetProjectModelVersion>
-    <RefOnlyNugetPackagingVersion>4.9.4</RefOnlyNugetPackagingVersion>
+    <RefOnlyNugetProtocolVersion>4.9.6</RefOnlyNugetProtocolVersion>
+    <RefOnlyNugetProjectModelVersion>4.9.6</RefOnlyNugetProjectModelVersion>
+    <RefOnlyNugetPackagingVersion>4.9.6</RefOnlyNugetPackagingVersion>
     <!-- System.Data.SqlClient -->
     <SystemDataSqlClientVersion>4.8.0</SystemDataSqlClientVersion>
     <!-- Testing -->

--- a/src/clickonce/MageCLI/MageCLI.csproj
+++ b/src/clickonce/MageCLI/MageCLI.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(ArtifactsBinDir)Launcher/$(Configuration)/net45/Launcher.exe" />

--- a/tools-local/tasks/installer.tasks/installer.tasks.csproj
+++ b/tools-local/tasks/installer.tasks/installer.tasks.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
+    <PackageReference Include="NuGet.Protocol" Version="$(RefOnlyNugetProtocolVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(RefOnlyNugetProjectModelVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(RefOnlyNugetPackagingVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.7.0" />


### PR DESCRIPTION
Fixes:

- Update NuGet.Protocol and related packages to 4.9.6
- Add explicit dependency to System.Drawing.Common 4.7.2 package, in MageCLI project
