### PR TITLE
Launcher PDB should be published

### DIFF
--- a/src/clickonce/launcher/Launcher.csproj
+++ b/src/clickonce/launcher/Launcher.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable Condition="'$(TargetArchitecture)' == 'x86'">true</IsPackable>
-    <IsShipping>false</IsShipping>
+    <IsShipping>true</IsShipping>
     <IsShippingPackage>false</IsShippingPackage>
     <PackageId>VS.Redist.Common.NetCore.Launcher</PackageId>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>


### PR DESCRIPTION
Enables publishing of Launcher PDB to symbol server.

I've verified that Launcher symbols are now included in PdbArtifacts: https://dev.azure.com/dnceng/internal/_build/results?buildId=2112719&view=logs&j=6c8d8e10-00f6-599f-9a42-dac02746d52f&t=9f58a776-c5c2-5290-ec37-0f37735a229a