### PR TITLE
Use new Arcade simplified extension point and

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,28 +1,10 @@
 <Project>
 
   <PropertyGroup>
-    <!-- Don't push rid agnostic nuget packages from other builds than win-x64 when not building inside the VMR. -->
-    <EnableDefaultPublishItems Condition="'$(DotNetBuildRepo)' != 'true' and
-                                          '$(TargetArchitecture)' != 'x64' and
-                                          '$(TargetArchitecture)' != ''">false</EnableDefaultPublishItems>
     <!-- This avoids creating VS.*.symbols.nupkg packages that are identical to the original package. -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
+    <!-- Set PlatformName to TargetArchitecture to create unique build manifest files. -->
+    <PlatformName Condition="'$(TargetArchitecture)' != ''">$(TargetArchitecture)</PlatformName>
   </PropertyGroup>
-
-  <Target Name="SetPackageToInclude"
-          BeforeTargets="BeforePublish"
-          Condition="'$(EnableDefaultPublishItems)' != 'true'">
-    <ItemGroup>
-      <!-- Only include RID specific packages -->
-      <PackageToInclude Include="Microsoft.NET.Tools.NETCoreCheck" />
-      <PackageToInclude Include="VS.Redist.Common.NETCoreCheck" />
-
-      <ExistingSymbolPackages Include="$(ArtifactsShippingPackagesDir)**/%(PackageToInclude.Identity)*.symbols.nupkg" IsShipping="true" />
-      <ExistingSymbolPackages Include="$(ArtifactsNonShippingPackagesDir)**/%(PackageToInclude.Identity)*.symbols.nupkg" IsShipping="false" />
-
-      <PackagesToPublish Include="$(ArtifactsShippingPackagesDir)**/%(PackageToInclude.Identity)*.nupkg" IsShipping="true" />
-      <PackagesToPublish Include="$(ArtifactsNonShippingPackagesDir)**/%(PackageToInclude.Identity)*.nupkg" IsShipping="false" />
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <UseDotNetCertificate>true</UseDotNetCertificate>
+    <!-- Don't sign and publish rid agnostic nuget packages from other builds than win-x64 when not building inside the VMR. -->
+    <EnableDefaultArtifacts Condition="'$(DotNetBuildOrchestrator)' != 'true' and
+                                       '$(TargetArchitecture)' != 'x64' and
+                                       '$(TargetArchitecture)' != ''">false</EnableDefaultArtifacts>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,9 +13,11 @@
     <FileSignInfo Include="Launcher.exe" CertificateName="None" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ItemsToSign Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheck.exe" />
-    <ItemsToSign Include="$(ArtifactsBinDir)win-$(TargetArchitecture).$(Configuration)\**\netcorecheckca.dll" />
+  <!-- Include RID specific packages when default items are disabled. -->
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'true'">
+    <Artifact Include="$(ArtifactsPackagesDir)**\Microsoft.NET.Tools.NETCoreCheck.*.nupkg;
+                       $(ArtifactsPackagesDir)**\VS.Redist.Common.NETCoreCheck.*.nupkg"
+              IsShipping="$([System.String]::Copy('%(RecursiveDir)').StartsWith('Shipping'))" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
... fix manifest file being overwritten.

From the last official build:

![image](https://github.com/dotnet/deployment-tools/assets/7412651/9726e660-cc32-4b28-8ced-afc13b31df5b)

There should be four manifest files but the Windows legs used the same PlatformName=AnyCPU which causes publish artifacts to be missing.