### PR TITLE
Disable native projects

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -3,11 +3,14 @@
   <PropertyGroup>
     <!-- Disable target framework filtering for top level projects -->
     <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+
+    <!-- Disable native projects - see https://github.com/dotnet/deployment-tools/issues/398 -->
+    <DisableNativeProjects>true</DisableNativeProjects>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DotNetBuild)' != 'true'">
     <ClickOnceProjectToBuild Include="src/clickonce/**/*.csproj" Pack="true" />
-    <ClickOnceProjectToBuild Include="src/clickonce/native/build-native.proj" Pack="false" />
+    <ClickOnceProjectToBuild Include="src/clickonce/native/build-native.proj" Pack="false" Condition="'$(DisableNativeProjects)' != 'true'"/>
     <ProjectReference Include="@(ClickOnceProjectToBuild)"
                       BuildInParallel="true"
                       Test="false">
@@ -18,7 +21,7 @@
                       Pack="true"
                       Test="false"
                       BuildInParallel="false"
-                      Condition="'$(TargetOS)' == 'windows'">
+                      Condition="'$(TargetOS)' == 'windows' and '$(DisableNativeProjects)' != 'true'">
       <AdditionalProperties Condition="'$(ClickOnceConfiguration)' != ''">Configuration=$(ClickOnceConfiguration)</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,6 +1,14 @@
 <Project>
 
   <PropertyGroup>
+    <!--
+      Windows arm/arm64 jobs, as well as x86 if not building NetCoreCheck, don't have any artifacts to sign.
+      Keep it simple: allow not finding any matches here and rely on overall signing validation.
+
+      During post build signing, there are no packages to sign during SignFinalPackages.
+    -->
+    <AllowEmptySignList>true</AllowEmptySignList>
+
     <UseDotNetCertificate>true</UseDotNetCertificate>
     <!-- Don't sign and publish rid agnostic nuget packages from other builds than win-x64 when not building
         inside the VMR or producing source-build artifacts. -->


### PR DESCRIPTION
Fixes: https://github.com/dotnet/deployment-tools/issues/398

Native projects are failing due to compiler mismatch between object file produced in the build and dependent lib file produced by `runtime`. Per @MSLukeWest these projects can be disabled. If we ever need to build them again, it will be easy to re-enable them. Historically, compiler mismatch only existed during short period around .NET GA timeframe.

Additionally I've updated the Signing.props file to allow empty sign list as there won't be any artifacts for signing in x86/arm64 builds. This follows existing pattern in `runtime` and `aspnetcore`.