### PR TITLE
Fix patch numbers and stable versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,8 +5,7 @@
   <PropertyGroup>
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PatchVersion>2</PatchVersion>
     <PreReleaseVersionIteration>3</PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -8,9 +8,9 @@
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>2</PatchVersion>
+    <_PatchNumber>2</_PatchNumber>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
 
     <!-- Always produce this package in the .NET unified product build so that it may flow to downstream consumers. -->


### PR DESCRIPTION
Arcade switches between using `PatchVersion` and `_PatchNumber` for packages. Locally this now produces the desired 1.0.2 version for the package when running `-pack`.