### PR TITLE
[release/8.0] 1ES pipeline templates

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -18,21 +18,13 @@ variables:
   # Skip Running CI tests
   - name: SkipTests
     value: false
-
   # Produce test-signed build for PR and Public builds
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: SignType
-      value: test
+  - name: SignType
+    value: test
 
 stages:
 - stage: Build
   jobs:
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-    - template: /eng/common/templates/job/onelocbuild.yml
-      parameters:
-        MirrorRepo: deployment-tools
-        LclSource: lclFilesfromPackage
-        LclPackageId: 'LCL-JUNO-PROD-MAGE'
   # -------- Build Windows legs --------
   # Windows x64
   - template: /eng/jobs/windows-build.yml
@@ -57,49 +49,3 @@ stages:
   # Source-build
   - template: /eng/common/templates/jobs/source-build.yml
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - stage: PrepareForPublish
-    displayName: Prepare for Publish
-    dependsOn: Build
-    jobs:
-    # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
-    - template: /eng/jobs/prepare-signed-artifacts.yml
-      parameters:
-        PublishRidAgnosticPackagesFromJobName: Windows_x64
-    # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        dependsOn: PrepareSignedArtifacts
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2019.amd64
-
-# Stages-based publishing entry point
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      validateDependsOn:
-      - PrepareForPublish
-      publishingInfraVersion: 3
-      enableSymbolValidation: false
-      enableSigningValidation: false
-      enableNugetValidation: false
-      enableSourceLinkValidation: false
-      publishInstallersAndChecksums: true
-      # Enable SDL validation, passing through values from the 'deployment-tools-sdl-validation' group.
-      SDLValidationParameters:
-        enable: true
-        params: >-
-          -SourceToolsList @("policheck","credscan")
-          -ArtifactToolsList @("binskim")
-          -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True","SymbolsPath < SRV*https://msdl.microsoft.com/download/symbols")
-          -TsaInstanceURL "$(TsaInstanceURL)"
-          -TsaProjectName "$(TsaProjectName)"
-          -TsaNotificationEmail "$(TsaNotificationEmail)"
-          -TsaCodebaseAdmin "$(TsaCodebaseAdmin)"
-          -TsaBugAreaPath "$(TsaBugAreaPath)"
-          -TsaIterationPath "$(TsaIterationPath)"
-          -TsaRepositoryName "$(TsaRepositoryName)"
-          -TsaCodebaseName "$(TsaCodebaseName)"
-          -TsaPublish $True

--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -1,0 +1,105 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - release/*
+
+pr:
+- main
+- release/*
+
+
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+variables:
+  - name: TeamName
+    value: dotnet-core-acquisition
+  # Skip Running CI tests
+  - name: SkipTests
+    value: false
+
+  # Produce test-signed build for PR and Public builds
+  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+    - name: SignType
+      value: test
+
+stages:
+- stage: Build
+  jobs:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+    - template: /eng/common/templates/job/onelocbuild.yml
+      parameters:
+        MirrorRepo: deployment-tools
+        LclSource: lclFilesfromPackage
+        LclPackageId: 'LCL-JUNO-PROD-MAGE'
+  # -------- Build Windows legs --------
+  # Windows x64
+  - template: /eng/jobs/windows-build.yml
+    parameters:
+      name: Windows_x64
+      publishRidAgnosticPackages: true
+      targetArchitecture: x64
+      codeql: true
+
+  # Windows x86
+  - template: /eng/jobs/windows-build.yml
+    parameters:
+      name: Windows_x86
+      targetArchitecture: x86
+
+  # Windows arm64
+  - template: /eng/jobs/windows-build.yml
+    parameters:
+      name: Windows_arm64
+      targetArchitecture: arm64
+  
+  # Source-build
+  - template: /eng/common/templates/jobs/source-build.yml
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - stage: PrepareForPublish
+    displayName: Prepare for Publish
+    dependsOn: Build
+    jobs:
+    # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
+    - template: /eng/jobs/prepare-signed-artifacts.yml
+      parameters:
+        PublishRidAgnosticPackagesFromJobName: Windows_x64
+    # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
+    - template: /eng/common/templates/job/publish-build-assets.yml
+      parameters:
+        publishUsingPipelines: true
+        dependsOn: PrepareSignedArtifacts
+        pool:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals windows.vs2019.amd64
+
+# Stages-based publishing entry point
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: /eng/common/templates/post-build/post-build.yml
+    parameters:
+      validateDependsOn:
+      - PrepareForPublish
+      publishingInfraVersion: 3
+      enableSymbolValidation: false
+      enableSigningValidation: false
+      enableNugetValidation: false
+      enableSourceLinkValidation: false
+      publishInstallersAndChecksums: true
+      # Enable SDL validation, passing through values from the 'deployment-tools-sdl-validation' group.
+      SDLValidationParameters:
+        enable: true
+        params: >-
+          -SourceToolsList @("policheck","credscan")
+          -ArtifactToolsList @("binskim")
+          -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True","SymbolsPath < SRV*https://msdl.microsoft.com/download/symbols")
+          -TsaInstanceURL "$(TsaInstanceURL)"
+          -TsaProjectName "$(TsaProjectName)"
+          -TsaNotificationEmail "$(TsaNotificationEmail)"
+          -TsaCodebaseAdmin "$(TsaCodebaseAdmin)"
+          -TsaBugAreaPath "$(TsaBugAreaPath)"
+          -TsaIterationPath "$(TsaIterationPath)"
+          -TsaRepositoryName "$(TsaRepositoryName)"
+          -TsaCodebaseName "$(TsaCodebaseName)"
+          -TsaPublish $True

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,114 +5,93 @@ trigger:
     - main
     - release/*
     - internal/release/*
-
 pr:
 - main
 - release/*
 - internal/release/*
-
-
 name: $(Date:yyyyMMdd)$(Rev:.r)
-
 variables:
-  - name: TeamName
-    value: dotnet-core-acquisition
-  # Skip Running CI tests
-  - name: SkipTests
-    value: false
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    # Set Official Build Id
-    - name: OfficialBuildId
-      value: $(Build.BuildNumber)
-
-  # Produce test-signed build for PR and Public builds
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: SignType
-      value: test
-
-  # Set up non-PR build from internal project
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: SignType
-      value: $[ coalesce(variables.OfficialSignType, 'real') ]
-    # Values for SDLValidationParameters
-    - group: core-setup-sdl-validation
-
-stages:
-- stage: Build
-  jobs:
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-    - template: /eng/common/templates/job/onelocbuild.yml
-      parameters:
-        MirrorRepo: deployment-tools
-        LclSource: lclFilesfromPackage
-        LclPackageId: 'LCL-JUNO-PROD-MAGE'
-  # -------- Build Windows legs --------
-  # Windows x64
-  - template: /eng/jobs/windows-build.yml
-    parameters:
-      name: Windows_x64
-      publishRidAgnosticPackages: true
-      targetArchitecture: x64
-      codeql: true
-
-  # Windows x86
-  - template: /eng/jobs/windows-build.yml
-    parameters:
-      name: Windows_x86
-      targetArchitecture: x86
-
-  # Windows arm64
-  - template: /eng/jobs/windows-build.yml
-    parameters:
-      name: Windows_arm64
-      targetArchitecture: arm64
-  
-  # Source-build
-  - template: /eng/common/templates/jobs/source-build.yml
-
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
+- name: TeamName
+  value: dotnet-core-acquisition
+- name: SkipTests
+  value: false
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - stage: PrepareForPublish
-    displayName: Prepare for Publish
-    dependsOn: Build
-    jobs:
-    # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
-    - template: /eng/jobs/prepare-signed-artifacts.yml
-      parameters:
-        PublishRidAgnosticPackagesFromJobName: Windows_x64
-    # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        dependsOn: PrepareSignedArtifacts
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2019.amd64
-
-# Stages-based publishing entry point
+  - name: OfficialBuildId
+    value: $(Build.BuildNumber)
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: SignType
+    value: test
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      validateDependsOn:
-      - PrepareForPublish
-      publishingInfraVersion: 3
-      enableSymbolValidation: false
-      enableSigningValidation: false
-      enableNugetValidation: false
-      enableSourceLinkValidation: false
-      publishInstallersAndChecksums: true
-      # Enable SDL validation, passing through values from the 'deployment-tools-sdl-validation' group.
-      SDLValidationParameters:
-        enable: true
-        params: >-
-          -SourceToolsList @("policheck","credscan")
-          -ArtifactToolsList @("binskim")
-          -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True","SymbolsPath < SRV*https://msdl.microsoft.com/download/symbols")
-          -TsaInstanceURL "$(TsaInstanceURL)"
-          -TsaProjectName "$(TsaProjectName)"
-          -TsaNotificationEmail "$(TsaNotificationEmail)"
-          -TsaCodebaseAdmin "$(TsaCodebaseAdmin)"
-          -TsaBugAreaPath "$(TsaBugAreaPath)"
-          -TsaIterationPath "$(TsaIterationPath)"
-          -TsaRepositoryName "$(TsaRepositoryName)"
-          -TsaCodebaseName "$(TsaCodebaseName)"
-          -TsaPublish $True
+  - name: SignType
+    value: $[ coalesce(variables.OfficialSignType, 'real') ]
+  - group: core-setup-sdl-validation
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: $(DncEngInternalBuildPool)
+      image: 1es-windows-2022-pt
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: Build
+      jobs:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+        - template: /eng/common/templates-official/job/onelocbuild.yml@self
+          parameters:
+            MirrorRepo: deployment-tools
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-MAGE'
+      - template: /eng/jobs/windows-build.yml@self
+        parameters:
+          name: Windows_x64
+          publishRidAgnosticPackages: true
+          targetArchitecture: x64
+          codeql: true
+      - template: /eng/jobs/windows-build.yml@self
+        parameters:
+          name: Windows_x86
+          targetArchitecture: x86
+      - template: /eng/jobs/windows-build.yml@self
+        parameters:
+          name: Windows_arm64
+          targetArchitecture: arm64
+      - template: /eng/common/templates-official/jobs/source-build.yml@self
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - stage: PrepareForPublish
+        displayName: Prepare for Publish
+        dependsOn: Build
+        jobs:
+        - template: /eng/jobs/prepare-signed-artifacts.yml@self
+          parameters:
+            PublishRidAgnosticPackagesFromJobName: Windows_x64
+        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+          parameters:
+            publishUsingPipelines: true
+            dependsOn: PrepareSignedArtifacts
+            pool:
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022-pt
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates-official/post-build/post-build.yml@self
+        parameters:
+          validateDependsOn:
+          - PrepareForPublish
+          publishingInfraVersion: 3
+          enableSymbolValidation: false
+          enableSigningValidation: false
+          enableNugetValidation: false
+          enableSourceLinkValidation: false
+          publishInstallersAndChecksums: true
+          SDLValidationParameters:
+            enable: true
+            params: >-
+              -SourceToolsList @("policheck","credscan") -ArtifactToolsList @("binskim") -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True","SymbolsPath < SRV*https://msdl.microsoft.com/download/symbols") -TsaInstanceURL "$(TsaInstanceURL)" -TsaProjectName "$(TsaProjectName)" -TsaNotificationEmail "$(TsaNotificationEmail)" -TsaCodebaseAdmin "$(TsaCodebaseAdmin)" -TsaBugAreaPath "$(TsaBugAreaPath)" -TsaIterationPath "$(TsaIterationPath)" -TsaRepositoryName "$(TsaRepositoryName)" -TsaCodebaseName "$(TsaCodebaseName)" -TsaPublish $True

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,6 @@ variables:
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 - name: TeamName
   value: dotnet-core-acquisition
-- name: SkipTests
-  value: false
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - name: OfficialBuildId
-    value: $(Build.BuildNumber)
 - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
   - name: SignType
     value: test
@@ -37,7 +32,7 @@ extends:
   parameters:
     pool:
       name: $(DncEngInternalBuildPool)
-      image: 1es-windows-2022-pt
+      image: windows.vs2019.amd64
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -52,46 +47,47 @@ extends:
             LclPackageId: 'LCL-JUNO-PROD-MAGE'
       - template: /eng/jobs/windows-build.yml@self
         parameters:
-          name: Windows_x64
-          publishRidAgnosticPackages: true
+          name: win_x64
+          displayName: win-x64
           targetArchitecture: x64
           codeql: true
       - template: /eng/jobs/windows-build.yml@self
         parameters:
-          name: Windows_x86
+          name: win_x86
+          displayName: win-x86
           targetArchitecture: x86
       - template: /eng/jobs/windows-build.yml@self
         parameters:
-          name: Windows_arm64
+          name: win_arm64
+          displayName: win-arm64
           targetArchitecture: arm64
       - template: /eng/common/templates-official/jobs/source-build.yml@self
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - stage: PrepareForPublish
-        displayName: Prepare for Publish
-        dependsOn: Build
-        jobs:
-        - template: /eng/jobs/prepare-signed-artifacts.yml@self
-          parameters:
-            PublishRidAgnosticPackagesFromJobName: Windows_x64
+        parameters:
+          platform:
+            name: 'Managed'
+            container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9'
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:
             publishUsingPipelines: true
-            dependsOn: PrepareSignedArtifacts
+            publishAssetsImmediately: true
+            dependsOn:
+            - win_x64
+            - win_x86
+            - win_arm64
+            - Source_Build_Managed
             pool:
               name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals 1es-windows-2022-pt
+              demands: ImageOverride -equals windows.vs2019.amd64
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
-          validateDependsOn:
-          - PrepareForPublish
-          publishingInfraVersion: 3
           enableSymbolValidation: false
           enableSigningValidation: false
           enableNugetValidation: false
           enableSourceLinkValidation: false
-          publishInstallersAndChecksums: true
+          publishAssetsImmediately: true
           SDLValidationParameters:
-            enable: true
+            enable: false
             params: >-
               -SourceToolsList @("policheck","credscan") -ArtifactToolsList @("binskim") -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True","SymbolsPath < SRV*https://msdl.microsoft.com/download/symbols") -TsaInstanceURL "$(TsaInstanceURL)" -TsaProjectName "$(TsaProjectName)" -TsaNotificationEmail "$(TsaNotificationEmail)" -TsaCodebaseAdmin "$(TsaCodebaseAdmin)" -TsaBugAreaPath "$(TsaBugAreaPath)" -TsaIterationPath "$(TsaIterationPath)" -TsaRepositoryName "$(TsaRepositoryName)" -TsaCodebaseName "$(TsaCodebaseName)" -TsaPublish $True

--- a/eng/jobs/prepare-signed-artifacts.yml
+++ b/eng/jobs/prepare-signed-artifacts.yml
@@ -1,24 +1,23 @@
 parameters:
   dependsOn: []
   PublishRidAgnosticPackagesFromJobName: ''
-
 jobs:
 - job: PrepareSignedArtifacts
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
-  pool:
-    name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals windows.vs2019.amd64
-  # Double the default timeout.
   timeoutInMinutes: 120
   workspace:
     clean: all
-
+  templateContext:
+    outputs:
+    - output: pipelineArtifact
+      displayName: 'Publish Artifact BuildLogs'
+      condition: succeededOrFailed()
+      targetPath: '$(Build.StagingDirectory)\BuildLogs'
+      artifactName: Logs-PrepareSignedArtifacts
   steps:
-
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: NuGetAuthenticate@0
-
   - task: MicroBuildSigningPlugin@2
     displayName: Install MicroBuild plugin for Signing
     inputs:
@@ -27,23 +26,14 @@ jobs:
       feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
     continueOnError: false
     condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
-
   - task: DownloadBuildArtifacts@0
     displayName: Download IntermediateUnsignedArtifacts
     inputs:
       artifactName: IntermediateUnsignedArtifacts
       downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
-
   - script: >-
-      build.cmd -ci
-      -subset installer.publish
-      /p:Configuration=Release
-      /p:PublishRidAgnosticPackagesFromJobName=${{ parameters.PublishRidAgnosticPackagesFromJobName }}
-      /p:SignType=$(SignType)
-      /p:DotNetSignType=$(SignType)
-      /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
+      build.cmd -ci -subset installer.publish /p:Configuration=Release /p:PublishRidAgnosticPackagesFromJobName=${{ parameters.PublishRidAgnosticPackagesFromJobName }} /p:SignType=$(SignType) /p:DotNetSignType=$(SignType) /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
     displayName: Prepare artifacts and upload to build
-
   - task: CopyFiles@2
     displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
     inputs:
@@ -53,11 +43,4 @@ jobs:
         **/*.binlog
       TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
     continueOnError: true
-    condition: succeededOrFailed()
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifact BuildLogs
-    inputs:
-      PathtoPublish: '$(Build.StagingDirectory)\BuildLogs'
-      ArtifactName: Logs-PrepareSignedArtifacts
     condition: succeededOrFailed()

--- a/eng/jobs/steps/upload-job-artifacts-PR.yml
+++ b/eng/jobs/steps/upload-job-artifacts-PR.yml
@@ -1,0 +1,86 @@
+parameters:
+  name: ''
+
+steps:
+# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - powershell: |
+     $folderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
+     Write-Output "##vso[task.setvariable variable=ArtifactsPackagesFolderExists]$folderExists"
+    displayName: Detect Packages subdirectory
+
+  - task: CopyFiles@2
+    displayName: Prepare job-specific Artifacts subdirectory
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+      Contents: |
+        Shipping/**/*
+        NonShipping/**/*
+      TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
+      CleanTargetFolder: true
+    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsPackagesFolderExists'], True))
+
+  - powershell: |
+     $folderExists = Test-Path -Path "$(Build.StagingDirectory)/Artifacts"
+     Write-Output "##vso[task.setvariable variable=StagingArtifactsFolderExist]$folderExists"
+    displayName: Detect Staged Artifacts subdirectory
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Artifacts
+    inputs:
+      pathToPublish: '$(Build.StagingDirectory)/Artifacts'
+      artifactName: IntermediateUnsignedArtifacts
+      artifactType: container
+    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
+
+# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - task: CopyFiles@2
+    displayName: Prepare job-specific PdbArtifacts subdirectory
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/artifacts/SymStore/$(_BuildConfig)'
+      Contents: |
+        **/*
+      TargetFolder: '$(Build.StagingDirectory)/PdbArtifacts/${{ parameters.name }}'
+      CleanTargetFolder: true
+    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish PdbArtifacts
+    inputs:
+      pathToPublish: '$(Build.StagingDirectory)/PdbArtifacts'
+      artifactName: PdbArtifacts
+      artifactType: container
+    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+
+# Always upload test outputs and build logs.
+- task: PublishTestResults@2
+  displayName: Publish Test Results
+  inputs:
+    testResultsFormat: 'xUnit'
+    testResultsFiles: '*.xml'
+    searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+    mergeTestResults: true
+    testRunTitle: ${{ parameters.name }}-$(_BuildConfig)
+  continueOnError: true
+  condition: always()
+
+- task: CopyFiles@2
+  displayName: Prepare BuildLogs staging directory
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    Contents: |
+      **/*.log
+      **/*.binlog
+    TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
+    CleanTargetFolder: true
+  continueOnError: true
+  condition: succeededOrFailed()
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish BuildLogs
+  inputs:
+    PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
+    ArtifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
+  continueOnError: true
+  condition: succeededOrFailed()

--- a/eng/jobs/steps/upload-job-artifacts-PR.yml
+++ b/eng/jobs/steps/upload-job-artifacts-PR.yml
@@ -2,57 +2,6 @@ parameters:
   name: ''
 
 steps:
-# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - powershell: |
-     $folderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
-     Write-Output "##vso[task.setvariable variable=ArtifactsPackagesFolderExists]$folderExists"
-    displayName: Detect Packages subdirectory
-
-  - task: CopyFiles@2
-    displayName: Prepare job-specific Artifacts subdirectory
-    inputs:
-      SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
-      Contents: |
-        Shipping/**/*
-        NonShipping/**/*
-      TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
-      CleanTargetFolder: true
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsPackagesFolderExists'], True))
-
-  - powershell: |
-     $folderExists = Test-Path -Path "$(Build.StagingDirectory)/Artifacts"
-     Write-Output "##vso[task.setvariable variable=StagingArtifactsFolderExist]$folderExists"
-    displayName: Detect Staged Artifacts subdirectory
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifacts
-    inputs:
-      pathToPublish: '$(Build.StagingDirectory)/Artifacts'
-      artifactName: IntermediateUnsignedArtifacts
-      artifactType: container
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
-
-# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - task: CopyFiles@2
-    displayName: Prepare job-specific PdbArtifacts subdirectory
-    inputs:
-      SourceFolder: '$(Build.SourcesDirectory)/artifacts/SymStore/$(_BuildConfig)'
-      Contents: |
-        **/*
-      TargetFolder: '$(Build.StagingDirectory)/PdbArtifacts/${{ parameters.name }}'
-      CleanTargetFolder: true
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish PdbArtifacts
-    inputs:
-      pathToPublish: '$(Build.StagingDirectory)/PdbArtifacts'
-      artifactName: PdbArtifacts
-      artifactType: container
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-
 # Always upload test outputs and build logs.
 - task: PublishTestResults@2
   displayName: Publish Test Results

--- a/eng/jobs/steps/upload-job-artifacts.yml
+++ b/eng/jobs/steps/upload-job-artifacts.yml
@@ -1,14 +1,11 @@
 parameters:
   name: ''
-
 steps:
-# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - powershell: |
-     $folderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
-     Write-Output "##vso[task.setvariable variable=ArtifactsPackagesFolderExists]$folderExists"
+      $folderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
+      Write-Output "##vso[task.setvariable variable=ArtifactsPackagesFolderExists]$folderExists"
     displayName: Detect Packages subdirectory
-
   - task: CopyFiles@2
     displayName: Prepare job-specific Artifacts subdirectory
     inputs:
@@ -19,21 +16,10 @@ steps:
       TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
       CleanTargetFolder: true
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsPackagesFolderExists'], True))
-
   - powershell: |
-     $folderExists = Test-Path -Path "$(Build.StagingDirectory)/Artifacts"
-     Write-Output "##vso[task.setvariable variable=StagingArtifactsFolderExist]$folderExists"
+      $folderExists = Test-Path -Path "$(Build.StagingDirectory)/Artifacts"
+      Write-Output "##vso[task.setvariable variable=StagingArtifactsFolderExist]$folderExists"
     displayName: Detect Staged Artifacts subdirectory
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifacts
-    inputs:
-      pathToPublish: '$(Build.StagingDirectory)/Artifacts'
-      artifactName: IntermediateUnsignedArtifacts
-      artifactType: container
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
-
-# Upload build outputs as build artifacts only if internal and not PR, to save storage space.
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - task: CopyFiles@2
     displayName: Prepare job-specific PdbArtifacts subdirectory
@@ -44,16 +30,6 @@ steps:
       TargetFolder: '$(Build.StagingDirectory)/PdbArtifacts/${{ parameters.name }}'
       CleanTargetFolder: true
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish PdbArtifacts
-    inputs:
-      pathToPublish: '$(Build.StagingDirectory)/PdbArtifacts'
-      artifactName: PdbArtifacts
-      artifactType: container
-    condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-
-# Always upload test outputs and build logs.
 - task: PublishTestResults@2
   displayName: Publish Test Results
   inputs:
@@ -64,7 +40,6 @@ steps:
     testRunTitle: ${{ parameters.name }}-$(_BuildConfig)
   continueOnError: true
   condition: always()
-
 - task: CopyFiles@2
   displayName: Prepare BuildLogs staging directory
   inputs:
@@ -74,13 +49,5 @@ steps:
       **/*.binlog
     TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
     CleanTargetFolder: true
-  continueOnError: true
-  condition: succeededOrFailed()
-
-- task: PublishBuildArtifacts@1
-  displayName: Publish BuildLogs
-  inputs:
-    PathtoPublish: '$(Build.StagingDirectory)/BuildLogs'
-    ArtifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
   continueOnError: true
   condition: succeededOrFailed()

--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -43,75 +43,18 @@ jobs:
 
     steps:
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: NuGetAuthenticate@0
-
-      - task: MicroBuildSigningPlugin@2
-        displayName: Install MicroBuild plugin for Signing
-        inputs:
-          signType: $(SignType)
-          zipSources: false
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        continueOnError: false
-        condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
-
-    # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
-    # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
-    - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
-      displayName: Clear NuGet http cache (if exists)
-
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        condition: eq(variables['Agent.OS'], 'Windows_NT')
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - script: >-
-          build.cmd -subset clickonce+installer+dotnet_releases -ci -test
-          $(CommonMSBuildArgs)
-          $(MsbuildSigningArguments)
-          /p:Sign=true /p:SignBinaries=true
-          /p:LocalizedBuild=true
-        displayName: Build and Sign Binaries
-
-    - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-      - script: >-
-          build.cmd -subset clickonce+installer+dotnet_releases -ci -test
-          $(CommonMSBuildArgs)
-          $(MsbuildSigningArguments)
-          /p:LocalizedBuild=true
-        displayName: Build
+    - script: >-
+        build.cmd -subset clickonce+installer+dotnet_releases -ci -test
+        $(CommonMSBuildArgs)
+        $(MsbuildSigningArguments)
+        /p:LocalizedBuild=true
+      displayName: Build
 
     - script: >-
         build.cmd -subset clickonce+installer+dotnet_releases -ci -pack
         $(CommonMSBuildArgs)
         $(MsbuildSigningArguments)
       displayName: Package
-
-    # Generate SBOM for the internal leg only
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: ..\common\templates\steps\generate-sbom.yml
-        parameters:
-          name: Generate_SBOM_${{ parameters.name }}
-
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true')) }}:
-      - task: NuGetToolInstaller@1
-        displayName: 'Install NuGet.exe'
-      - task: NuGetCommand@2
-        displayName: Push Visual Studio NuPkgs
-        inputs:
-          command: push
-          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
-          nuGetFeedType: external
-          publishFeedCredentials: 'DevDiv - VS package feed'
-        condition: and(
-          succeeded(),
-          eq(variables['_BuildConfig'], 'Release'))
 
     - template: steps/upload-job-artifacts.yml
       parameters:

--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -1,0 +1,118 @@
+parameters:
+  additionalMSBuildArguments: ''
+  displayName: ''
+  publishRidAgnosticPackages: false
+  skipTests: $(SkipTests)
+  targetArchitecture: null
+  timeoutInMinutes: 120
+  codeql: false
+
+jobs:
+  - job: ${{ parameters.name }}
+    displayName: ${{ parameters.name }}
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    pool:
+      # Use a hosted pool when possible.
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        name: NetCore-Public
+        demands: ImageOverride -equals windows.vs2019.amd64.open
+      ${{ if ne(variables['System.TeamProject'], 'public') }}:
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals windows.vs2019.amd64
+    strategy:
+      matrix: 
+        debug:
+          _BuildConfig: Debug
+        release:
+          _BuildConfig: Release
+    workspace:
+      clean: all
+    variables: 
+      CommonMSBuildArgs: >-
+        /p:Configuration=$(_BuildConfig)
+        /p:OfficialBuildId=$(OfficialBuildId)
+        /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+        /p:PortableBuild=true
+        /p:ContinuousIntegrationBuild=true
+        /p:SkipTests=${{ parameters.skipTests }}
+      MsbuildSigningArguments: >-
+        /p:CertificateId=400
+        /p:DotNetSignType=$(SignType)
+      TargetArchitecture: ${{ parameters.targetArchitecture }}
+      Codeql.Enabled: ${{ parameters.codeql }}
+
+    steps:
+
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: NuGetAuthenticate@0
+
+      - task: MicroBuildSigningPlugin@2
+        displayName: Install MicroBuild plugin for Signing
+        inputs:
+          signType: $(SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+        continueOnError: false
+        condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
+
+    # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
+    # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
+    - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
+      displayName: Clear NuGet http cache (if exists)
+
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - task: PowerShell@2
+        displayName: Setup Private Feeds Credentials
+        condition: eq(variables['Agent.OS'], 'Windows_NT')
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+        env:
+          Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - script: >-
+          build.cmd -subset clickonce+installer+dotnet_releases -ci -test
+          $(CommonMSBuildArgs)
+          $(MsbuildSigningArguments)
+          /p:Sign=true /p:SignBinaries=true
+          /p:LocalizedBuild=true
+        displayName: Build and Sign Binaries
+
+    - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+      - script: >-
+          build.cmd -subset clickonce+installer+dotnet_releases -ci -test
+          $(CommonMSBuildArgs)
+          $(MsbuildSigningArguments)
+          /p:LocalizedBuild=true
+        displayName: Build
+
+    - script: >-
+        build.cmd -subset clickonce+installer+dotnet_releases -ci -pack
+        $(CommonMSBuildArgs)
+        $(MsbuildSigningArguments)
+      displayName: Package
+
+    # Generate SBOM for the internal leg only
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: ..\common\templates\steps\generate-sbom.yml
+        parameters:
+          name: Generate_SBOM_${{ parameters.name }}
+
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true')) }}:
+      - task: NuGetToolInstaller@1
+        displayName: 'Install NuGet.exe'
+      - task: NuGetCommand@2
+        displayName: Push Visual Studio NuPkgs
+        inputs:
+          command: push
+          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
+          nuGetFeedType: external
+          publishFeedCredentials: 'DevDiv - VS package feed'
+        condition: and(
+          succeeded(),
+          eq(variables['_BuildConfig'], 'Release'))
+
+    - template: steps/upload-job-artifacts.yml
+      parameters:
+        name: ${{ parameters.name }}

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -1,3 +1,4 @@
+
 parameters:
   additionalMSBuildArguments: ''
   displayName: ''
@@ -6,113 +7,87 @@ parameters:
   targetArchitecture: null
   timeoutInMinutes: 120
   codeql: false
-
 jobs:
-  - job: ${{ parameters.name }}
-    displayName: ${{ parameters.name }}
-    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
-    pool:
-      # Use a hosted pool when possible.
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore-Public
-        demands: ImageOverride -equals windows.vs2019.amd64.open
-      ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals windows.vs2019.amd64
-    strategy:
-      matrix: 
-        debug:
-          _BuildConfig: Debug
-        release:
-          _BuildConfig: Release
-    workspace:
-      clean: all
-    variables: 
-      CommonMSBuildArgs: >-
-        /p:Configuration=$(_BuildConfig)
-        /p:OfficialBuildId=$(OfficialBuildId)
-        /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-        /p:PortableBuild=true
-        /p:ContinuousIntegrationBuild=true
-        /p:SkipTests=${{ parameters.skipTests }}
-      MsbuildSigningArguments: >-
-        /p:CertificateId=400
-        /p:DotNetSignType=$(SignType)
-      TargetArchitecture: ${{ parameters.targetArchitecture }}
-      Codeql.Enabled: ${{ parameters.codeql }}
-
-    steps:
-
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: NuGetAuthenticate@0
-
-      - task: MicroBuildSigningPlugin@2
-        displayName: Install MicroBuild plugin for Signing
-        inputs:
-          signType: $(SignType)
-          zipSources: false
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        continueOnError: false
-        condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
-
-    # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
-    # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
-    - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
-      displayName: Clear NuGet http cache (if exists)
-
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        condition: eq(variables['Agent.OS'], 'Windows_NT')
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - script: >-
-          build.cmd -subset clickonce+installer+dotnet_releases -ci -test
-          $(CommonMSBuildArgs)
-          $(MsbuildSigningArguments)
-          /p:Sign=true /p:SignBinaries=true
-          /p:LocalizedBuild=true
-        displayName: Build and Sign Binaries
-
-    - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-      - script: >-
-          build.cmd -subset clickonce+installer+dotnet_releases -ci -test
-          $(CommonMSBuildArgs)
-          $(MsbuildSigningArguments)
-          /p:LocalizedBuild=true
-        displayName: Build
-
+- job: ${{ parameters.name }}
+  displayName: ${{ parameters.name }}
+  timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+  strategy:
+    matrix:
+      debug:
+        _BuildConfig: Debug
+      release:
+        _BuildConfig: Release
+  workspace:
+    clean: all
+  variables:
+    CommonMSBuildArgs: >-
+      /p:Configuration=$(_BuildConfig) /p:OfficialBuildId=$(OfficialBuildId) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:PortableBuild=true /p:ContinuousIntegrationBuild=true /p:SkipTests=${{ parameters.skipTests }}
+    MsbuildSigningArguments: >-
+      /p:CertificateId=400 /p:DotNetSignType=$(SignType)
+    TargetArchitecture: ${{ parameters.targetArchitecture }}
+    Codeql.Enabled: ${{ parameters.codeql }}
+  templateContext:
+    outputs:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true'), eq(variables['_BuildConfig'], 'Release')) }}:
+      - output: nuget
+        displayName: 'Push Visual Studio NuPkgs'
+        condition: and( succeeded(), eq(variables['_BuildConfig'], 'Release'))
+        packageParentPath: '$(Build.ArtifactStagingDirectory)'
+        packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
+        nuGetFeedType: external
+        publishFeedCredentials: 'DevDiv - VS package feed'
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True)) }}:
+      - output: pipelineArtifact
+        displayName: 'Publish Artifacts'
+        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
+        targetPath: '$(Build.StagingDirectory)/Artifacts'
+        artifactName: IntermediateUnsignedArtifacts
+        artifactType: container
+    - output: pipelineArtifact
+      displayName: 'Publish BuildLogs'
+      condition: succeededOrFailed()
+      targetPath: '$(Build.StagingDirectory)/BuildLogs'
+      artifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
+  steps:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - task: NuGetAuthenticate@0
+    - task: MicroBuildSigningPlugin@2
+      displayName: Install MicroBuild plugin for Signing
+      inputs:
+        signType: $(SignType)
+        zipSources: false
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      continueOnError: false
+      condition: and(succeeded(), in(variables['SignType'], 'real', 'test'))
+  - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
+    displayName: Clear NuGet http cache (if exists)
+  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - task: PowerShell@2
+      displayName: Setup Private Feeds Credentials
+      condition: eq(variables['Agent.OS'], 'Windows_NT')
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+      env:
+        Token: $(dn-bot-dnceng-artifact-feeds-rw)
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - script: >-
-        build.cmd -subset clickonce+installer+dotnet_releases -ci -pack
-        $(CommonMSBuildArgs)
-        $(MsbuildSigningArguments)
-      displayName: Package
-
-    # Generate SBOM for the internal leg only
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: ..\common\templates\steps\generate-sbom.yml
-        parameters:
-          name: Generate_SBOM_${{ parameters.name }}
-
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true')) }}:
-      - task: NuGetToolInstaller@1
-        displayName: 'Install NuGet.exe'
-      - task: NuGetCommand@2
-        displayName: Push Visual Studio NuPkgs
-        inputs:
-          command: push
-          packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
-          nuGetFeedType: external
-          publishFeedCredentials: 'DevDiv - VS package feed'
-        condition: and(
-          succeeded(),
-          eq(variables['_BuildConfig'], 'Release'))
-
-    - template: steps/upload-job-artifacts.yml
+        build.cmd -subset clickonce+installer+dotnet_releases -ci -test $(CommonMSBuildArgs) $(MsbuildSigningArguments) /p:Sign=true /p:SignBinaries=true /p:LocalizedBuild=true
+      displayName: Build and Sign Binaries
+  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+    - script: >-
+        build.cmd -subset clickonce+installer+dotnet_releases -ci -test $(CommonMSBuildArgs) $(MsbuildSigningArguments) /p:LocalizedBuild=true
+      displayName: Build
+  - script: >-
+      build.cmd -subset clickonce+installer+dotnet_releases -ci -pack $(CommonMSBuildArgs) $(MsbuildSigningArguments)
+    displayName: Package
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/common/templates-official/steps/generate-sbom.yml@self
       parameters:
-        name: ${{ parameters.name }}
+        name: Generate_SBOM_${{ parameters.name }}
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true')) }}:
+    - task: NuGetToolInstaller@1
+      displayName: 'Install NuGet.exe'
+  - template: /eng/jobs/steps/upload-job-artifacts.yml@self
+    parameters:
+      name: ${{ parameters.name }}

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -1,50 +1,51 @@
-
 parameters:
   additionalMSBuildArguments: ''
   displayName: ''
   publishRidAgnosticPackages: false
-  skipTests: $(SkipTests)
   targetArchitecture: null
   timeoutInMinutes: 120
   codeql: false
 jobs:
 - job: ${{ parameters.name }}
-  displayName: ${{ parameters.name }}
+  displayName: ${{ parameters.displayName }}
   timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
-  pool:
-    # Use a hosted pool when possible.
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      name: NetCore-Public
-      demands: ImageOverride -equals windows.vs2019.amd64.open
-    ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      name: $(DncEngInternalBuildPool)
-      demands: ImageOverride -equals windows.vs2019.amd64
   strategy:
     matrix:
-      debug:
-        _BuildConfig: Debug
       release:
         _BuildConfig: Release
+      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        debug:
+          _BuildConfig: Debug
   workspace:
     clean: all
   variables:
     CommonMSBuildArgs: >-
-      /p:Configuration=$(_BuildConfig) /p:OfficialBuildId=$(OfficialBuildId) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:PortableBuild=true /p:ContinuousIntegrationBuild=true /p:SkipTests=${{ parameters.skipTests }}
-    MsbuildSigningArguments: >-
-      /p:CertificateId=400 /p:DotNetSignType=$(SignType)
-    TargetArchitecture: ${{ parameters.targetArchitecture }}
+      -c $(_BuildConfig) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:DotNetSignType=$(SignType)
+    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      InternalMSBuildArgs: >-
+        /p:OfficialBuildId=$(Build.BuildNumber) /p:DotNetPublishUsingPipelines=true /p:Test=false
+    ${{ else }}:
+      InternalMSBuildArgs: ''
     Codeql.Enabled: ${{ parameters.codeql }}
   templateContext:
     outputs:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true'), eq(variables['_BuildConfig'], 'Release')) }}:
       - output: nuget
         displayName: 'Push Visual Studio NuPkgs'
-        condition: and( succeeded(), eq(variables['_BuildConfig'], 'Release'))
+        condition: succeeded()
         packageParentPath: '$(Build.ArtifactStagingDirectory)'
-        packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.*.nupkg'
+        packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.NETCoreCheck.*.nupkg
         nuGetFeedType: external
         publishFeedCredentials: 'DevDiv - VS package feed'
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True)) }}:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Release'), eq(parameters.targetArchitecture, 'x64')) }}:
+      - output: nuget
+        displayName: 'Push Visual Studio NuPkgs'
+        condition: succeeded()
+        packageParentPath: '$(Build.ArtifactStagingDirectory)'
+        packagesToPush: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.NetCore.Launcher.*.nupkg
+        nuGetFeedType: external
+        publishFeedCredentials: 'DevDiv - VS package feed'
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Release'), eq(variables['StagingArtifactsFolderExist'], True)) }}:
       - output: pipelineArtifact
         displayName: 'Publish Artifacts'
         condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
@@ -78,24 +79,65 @@ jobs:
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
       env:
         Token: $(dn-bot-dnceng-artifact-feeds-rw)
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - script: >-
-        build.cmd -subset clickonce+installer+dotnet_releases -ci -test $(CommonMSBuildArgs) $(MsbuildSigningArguments) /p:Sign=true /p:SignBinaries=true /p:LocalizedBuild=true
-      displayName: Build and Sign Binaries
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - script: >-
-        build.cmd -subset clickonce+installer+dotnet_releases -ci -test $(CommonMSBuildArgs) $(MsbuildSigningArguments) /p:LocalizedBuild=true
-      displayName: Build
   - script: >-
-      build.cmd -subset clickonce+installer+dotnet_releases -ci -pack $(CommonMSBuildArgs) $(MsbuildSigningArguments)
-    displayName: Package
+      eng\common\cibuild.cmd $(CommonMSBuildArgs) $(InternalMSBuildArgs)
+    displayName: Build
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates-official/steps/generate-sbom.yml@self
       parameters:
         name: Generate_SBOM_${{ parameters.name }}
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true')) }}:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true'), eq(variables['_BuildConfig'], 'Release')) }}:
     - task: NuGetToolInstaller@1
       displayName: 'Install NuGet.exe'
-  - template: /eng/jobs/steps/upload-job-artifacts.yml@self
-    parameters:
-      name: ${{ parameters.name }}
+    - ${{ if eq(parameters.targetArchitecture, 'x64') }}: []
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - powershell: |
+        $folderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
+        Write-Output "##vso[task.setvariable variable=ArtifactsPackagesFolderExists]$folderExists"
+      displayName: Detect Packages subdirectory
+    - task: CopyFiles@2
+      displayName: Prepare job-specific Artifacts subdirectory
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+        Contents: |
+          Shipping/**/*
+          NonShipping/**/*
+        TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
+        CleanTargetFolder: true
+      condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsPackagesFolderExists'], True))
+    - powershell: |
+        $folderExists = Test-Path -Path "$(Build.StagingDirectory)/Artifacts"
+        Write-Output "##vso[task.setvariable variable=StagingArtifactsFolderExist]$folderExists"
+      displayName: Detect Staged Artifacts subdirectory
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - task: CopyFiles@2
+      displayName: Prepare job-specific PdbArtifacts subdirectory
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts/SymStore/$(_BuildConfig)'
+        Contents: |
+          **/*
+        TargetFolder: '$(Build.StagingDirectory)/PdbArtifacts/${{ parameters.name }}'
+        CleanTargetFolder: true
+      condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+    - task: PublishTestResults@2
+      displayName: Publish Test Results
+      inputs:
+        testResultsFormat: 'xUnit'
+        testResultsFiles: '*.xml'
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+        mergeTestResults: true
+        testRunTitle: ${{ parameters.name }}-$(_BuildConfig)
+      continueOnError: true
+      condition: always()
+  - task: CopyFiles@2
+    displayName: Prepare BuildLogs staging directory
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)'
+      Contents: |
+        **/*.log
+        **/*.binlog
+      TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
+      CleanTargetFolder: true
+    continueOnError: true
+    condition: succeededOrFailed()

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -11,6 +11,14 @@ jobs:
 - job: ${{ parameters.name }}
   displayName: ${{ parameters.name }}
   timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+  pool:
+    # Use a hosted pool when possible.
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCore-Public
+      demands: ImageOverride -equals windows.vs2019.amd64.open
+    ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      name: $(DncEngInternalBuildPool)
+      demands: ImageOverride -equals windows.vs2019.amd64
   strategy:
     matrix:
       debug:
@@ -50,7 +58,7 @@ jobs:
       artifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
   steps:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@1
     - task: MicroBuildSigningPlugin@2
       displayName: Install MicroBuild plugin for Signing
       inputs:


### PR DESCRIPTION
Splits the existing CI pipeline into two separate pipelines:

- azure-pipelines-PR.yml: for public builds - This is the same as the original content except that conditional logic has been removed that was meant to support internal builds.
- azure-pipelines.yml: for internal builds - Uses the 1ES pipeline template pattern. I've ported the implementation from `main` which simplified existing ymls quite a bit.

Successful validation builds:
- internal: https://dev.azure.com/dnceng/internal/_build/results?buildId=2415618&view=results
- public: https://dev.azure.com/dnceng-public/public/_build/results?buildId=619754&view=results
