### PR TITLE
Fix publishing for DotNetRuntimeValidation tool

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <ProjectReference Include="src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj"
                       Pack="false"
+                      Publish="true"
                       Test="false"
                       BuildInParallel="false"
                       Condition="'$(TargetOS)' == 'windows'">

--- a/src/DotNetRuntimeValidation/Directory.Build.targets
+++ b/src/DotNetRuntimeValidation/Directory.Build.targets
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <!-- We just want to .zip these up -->
-  <Target Name="_ZipValidationExe" AfterTargets="Build" Condition="!Exists('DotNetRuntimeValidationZipFilePath')">
+  <Target Name="_ZipValidationExe" AfterTargets="DotNetPublish" Condition="!Exists('DotNetRuntimeValidationZipFilePath')">
     <ItemGroup>
-      <RuntimeValidationSourceFiles Include="$(ArtifactsBinDir)DotNetRuntimeValidation\**\DotNetRuntimeValidation.exe" />
+      <RuntimeValidationSourceFiles Include="$(PublishUrl)DotNetRuntimeValidation.exe" />
     </ItemGroup>
 
     <Copy 

--- a/src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj
+++ b/src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCurrent)</TargetFramework>
+    <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
     <DeployOnBuild>true</DeployOnBuild>

--- a/src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj
+++ b/src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
+    <EnableArcadeRuntimeIdentifierInference>true</EnableArcadeRuntimeIdentifierInference>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
     <DeployOnBuild>true</DeployOnBuild>

--- a/src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj
+++ b/src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
+    <DeployOnBuild>true</DeployOnBuild>
     <DebugType>embedded</DebugType>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
We need to .zip up the output of `dotnet publish` here, not `dotnet build`, as that gets us a standalone app that works on machines w/ the dotnet runtimes installed.