### PR TITLE
Downgrade S.T.J to 8.0.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Runtime dependencies -->
-    <SystemTextJsonVersion>8.0.3</SystemTextJsonVersion>
+    <SystemTextJsonVersion>8.0.0</SystemTextJsonVersion>
     <SystemSecurityCryptographyXmlVersion>8.0.0</SystemSecurityCryptographyXmlVersion>
     <!-- MSBuild dependencies -->
     <MicrosoftBuildTasksCoreVersion>17.8.3</MicrosoftBuildTasksCoreVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Runtime dependencies -->
-    <SystemTextJsonVersion>8.0.4</SystemTextJsonVersion>
+    <SystemTextJsonVersion>8.0.3</SystemTextJsonVersion>
     <SystemSecurityCryptographyXmlVersion>8.0.0</SystemSecurityCryptographyXmlVersion>
     <!-- MSBuild dependencies -->
     <MicrosoftBuildTasksCoreVersion>17.8.3</MicrosoftBuildTasksCoreVersion>


### PR DESCRIPTION
This is necessary so that dotnet/sdk can also downgrade STJ back to 8.0.0. I had to pick 8.0.0 as 8.0.3 isn't available on SBRP.
We can't update to 8.0.4 yet as we don't yet have a VS with S.T.J/8.0.0.4 binding redirects for msbuild on .NET Framework.

This is needed for 9.0 P7. Apparently this doesn't need to be backported as this repo doesn't branch per preview.

cc @rainersigwald @marcpopMSFT @Forgind 