### PR TITLE
Update MSBuild versoion to 17.10.29

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <!-- MSBuild dependencies -->
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.9.5" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.29" />
 
     <!-- Runtime dependencies -->
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.0" />

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -129,14 +129,14 @@ while [[ $# > 0 ]]; do
     -pack)
       pack=true
       ;;
-    -sourcebuild|-sb)
+    -sourcebuild|-source-build|-sb)
       build=true
       source_build=true
       product_build=true
       restore=true
       pack=true
       ;;
-    -productbuild|-pb)
+    -productbuild|-product-build|-pb)
       build=true
       product_build=true
       restore=true


### PR DESCRIPTION
MSBuild version in this repo is vulnerable. Updating to next up that is fine.