### PR TITLE
Update variable name for sign type

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -15,7 +15,7 @@ name: $(Date:yyyyMMdd)$(Rev:.r)
 variables:
   - name: TeamName
     value: dotnet-core-acquisition
-  - name: SignType
+  - name: _SignType
     value: test
 
 stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,10 +17,10 @@ variables:
 - name: 1esWindowsImage
   value: 1es-windows-2022
 - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-  - name: SignType
+  - name: _SignType
     value: test
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - name: SignType
+  - name: _SignType
     value: $[ coalesce(variables.OfficialSignType, 'real') ]
   - group: core-setup-sdl-validation
 resources:

--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -27,7 +27,7 @@ jobs:
     clean: all
   variables:
     CommonMSBuildArgs: >-
-      -c $(_BuildConfig) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:DotNetSignType=$(SignType)
+      -c $(_BuildConfig) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:DotNetSignType=$(_SignType)
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       InternalMSBuildArgs: >-
         /p:OfficialBuildId=$(Build.BuildNumber) /p:DotNetPublishUsingPipelines=true /p:Test=false

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -20,7 +20,7 @@ jobs:
     clean: all
   variables:
     CommonMSBuildArgs: >-
-      -c $(_BuildConfig) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:DotNetSignType=$(SignType)
+      -c $(_BuildConfig) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:DotNetSignType=$(_SignType)
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       InternalMSBuildArgs: >-
         /p:OfficialBuildId=$(Build.BuildNumber) /p:DotNetPublishUsingPipelines=true /p:Test=false


### PR DESCRIPTION
With https://github.com/dotnet/deployment-tools/pull/501, we are now using a new MicroBuild template that uses a differently-named variable for sign type - `_SignType` - https://github.com/dotnet/deployment-tools/blob/797d613c4425d83a11e2c38a2410bcc8a88af302/eng/common/core-templates/steps/install-microbuild.yml#L71

This updates the root and other templates to use the variable of the same name.