### PR TITLE
Expose ActivationData to launched .NET app

### DIFF
--- a/src/clickonce/launcher/Program.cs
+++ b/src/clickonce/launcher/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Win32;
 using System;
 using System.Deployment.Application;
 using System.IO;
+using System.Linq;
 
 namespace Microsoft.Deployment.Launcher
 {
@@ -140,8 +141,8 @@ namespace Microsoft.Deployment.Launcher
         {
             if (ApplicationDeployment.IsNetworkDeployed)
             {
+                // ApplicationDeployment properties
                 ApplicationDeployment ad = ApplicationDeployment.CurrentDeployment;
-
                 Environment.SetEnvironmentVariable("ClickOnce_ActivationUri", ad.ActivationUri?.ToString());
                 Environment.SetEnvironmentVariable("ClickOnce_CurrentVersion", ad.CurrentVersion?.ToString());
                 Environment.SetEnvironmentVariable("ClickOnce_DataDirectory", ad.DataDirectory?.ToString());
@@ -150,6 +151,17 @@ namespace Microsoft.Deployment.Launcher
                 Environment.SetEnvironmentVariable("ClickOnce_UpdatedApplicationFullName", ad.UpdatedApplicationFullName?.ToString());
                 Environment.SetEnvironmentVariable("ClickOnce_UpdatedVersion", ad.UpdatedVersion?.ToString());
                 Environment.SetEnvironmentVariable("ClickOnce_UpdateLocation", ad.UpdateLocation?.ToString());
+
+                // ClickOnce ActivationData
+                string[] activationData = AppDomain.CurrentDomain?.SetupInformation?.ActivationArguments?.ActivationData;
+                if (activationData != null && activationData.Count() > 0)
+                {
+                    Environment.SetEnvironmentVariable("ClickOnce_ActivationData_Count", activationData.Count().ToString());
+                    for (int i = 0; i < activationData.Count(); i++)
+                    {
+                        Environment.SetEnvironmentVariable($"ClickOnce_ActivationData_{i}", activationData[i]);
+                    }
+                }
             }
 
             Environment.SetEnvironmentVariable("ClickOnce_IsNetworkDeployed", ApplicationDeployment.IsNetworkDeployed.ToString());

--- a/src/clickonce/launcher/Program.cs
+++ b/src/clickonce/launcher/Program.cs
@@ -5,7 +5,6 @@ using Microsoft.Win32;
 using System;
 using System.Deployment.Application;
 using System.IO;
-using System.Linq;
 
 namespace Microsoft.Deployment.Launcher
 {
@@ -154,10 +153,10 @@ namespace Microsoft.Deployment.Launcher
 
                 // ClickOnce ActivationData
                 string[] activationData = AppDomain.CurrentDomain?.SetupInformation?.ActivationArguments?.ActivationData;
-                if (activationData != null && activationData.Count() > 0)
+                if (activationData != null && activationData.Length > 0)
                 {
-                    Environment.SetEnvironmentVariable("ClickOnce_ActivationData_Count", activationData.Count().ToString());
-                    for (int i = 0; i < activationData.Count(); i++)
+                    Environment.SetEnvironmentVariable("ClickOnce_ActivationData_Count", activationData.Length.ToString());
+                    for (int i = 0; i < activationData.Length; i++)
                     {
                         Environment.SetEnvironmentVariable($"ClickOnce_ActivationData_{i}", activationData[i]);
                     }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/deployment-tools/issues/236 and https://github.com/dotnet/deployment-tools/issues/113

### Description

This work enables .NET app, deployed using ClickOnce, to use the activation arguments.

This solves two scenarios:
1) app was activated using appref-ms shortcut and custom arguments were provided on the command-line
2) app was activated using a file with custom extension, registered using file association feature

Launcher reads the `AppDomain.CurrentDomain.SetupInformation.ActivationArguments.ActivationData` array and sets some environment variables if array is non-empty.

### New environment variables

`ClickOnce_ActivationData_Count`

If this variable exists, the value is the count of elements in ActivationData string array.

`ClickOnce_ActivationData_<n>`

For each element in array, new environment variable gets added, with a zero-based index, i.e.:
`ClickOnce_ActivationData_0`
`ClickOnce_ActivationData_1`
...

Note that the scenarios being fixed always use the `0`-index element, so the variable will always be `ClickOnce_ActivationData_0`, but the code is flexible and is able to pass all activation data to .NET app.

### Usage scenario

Developer can read these environment variables to discover ActivationData content, using something like the following:

`string value = Environment.GetEnvironmentVariable("ClickOnce_ActivationData_0");`

Previously, for .NET FX apps, this would have been achieved using the following code:

`string value = AppDomain.CurrentDomain?.SetupInformation?.ActivationArguments?.ActivationData?[0];`
