### PR TITLE
fix alignment in the options help message

### DIFF
--- a/src/clickonce/MageCLI/Application.resx
+++ b/src/clickonce/MageCLI/Application.resx
@@ -145,7 +145,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.cs.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.cs.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.de.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.de.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.es.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.es.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.fr.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.fr.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.it.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.it.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.ja.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ja.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.ko.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ko.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.pl.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.pl.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.pt-BR.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.pt-BR.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.ru.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.ru.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.tr.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.tr.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.zh-Hans.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.zh-Hans.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf

--- a/src/clickonce/MageCLI/xlf/Application.zh-Hant.xlf
+++ b/src/clickonce/MageCLI/xlf/Application.zh-Hant.xlf
@@ -95,7 +95,7 @@
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf
@@ -134,7 +134,7 @@ Use "mage -help verbose" for more detailed help</source>
 
 
 Options
-  -Algorithm &lt;sha256RSA&gt;           -a
+  -Algorithm &lt;sha256RSA&gt;            -a
   -AppCodeBase &lt;path&gt;	            -appc
   -AppManifest &lt;path&gt;	            -appm
   -CertFile &lt;file_name&gt;	            -cf


### PR DESCRIPTION
Added a white space to fix alignment of the `-a` option- 

```
	Q:\mage>Q:\mage\artifacts\bin\MageCLI\Debug\net8.0\dotnet-mage
Commands
  -New <file_type>                -n
  -Update <file_name>             -u
  -Sign <file_name>               -s
  -ClearApplicationCache          -cc
  -Verify <manifest_file_name>    -ver
  -AddLauncher <binary_to_launch> -al
  -Help [verbose]                 -h -?



Options
  -Algorithm <sha256RSA>           -a
  -AppCodeBase <path>               -appc
  -AppManifest <path>               -appm
  -CertFile <file_name>             -cf
```