### PR TITLE
Update SDK versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -18,7 +18,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24062.5",
-    "Microsoft.Build.NoTargets": "1.0.53",
-    "Microsoft.Build.Traversal": "2.0.34"
+    "Microsoft.Build.NoTargets": "3.7.0",
+    "Microsoft.Build.Traversal": "3.4.0"
   }
 }


### PR DESCRIPTION
Updating versions of `Microsoft.Build.NoTarget` and `Microsoft.Build.Traversal` SDKs to the latest available.
