### PR TITLE
Remove trimmable setting which is not supported in netstandard2.0

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -5,8 +5,6 @@
     <MinorVersion>0</MinorVersion>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <IsTrimmable>true</IsTrimmable>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #288

According to https://learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1195, trimming in only supported on netcoreapp3.0 and above.  Microsoft.Deployment.DotNet.Releases targets netstandard2.0