### PR TITLE
Prepping 1.0.2 release

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -5,10 +5,13 @@
     <TargetFrameworks>$(NetCurrent);netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
-    <MajorVersion>2</MajorVersion>
+    <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
+    <PatchVersion>2</PatchVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
 
     <!-- Always produce this package in the .NET unified product build so that it may flow to downstream consumers. -->
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
This is only used for building an official 1.0.2 copy of the package.