### PR TITLE
1ES pipeline templates

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -1,0 +1,52 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - release/*
+
+pr:
+- main
+- release/*
+
+
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+variables:
+  - name: TeamName
+    value: dotnet-core-acquisition
+  - name: SignType
+    value: test
+
+stages:
+- stage: Build
+  jobs:
+  # -------- Build Windows legs --------
+  # Windows x64
+  - template: /eng/jobs/windows-build-PR.yml
+    parameters:
+      name: win_x64
+      displayName: win-x64
+      targetArchitecture: x64
+      codeql: true
+
+  # Windows x86
+  - template: /eng/jobs/windows-build-PR.yml
+    parameters:
+      name: win_x86
+      displayName: win-x86
+      targetArchitecture: x86
+
+  # Windows arm64
+  - template: /eng/jobs/windows-build-PR.yml
+    parameters:
+      name: win_arm64
+      displayName: win-arm64
+      targetArchitecture: arm64
+  
+  # Source-build
+  - template: /eng/common/templates/jobs/source-build.yml
+    parameters:
+        platform:
+          name: 'Managed'
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,106 +5,88 @@ trigger:
     - main
     - release/*
     - internal/release/*
-
 pr:
 - main
 - release/*
 - internal/release/*
-
-
 name: $(Date:yyyyMMdd)$(Rev:.r)
-
 variables:
-  - name: TeamName
-    value: dotnet-core-acquisition
-  # Produce test-signed build for PR and Public builds
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: SignType
-      value: test
-
-  # Set up non-PR build from internal project
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: SignType
-      value: $[ coalesce(variables.OfficialSignType, 'real') ]
-    # Values for SDLValidationParameters
-    - group: core-setup-sdl-validation
-
-stages:
-- stage: Build
-  jobs:
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-    - template: /eng/common/templates/job/onelocbuild.yml
-      parameters:
-        MirrorRepo: deployment-tools
-        LclSource: lclFilesfromPackage
-        LclPackageId: 'LCL-JUNO-PROD-MAGE'
-  # -------- Build Windows legs --------
-  # Windows x64
-  - template: /eng/jobs/windows-build.yml
-    parameters:
-      name: win_x64
-      displayName: win-x64
-      targetArchitecture: x64
-      codeql: true
-
-  # Windows x86
-  - template: /eng/jobs/windows-build.yml
-    parameters:
-      name: win_x86
-      displayName: win-x86
-      targetArchitecture: x86
-
-  # Windows arm64
-  - template: /eng/jobs/windows-build.yml
-    parameters:
-      name: win_arm64
-      displayName: win-arm64
-      targetArchitecture: arm64
-  
-  # Source-build
-  - template: /eng/common/templates/jobs/source-build.yml
-    parameters:
-        platform:
-          name: 'Managed'
-          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9'
-
-  # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        publishAssetsImmediately: true
-        dependsOn:
-          - win_x64
-          - win_x86
-          - win_arm64
-          - Source_Build_Managed
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022.amd64
-
-# Stages-based publishing entry point
+- name: TeamName
+  value: dotnet-core-acquisition
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: SignType
+    value: test
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      enableSymbolValidation: false
-      enableSigningValidation: false
-      enableNugetValidation: false
-      enableSourceLinkValidation: false
-      publishAssetsImmediately: true
-      # Enable SDL validation, passing through values from the 'deployment-tools-sdl-validation' group.
-      SDLValidationParameters:
-        enable: false
-        params: >-
-          -SourceToolsList @("policheck","credscan")
-          -ArtifactToolsList @("binskim")
-          -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True","SymbolsPath < SRV*https://msdl.microsoft.com/download/symbols")
-          -TsaInstanceURL "$(TsaInstanceURL)"
-          -TsaProjectName "$(TsaProjectName)"
-          -TsaNotificationEmail "$(TsaNotificationEmail)"
-          -TsaCodebaseAdmin "$(TsaCodebaseAdmin)"
-          -TsaBugAreaPath "$(TsaBugAreaPath)"
-          -TsaIterationPath "$(TsaIterationPath)"
-          -TsaRepositoryName "$(TsaRepositoryName)"
-          -TsaCodebaseName "$(TsaCodebaseName)"
-          -TsaPublish $True
+  - name: SignType
+    value: $[ coalesce(variables.OfficialSignType, 'real') ]
+  - group: core-setup-sdl-validation
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: NetCore1ESPool-Internal
+      image: 1es-windows-2022-pt
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: Build
+      jobs:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+        - template: /eng/common/templates-official/job/onelocbuild.yml@self
+          parameters:
+            MirrorRepo: deployment-tools
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-MAGE'
+      - template: /eng/jobs/windows-build.yml@self
+        parameters:
+          name: win_x64
+          displayName: win-x64
+          targetArchitecture: x64
+          codeql: true
+      - template: /eng/jobs/windows-build.yml@self
+        parameters:
+          name: win_x86
+          displayName: win-x86
+          targetArchitecture: x86
+      - template: /eng/jobs/windows-build.yml@self
+        parameters:
+          name: win_arm64
+          displayName: win-arm64
+          targetArchitecture: arm64
+      - template: /eng/common/templates-official/jobs/source-build.yml@self
+        parameters:
+          platform:
+            name: 'Managed'
+            container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9'
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+          parameters:
+            publishUsingPipelines: true
+            publishAssetsImmediately: true
+            dependsOn:
+            - win_x64
+            - win_x86
+            - win_arm64
+            - Source_Build_Managed
+            pool:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals windows.vs2022.amd64
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates-official/post-build/post-build.yml@self
+        parameters:
+          enableSymbolValidation: false
+          enableSigningValidation: false
+          enableNugetValidation: false
+          enableSourceLinkValidation: false
+          publishAssetsImmediately: true
+          SDLValidationParameters:
+            enable: false
+            params: >-
+              -SourceToolsList @("policheck","credscan") -ArtifactToolsList @("binskim") -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True","SymbolsPath < SRV*https://msdl.microsoft.com/download/symbols") -TsaInstanceURL "$(TsaInstanceURL)" -TsaProjectName "$(TsaProjectName)" -TsaNotificationEmail "$(TsaNotificationEmail)" -TsaCodebaseAdmin "$(TsaCodebaseAdmin)" -TsaBugAreaPath "$(TsaBugAreaPath)" -TsaIterationPath "$(TsaIterationPath)" -TsaRepositoryName "$(TsaRepositoryName)" -TsaCodebaseName "$(TsaCodebaseName)" -TsaPublish $True

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ pr:
 - internal/release/*
 name: $(Date:yyyyMMdd)$(Rev:.r)
 variables:
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
 - name: TeamName
   value: dotnet-core-acquisition
 - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -30,7 +31,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: NetCore1ESPool-Internal
+      name: $(DncEngInternalBuildPool)
       image: 1es-windows-2022-pt
       os: windows
     customBuildTags:
@@ -76,8 +77,8 @@ extends:
             - win_arm64
             - Source_Build_Managed
             pool:
-              name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2022.amd64
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022-pt
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:

--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -9,6 +9,13 @@ jobs:
 - job: ${{ parameters.name }}
   displayName: ${{ parameters.displayName }}
   timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+  pool:
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCore-Public
+      demands: ImageOverride -equals windows.vs2022.amd64.open
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals windows.vs2022.amd64
   strategy:
     matrix:
       release:
@@ -27,36 +34,6 @@ jobs:
     ${{ else }}:
       InternalMSBuildArgs: ''
     Codeql.Enabled: ${{ parameters.codeql }}
-  templateContext:
-    outputs:
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true'), eq(variables['_BuildConfig'], 'Release')) }}:
-      - output: nuget
-        displayName: 'Push Visual Studio NuPkgs'
-        condition: succeeded()
-        packageParentPath: '$(Build.ArtifactStagingDirectory)'
-        packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.NETCoreCheck.*.nupkg
-        nuGetFeedType: external
-        publishFeedCredentials: 'DevDiv - VS package feed'
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Release'), eq(parameters.targetArchitecture, 'x64')) }}:
-      - output: nuget
-        displayName: 'Push Visual Studio NuPkgs'
-        condition: succeeded()
-        packageParentPath: '$(Build.ArtifactStagingDirectory)'
-        packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.NetCore.Launcher.*.nupkg
-        nuGetFeedType: external
-        publishFeedCredentials: 'DevDiv - VS package feed'
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Release'), eq(variables['StagingArtifactsFolderExist'], True)) }}:
-      - output: pipelineArtifact
-        displayName: 'Publish Artifacts'
-        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
-        targetPath: '$(Build.StagingDirectory)/Artifacts'
-        artifactName: IntermediateUnsignedArtifacts
-        artifactType: container
-    - output: pipelineArtifact
-      displayName: 'Publish BuildLogs'
-      condition: succeededOrFailed()
-      targetPath: '$(Build.StagingDirectory)/BuildLogs'
-      artifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
   steps:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: NuGetAuthenticate@1
@@ -83,13 +60,29 @@ jobs:
       eng\common\cibuild.cmd $(CommonMSBuildArgs) $(InternalMSBuildArgs)
     displayName: Build
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+    - template: /eng/common/templates/steps/generate-sbom.yml@self
       parameters:
         name: Generate_SBOM_${{ parameters.name }}
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true'), eq(variables['_BuildConfig'], 'Release')) }}:
     - task: NuGetToolInstaller@1
       displayName: 'Install NuGet.exe'
-    - ${{ if eq(parameters.targetArchitecture, 'x64') }}: []
+    - task: NuGetCommand@2
+      displayName: Push Visual Studio NuPkgs
+      inputs:
+        command: push
+        packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.NETCoreCheck.*.nupkg
+        nuGetFeedType: external
+        publishFeedCredentials: 'DevDiv - VS package feed'
+      condition: succeeded()
+    - ${{ if eq(parameters.targetArchitecture, 'x64') }}:
+      - task: NuGetCommand@2
+        displayName: Push Visual Studio NuPkgs
+        inputs:
+          command: push
+          packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.NetCore.Launcher.*.nupkg
+          nuGetFeedType: external
+          publishFeedCredentials: 'DevDiv - VS package feed'
+        condition: succeeded()
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - powershell: |
         $folderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
@@ -109,6 +102,13 @@ jobs:
         $folderExists = Test-Path -Path "$(Build.StagingDirectory)/Artifacts"
         Write-Output "##vso[task.setvariable variable=StagingArtifactsFolderExist]$folderExists"
       displayName: Detect Staged Artifacts subdirectory
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifacts
+      inputs:
+        pathToPublish: '$(Build.StagingDirectory)/Artifacts'
+        artifactName: IntermediateUnsignedArtifacts
+        artifactType: container
+      condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: CopyFiles@2
       displayName: Prepare job-specific PdbArtifacts subdirectory
@@ -118,6 +118,13 @@ jobs:
           **/*
         TargetFolder: '$(Build.StagingDirectory)/PdbArtifacts/${{ parameters.name }}'
         CleanTargetFolder: true
+      condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+    - task: PublishBuildArtifacts@1
+      displayName: Publish PdbArtifacts
+      inputs:
+        pathToPublish: '$(Build.StagingDirectory)/PdbArtifacts'
+        artifactName: PdbArtifacts
+        artifactType: container
       condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
     - task: PublishTestResults@2
@@ -139,5 +146,12 @@ jobs:
         **/*.binlog
       TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
       CleanTargetFolder: true
+    continueOnError: true
+    condition: succeededOrFailed()
+  - task: PublishBuildArtifacts@1
+    displayName: Publish BuildLogs
+    inputs:
+      PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
+      ArtifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
     continueOnError: true
     condition: succeededOrFailed()


### PR DESCRIPTION
Splits the existing CI pipeline into two separate pipelines:

- azure-pipelines-PR.yml: for public builds - This is the same as the original content except that conditional logic has been removed that was meant to support internal builds.
- azure-pipelines.yml: for internal builds - Uses the 1ES pipeline template pattern

Successful validation builds:
- internal: https://dev.azure.com/dnceng/internal/_build/results?buildId=2414346&view=results
- public: https://dev.azure.com/dnceng-public/public/_build/results?buildId=617819&view=results
