### PR TITLE
Suppress NuGet audit warning for S.T.J 8.0.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,4 +24,9 @@
     <PackageVersion Update="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(SystemTextJsonVersion)' != ''" />
   </ItemGroup>
 
+  <!-- Suppress System.Text.Json/8.0.4 advisory as desktop msbuild doesn't yet provide binding redirects for the non-vulnerable version (8.0.5). -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Builds are failing with NuGet audit warning, turned into error.

We are going to suppress the warning for 8.0.4 version of `System.Text.Json`, similar to how it's done in other places, i.e.: https://github.com/dotnet/arcade/blob/main/eng/BuildTask.Packages.props#L23