### PR TITLE
Introduce repo-specific pipeline yml

### DIFF
--- a/vmr-build-pr.yml
+++ b/vmr-build-pr.yml
@@ -1,0 +1,24 @@
+trigger: none
+pr: none
+
+variables:
+- template: /eng/common/templates/variables/pool-providers.yml@self
+
+- name: skipComponentGovernanceDetection  # we run CG on internal builds only
+  value: true
+
+- name: Codeql.Enabled  # we run CodeQL on internal builds only
+  value: false
+
+resources:
+  repositories:
+  - repository: vmr
+    type: github
+    name: dotnet/dotnet
+    endpoint: dotnet
+
+stages:
+- template: /eng/pipelines/templates/stages/vmr-build.yml@vmr
+  parameters:
+    isBuiltFromVmr: false
+    scope: lite


### PR DESCRIPTION
Per discussion in https://github.com/dotnet/source-build-reference-packages/pull/1262, we are moving away from a shared YML for repo-specific VMR verification pipeline. This new model allows for easier selection of VMR verifications that should be run for each repo.

This consumes the new functionality in VMR templates implemented with https://github.com/dotnet/dotnet/pull/1189

This PR essentially copies the existing shared YML file to repo specific location.