### PR TITLE
Stable versioning for 9.0 GA

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,10 +6,9 @@
     <MajorVersion>9</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <!-- Enable to remove prerelease label. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -468,7 +468,6 @@ if (MSVC)
     add_compile_options(/Gz)
   endif (CLR_CMAKE_HOST_ARCH_I386)
 
-  add_compile_options($<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/GL>)
   add_compile_options($<$<OR:$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>,$<CONFIG:Checked>>:/O1>)
 
   if (CLR_CMAKE_HOST_ARCH_AMD64)

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.7.24407.12",
+    "version": "9.0.100",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "9.0.100-preview.7.24407.12"
+    "dotnet": "9.0.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24423.2",

--- a/src/clickonce/MageCLI/MageCLI.csproj
+++ b/src/clickonce/MageCLI/MageCLI.csproj
@@ -9,6 +9,7 @@
     <AssemblyAttributeClsCompliant>false</AssemblyAttributeClsCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <!-- Suppress obsolete warning for X509Certificate2 constructor -->
     <NoWarn>$(NoWarn);SYSLIB0057</NoWarn>
   </PropertyGroup>
 

--- a/src/clickonce/MageCLI/MageCLI.csproj
+++ b/src/clickonce/MageCLI/MageCLI.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCurrent)</TargetFramework>
+    <TargetFramework>$(NetMinimum)</TargetFramework>
+    <RollForward>Major</RollForward>
     <AssemblyName>dotnet-mage</AssemblyName>
     <OutputType>Exe</OutputType>
     <SignAssemblyAttribute>true</SignAssemblyAttribute>

--- a/src/clickonce/MageCLI/MageCLI.csproj
+++ b/src/clickonce/MageCLI/MageCLI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetMinimum)</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>dotnet-mage</AssemblyName>
     <OutputType>Exe</OutputType>
     <SignAssemblyAttribute>true</SignAssemblyAttribute>
@@ -9,6 +9,7 @@
     <AssemblyAttributeClsCompliant>false</AssemblyAttributeClsCompliant>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <NoWarn>$(NoWarn);SYSLIB0057</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Includes:
- Changes to enable stable versioning for 9.0 GA release
- Fix for native build required due to build host machine changes - a backport from main
- Suppression of SYSLIB0057 - deprecated API in 9.0 GA SDK