### PR TITLE
build.cmd: Fix VS2022 setup vars

### DIFF
--- a/src/clickonce/native/build.cmd
+++ b/src/clickonce/native/build.cmd
@@ -73,8 +73,8 @@ exit /b 1
 
 :VS2022
 :: Setup vars for VS2022
-set __PlatformToolset=v142
-set __VSVersion=16 2019
+set __PlatformToolset=v143
+set __VSVersion=17 2022
 :: Set the environment for the native build
 call "%VS170COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%
 goto :SetupDirs


### PR DESCRIPTION
Hi,

I was trying to build this project on my own machine which has only VS2022 installed and I found out I was not able to build it because the vars were simply setup wrong. Fixing those made the project building successfully.

Feel free to ping me if you have any question but the PR is pretty much self-explanatory.

Cheers!