### PR TITLE
Do not set repo-specific NETCoreAppMaximumVersion property

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,12 +11,4 @@
   <Import Project="$(RepositoryEngineeringDir)python.targets" />
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(SkipImportArcadeSdkFromRoot)' != 'true'" />
 
-  <PropertyGroup>
-    <!--
-      Define this here (not just in Versions.props) because the SDK resets it
-      unconditionally in Microsoft.NETCoreSdk.BundledVersions.props.
-    -->
-    <NETCoreAppMaximumVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppMaximumVersion>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
We were setting NETCoreAppMaximumVersion property to a repo-specific value, constructed from `MajorVersion` and `MinorVersion`. This causes issues for projects that use custom versioning.

There is no need for this, as the property is set by .NET SDK.