### PR TITLE
Source-build should only target NetCurrent

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -11,7 +11,8 @@
     <IsPackable Condition="'$(TargetArchitecture)' == 'x86' OR '$(DotNetBuildFromSource)' == 'true'">true</IsPackable>
     <IsShipping>true</IsShipping>
     <PackageId>Microsoft.Deployment.DotNet.Releases</PackageId>
-    <TargetFrameworks>netstandard2.0;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">netstandard2.0;$(TargetFrameworks)</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>Microsoft.Deployment.DotNet.Releases</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/deployment-tools/issues/217

`Microsoft.Deployment.DotNet.Releases` is the only project that is building for source-build.

This change limits target TFM to `NetCurrent`, which, at the moment, is `net8.0`.