### PR TITLE
Remove comment about disabling native projects

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -4,7 +4,6 @@
     <!-- Disable target framework filtering for top level projects -->
     <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
 
-    <!-- Disable native projects - see https://github.com/dotnet/deployment-tools/issues/398 -->
     <DisableNativeProjects>false</DisableNativeProjects>
   </PropertyGroup>
 


### PR DESCRIPTION
Comment is not needed anymore as native projects were re-enabled with https://github.com/dotnet/deployment-tools/pull/406

I don't think we need any comments for this property as the name is self-explanatory.