### PR TITLE
Add DotNetRuntimeValidation tool to deployment-tools

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -37,4 +37,13 @@
                       BuildInParallel="true" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj"
+                      Pack="false"
+                      Test="false"
+                      BuildInParallel="false"
+                      Condition="'$(TargetOS)' == 'windows'">
+    </ProjectReference>
+  </ItemGroup>
+
 </Project>

--- a/Build.proj
+++ b/Build.proj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <ProjectReference Include="src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj"
-                      Pack="true"
+                      Pack="false"
                       Test="false"
                       BuildInParallel="false"
                       Condition="'$(TargetOS)' == 'windows'">

--- a/Build.proj
+++ b/Build.proj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <ProjectReference Include="src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj"
-                      Pack="false"
+                      Pack="true"
                       Test="false"
                       BuildInParallel="false"
                       Condition="'$(TargetOS)' == 'windows'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -70,7 +70,7 @@
 
   <!-- Artifacts layout. Keep these values consistent with items defined in eng/Signing.props. -->
   <PropertyGroup>
-    <ArtifactsZipsDir>$(ArtifactsDir)zips\$(Configuration)\</ArtifactsZipsDir>
+    <ArtifactsAssetsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'assets', '$(Configuration)'))</ArtifactsAssetsDir>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -68,6 +68,11 @@
     <PublishWindowsPdb>false</PublishWindowsPdb>
   </PropertyGroup>
 
+  <!-- Artifacts layout. Keep these values consistent with items defined in eng/Signing.props. -->
+  <PropertyGroup>
+    <ArtifactsZipsDir>$(ArtifactsDir)zips\$(Configuration)\</ArtifactsZipsDir>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="$(LicenseFile)"
              Pack="true"

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -16,6 +16,8 @@
     <EnableDefaultArtifacts Condition="'$(DotNetBuild)' != 'true' and
                                        '$(TargetArchitecture)' != 'x64' and
                                        '$(TargetArchitecture)' != ''">false</EnableDefaultArtifacts>
+
+    <ArtifactsAssetsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'assets', '$(Configuration)'))</ArtifactsAssetsDir>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Include DotNetRuntimeValidation .exe's explicitly -->
-    <Artifact Include="$(ArtifactsDir)zips\$(Configuration)\**\*.zip" Kind="Blob">
+    <!-- Include DotNetRuntimeValidation .zip's explicitly -->
+    <Artifact Include="$(ArtifactsAssetsDir)\**\DotNetRuntimeValidation*.zip" Kind="Blob">
       <IsShipping>false</IsShipping>
       <RelativeBlobPath>assets/$(TargetArchitecture)/%(Filename)%(Extension)</RelativeBlobPath>
     </Artifact>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <!-- Include DotNetRuntimeValidation .exe's explicitly -->
-    <Artifact Include="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe" Kind="Blob">
+    <Artifact Include="$(ArtifactsZipsDir)**\*.zip" Kind="Blob">
       <IsShipping>false</IsShipping>
       <RelativeBlobPath>assets/$(TargetArchitecture)/%(Filename)%(Extension)</RelativeBlobPath>
     </Artifact>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -33,7 +33,10 @@
 
   <ItemGroup>
     <!-- Include DotNetRuntimeValidation .exe's explicitly -->
-    <Artifact Include="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe" />
+    <Artifact Include="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe" Kind="Blob">
+      <IsShipping>false</IsShipping>
+      <UploadPathSegment>Runtime/$(TargetArchitecture)</UploadPathSegment>
+    </Artifact>
   </ItemGroup>
 
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <!-- Include DotNetRuntimeValidation .exe's explicitly -->
-    <Artifact Include="$(ArtifactsZipsDir)**\*.zip" Kind="Blob">
+    <Artifact Include="$(ArtifactsDir)zips\$(Configuration)\**\*.zip" Kind="Blob">
       <IsShipping>false</IsShipping>
       <RelativeBlobPath>assets/$(TargetArchitecture)/%(Filename)%(Extension)</RelativeBlobPath>
     </Artifact>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -35,7 +35,7 @@
     <!-- Include DotNetRuntimeValidation .exe's explicitly -->
     <Artifact Include="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe" Kind="Blob">
       <IsShipping>false</IsShipping>
-      <UploadPathSegment>Runtime/$(TargetArchitecture)</UploadPathSegment>
+      <RelativeBlobPath>assets/$(TargetArchitecture)/%(Filename)%(Extension)</RelativeBlobPath>
     </Artifact>
   </ItemGroup>
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -31,4 +31,9 @@
               PublishFlatContainer="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Include DotNetRuntimeValidation .exe's explicitly -->
+    <Artifact Include="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe" />
+  </ItemGroup>
+
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>9.0.0</ProductVersion>
+    <ProductVersion>10.0.0</ProductVersion>
     <!-- File version numbers -->
     <MajorVersion>9</MajorVersion>
     <MinorVersion>0</MinorVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
     <!-- The .NET product branding version -->
     <ProductVersion>10.0.0</ProductVersion>
     <!-- File version numbers -->
-    <MajorVersion>9</MajorVersion>
+    <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/src/DotNetRuntimeValidation/Directory.Build.targets
+++ b/src/DotNetRuntimeValidation/Directory.Build.targets
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <TempZipFolder>$(ArtifactsBinDir)DotNetRuntimeValidation\$(TargetArchitecture)\temp\zipcontents</TempZipFolder>
     <DotNetRuntimeValidationZipFilePath>$(ArtifactsAssetsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip</DotNetRuntimeValidationZipFilePath>
->$(ArtifactsAssetsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip</DotNetRuntimeValidationZipFilePath>
   </PropertyGroup>
 
   <!-- We just want to .zip these up -->

--- a/src/DotNetRuntimeValidation/Directory.Build.targets
+++ b/src/DotNetRuntimeValidation/Directory.Build.targets
@@ -4,10 +4,12 @@
 
   <PropertyGroup>
     <TempZipFolder>$(ArtifactsBinDir)DotNetRuntimeValidation\$(TargetArchitecture)\temp\zipcontents</TempZipFolder>
+    <DotNetRuntimeValidationZipFilePath>$(ArtifactsZipsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip</DotNetRuntimeValidationZipFilePath>
+>$(ArtifactsZipsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip</DotNetRuntimeValidationZipFilePath>
   </PropertyGroup>
 
   <!-- We just want to .zip these up -->
-  <Target Name="_ZipValidationExe" AfterTargets="Build">
+  <Target Name="_ZipValidationExe" AfterTargets="Build" Condition="!Exists('DotNetRuntimeValidationZipFilePath')">
     <ItemGroup>
       <RuntimeValidationSourceFiles Include="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe" />
     </ItemGroup>

--- a/src/DotNetRuntimeValidation/Directory.Build.targets
+++ b/src/DotNetRuntimeValidation/Directory.Build.targets
@@ -4,8 +4,8 @@
 
   <PropertyGroup>
     <TempZipFolder>$(ArtifactsBinDir)DotNetRuntimeValidation\$(TargetArchitecture)\temp\zipcontents</TempZipFolder>
-    <DotNetRuntimeValidationZipFilePath>$(ArtifactsZipsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip</DotNetRuntimeValidationZipFilePath>
->$(ArtifactsZipsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip</DotNetRuntimeValidationZipFilePath>
+    <DotNetRuntimeValidationZipFilePath>$(ArtifactsAssetsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip</DotNetRuntimeValidationZipFilePath>
+>$(ArtifactsAssetsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip</DotNetRuntimeValidationZipFilePath>
   </PropertyGroup>
 
   <!-- We just want to .zip these up -->
@@ -19,11 +19,11 @@
       DestinationFolder="$(TempZipFolder)" />
 
     <MakeDir
-      Directories="$(ArtifactsZipsDir)" />
+      Directories="$(ArtifactsAssetsDir)" />
 
     <ZipDirectory
       SourceDirectory="$(TempZipFolder)"
-      DestinationFile="$(ArtifactsZipsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip" />
+      DestinationFile="$(DotNetRuntimeValidationZipFilePath)" />
   </Target>
 
 </Project>

--- a/src/DotNetRuntimeValidation/Directory.Build.targets
+++ b/src/DotNetRuntimeValidation/Directory.Build.targets
@@ -8,8 +8,12 @@
 
   <!-- We just want to .zip these up -->
   <Target Name="_ZipValidationExe" AfterTargets="Build">
+    <ItemGroup>
+      <RuntimeValidationSourceFiles Include="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe" />
+    </ItemGroup>
+
     <Copy 
-      SourceFiles="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe"
+      SourceFiles="@(RuntimeValidationSourceFiles)"
       DestinationFolder="$(TempZipFolder)" />
 
     <ZipDirectory

--- a/src/DotNetRuntimeValidation/Directory.Build.targets
+++ b/src/DotNetRuntimeValidation/Directory.Build.targets
@@ -16,6 +16,9 @@
       SourceFiles="@(RuntimeValidationSourceFiles)"
       DestinationFolder="$(TempZipFolder)" />
 
+    <MakeDir
+      Directories="$(ArtifactsZipsDir)" />
+
     <ZipDirectory
       SourceDirectory="$(TempZipFolder)"
       DestinationFile="$(ArtifactsZipsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip" />

--- a/src/DotNetRuntimeValidation/Directory.Build.targets
+++ b/src/DotNetRuntimeValidation/Directory.Build.targets
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <!-- We just want to .zip these up -->
-  <Target Name="Pack">
+  <Target Name="_ZipValidationExe" AfterTargets="Build">
     <Copy 
       SourceFiles="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe"
       DestinationFolder="$(TempZipFolder)" />

--- a/src/DotNetRuntimeValidation/Directory.Build.targets
+++ b/src/DotNetRuntimeValidation/Directory.Build.targets
@@ -1,0 +1,20 @@
+<Project>
+
+  <Import Project="..\..\Directory.Build.targets" />
+
+  <PropertyGroup>
+    <TempZipFolder>$(ArtifactsBinDir)DotNetRuntimeValidation\$(TargetArchitecture)\temp\zipcontents</TempZipFolder>
+  </PropertyGroup>
+
+  <!-- We just want to .zip these up -->
+  <Target Name="Pack">
+    <Copy 
+      SourceFiles="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe"
+      DestinationFolder="$(TempZipFolder)" />
+
+    <ZipDirectory
+      SourceDirectory="$(TempZipFolder)"
+      DestinationFile="$(ArtifactsZipsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip" />
+  </Target>
+
+</Project>

--- a/src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj
+++ b/src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+    <DebugType>embedded</DebugType>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/DotNetRuntimeValidation/Program.cs
+++ b/src/DotNetRuntimeValidation/Program.cs
@@ -1,0 +1,13 @@
+try
+{
+    WebApplication.Create();
+
+    Console.WriteLine("Runtime validation success.");
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.WriteLine("Runtime validation failure.");
+    Console.WriteLine(ex.Message);
+    return 1;
+}

--- a/src/DotNetRuntimeValidation/appsettings.json
+++ b/src/DotNetRuntimeValidation/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
We hand this tool off to the 1P Gallery team every year - they use it to validate that all runtimes have been installed correctly & are working as expected on their machines. As part of the SFI push, this .exe has to be real-signed, which can no longer be done by hand (we used to hand it off manually via https://github.com/wtgodbe/DotNetRuntimeValidation). I'm proposing checking it in to this repo, rather than making a new one, as this repo is already in the VMR & has already paid the fixed start-up costs for SFI.

I also update branding to 10.0 in this PR