### PR TITLE
fix dotnet-mage tool documentation link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ all supported platforms, as well as the sources to .NET deployment tools.
 
 ## Tools documentation
 
-* [dotnet-mage](Documentation/dotnet-mage/README.md) usage patterns for dotnet-mage tool (formerly Mage.NET)
+* [dotnet-mage](docs/dotnet-mage/README.md) usage patterns for dotnet-mage tool (formerly Mage.NET)
 
 ## What is .NET?
 


### PR DESCRIPTION
dotnet-mage tool documentation link was pointed to a non-existant folder, fixed the link.