### PR TITLE
Update Microsoft.Build.Tasks.Core package version to 17.9.5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,6 +17,6 @@
     <SystemTextJsonVersion>8.0.3</SystemTextJsonVersion>
     <SystemSecurityCryptographyXmlVersion>8.0.0</SystemSecurityCryptographyXmlVersion>
     <!-- MSBuild dependencies -->
-    <MicrosoftBuildTasksCoreVersion>17.0.0</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildTasksCoreVersion>17.9.5</MicrosoftBuildTasksCoreVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,6 +17,6 @@
     <SystemTextJsonVersion>8.0.3</SystemTextJsonVersion>
     <SystemSecurityCryptographyXmlVersion>8.0.0</SystemSecurityCryptographyXmlVersion>
     <!-- MSBuild dependencies -->
-    <MicrosoftBuildTasksCoreVersion>17.8.3</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildTasksCoreVersion>17.0.0</MicrosoftBuildTasksCoreVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/deployment-tools/pull/373 has updated the version of `Microsoft.Build.Tasks.Core` package to 17.8.3.

This causes issues with `dotnet mage` signing step. Example output:

```
dotnet mage -sign files\app.manifest -cf test.pfx -pwd <password>

Internal error, please try again. Could not create hash algorithm object. If the application has been trimmed, ensure the required algorithm implementations are preserved.
   at Microsoft.Build.Tasks.Deployment.ManifestUtilities.SecurityUtilities.SignFileInternal(X509Certificate2 cert, Uri timestampUrl, String path, Boolean targetFrameworkSupportsSha256, ResourceManager resources, Boolean disallowMansignTimestampFallback)
   at Microsoft.Build.Tasks.Deployment.ManifestUtilities.SecurityUtilities.SignFile(X509Certificate2 cert, Uri timestampUrl, String path)
   at Microsoft.Deployment.MageCLI.Command.ExecuteManifestRelated() in D:\git2\deployment-tools\src\clickonce\MageCLI\Command.cs:line 1407
   at Microsoft.Deployment.MageCLI.Command.Execute() in D:\git2\deployment-tools\src\clickonce\MageCLI\Command.cs:line 1458
   at Microsoft.Deployment.MageCLI.Application.Main(String[] args) in D:\git2\deployment-tools\src\clickonce\MageCLI\Application.cs:line 44
```

Updating to 17.9.5 which has a fix.

@John-Hart @sujitnayak is this a known issue in newer versions of this package?