### PR TITLE
Turn of caching

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -11,7 +11,7 @@
     <IsShipping>true</IsShipping>
     <PackageId>Microsoft.Deployment.DotNet.Releases</PackageId>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <RootNamespace>Microsoft.Deployment.DotNet.Releases</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableXlfLocalization>true</EnableXlfLocalization>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
-using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -202,8 +201,7 @@ namespace Microsoft.Deployment.DotNet.Releases
                 throw new ArgumentNullException(nameof(address));
             }
 
-            using var client = new HttpClient();
-            using var stream = new MemoryStream(await client.GetByteArrayAsync(address));
+            using var stream = new MemoryStream(await Utils.s_httpClient.GetByteArrayAsync(address));
             using var reader = new StreamReader(stream);
 
             return await GetReleasesAsync(reader, this);

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ProductCollection.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ProductCollection.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -79,8 +78,7 @@ namespace Microsoft.Deployment.DotNet.Releases
                 throw new ArgumentNullException(nameof(releasesIndexUrl));
             }
 
-            using var client = new HttpClient();
-            using var stream = new MemoryStream(await client.GetByteArrayAsync(releasesIndexUrl));
+            using var stream = new MemoryStream(await Utils.s_httpClient.GetByteArrayAsync(releasesIndexUrl));
             using var reader = new StreamReader(stream);
 
             return await GetAsync(reader);


### PR DESCRIPTION
When the CDN is updated, default cache headers can still result in retrieving stale copies of the releases JSON files. Instead, we configure the default headers to turn caching off.