### PR TITLE
Pre102

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,6 +6,7 @@
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>2</PatchVersion>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>3</PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,8 +5,7 @@
   <PropertyGroup>
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PatchVersion>2</PatchVersion>
     <PreReleaseVersionIteration>3</PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -8,9 +8,9 @@
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>2</PatchVersion>
+    <_PatchNumber>2</_PatchNumber>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
 
     <!-- Always produce this package in the .NET unified product build so that it may flow to downstream consumers. -->

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -8,10 +8,8 @@
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>2</PatchVersion>
-    <_PatchNumber>2</_PatchNumber>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
 
     <!-- Always produce this package in the .NET unified product build so that it may flow to downstream consumers. -->
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
One more attempt. Locally, this produces 1.0.2 package

```
D:\git\forks\deployment-tools\artifacts\packages\Debug\Shipping\Microsoft.Deployment.DotNet.Releases.1.0.2.nupkg
```

Had copilot analyze the binlogs

```
The Arcade SDK's Version.BeforeCommonTargets.targets is overwriting VersionPrefix.

The project sets:

 <MajorVersion>1</MajorVersion>
 <MinorVersion>0</MinorVersion>
 <PatchVersion>2</PatchVersion>
 <DotNetFinalVersionKind>release</DotNetFinalVersionKind>

Arcade first computes VersionPrefix = 1.0.2 from MajorVersion.MinorVersion.PatchVersion. But then, because DotNetFinalVersionKind=release means PreReleaseVersionLabel is
empty, this block fires:

 <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == ''">
   <VersionPrefix>$(_VersionPrefixMajor).$(_VersionPrefixMinor).$(_PatchNumber)</VersionPrefix>
 </PropertyGroup>

_PatchNumber is derived from OfficialBuildId (20260423.4):

 SHORT_DATE = 26*1000 + 04*50 + 23 = 26223
 _PatchNumber = (26223 - 19000) * 100 + 4 = 722304

So VersionPrefix becomes 1.0.722304 instead of 1.0.2.

This is by design for "release-only" packages (empty PreReleaseVersionLabel). Arcade assumes the patch number should be the date-encoded build number so that each
official build produces a unique, monotonically increasing version. The project's PatchVersion=2 is saved as _OriginalVersionPrefix and used only for AssemblyVersion/
FileVersion calculation, not for the package version.

If you want to keep 1.0.2 as the package version, set PreReleaseVersionLabel to a non-empty value, or explicitly set VersionPrefix after the Arcade SDK import, or
override _PatchNumber to match your intended patch.
```

