### PR TITLE
Update version of MicroBuildSigningPlugin to @4

### DIFF
--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -48,7 +48,7 @@ jobs:
         Token: $(dn-bot-dnceng-artifact-feeds-rw)
     - task: NuGetAuthenticate@1
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - task: MicroBuildSigningPlugin@2
+    - task: MicroBuildSigningPlugin@4
       displayName: Install MicroBuild plugin for Signing
       inputs:
         signType: $(SignType)

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -71,7 +71,7 @@ jobs:
         Token: $(dn-bot-dnceng-artifact-feeds-rw)
     - task: NuGetAuthenticate@1
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - task: MicroBuildSigningPlugin@2
+    - task: MicroBuildSigningPlugin@4
       displayName: Install MicroBuild plugin for Signing
       inputs:
         signType: $(SignType)


### PR DESCRIPTION
Current version of MicroBuildSigningPlugin is rather old and needs to be updated to the latest version, to avoid build errors - https://dev.azure.com/dnceng/internal/_build/results?buildId=2613908&view=logs&j=067ed0b4-dcd1-5080-5399-b81cd109269d&t=184ceaac-4a3e-56b9-5eef-ea35f642522e

This is already the case in `main` - updating `release/9.0` branch.