### PR TITLE
Enable native projects

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -5,7 +5,7 @@
     <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
 
     <!-- Disable native projects - see https://github.com/dotnet/deployment-tools/issues/398 -->
-    <DisableNativeProjects>true</DisableNativeProjects>
+    <DisableNativeProjects>false</DisableNativeProjects>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DotNetBuild)' != 'true'">

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -468,7 +468,6 @@ if (MSVC)
     add_compile_options(/Gz)
   endif (CLR_CMAKE_HOST_ARCH_I386)
 
-  add_compile_options($<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/GL>)
   add_compile_options($<$<OR:$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>,$<CONFIG:Checked>>:/O1>)
 
   if (CLR_CMAKE_HOST_ARCH_AMD64)


### PR DESCRIPTION
Enable native project build. This requires removal of `/GL` for release build, to disable whole-program optimization. This is needed so we can link to `libnethost.lib` which might not be produced with exactly the same compiler version.