### PR TITLE
[release/10.0] - Port perf fixes to 10.0

### DIFF
--- a/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Product.cs
@@ -182,9 +182,9 @@ namespace Microsoft.Deployment.DotNet.Releases
         {
             await Utils.GetLatestFileAsync(path, downloadLatest, ReleasesJson).ConfigureAwait(false);
 
-            using TextReader reader = File.OpenText(path);
+            using FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
 
-            return await GetReleasesAsync(reader, this).ConfigureAwait(false);
+            return await GetReleasesAsync(stream, this).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -201,9 +201,8 @@ namespace Microsoft.Deployment.DotNet.Releases
             }
 
             using var stream = new MemoryStream(await Utils.s_httpClient.GetByteArrayAsync(address).ConfigureAwait(false));
-            using var reader = new StreamReader(stream);
 
-            return await GetReleasesAsync(reader, this).ConfigureAwait(false);
+            return await GetReleasesAsync(stream, this).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -224,19 +223,19 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <returns>A collection of releases. The releases are not linked to a specific <see cref="Product"/>.</returns>
         public static async Task<ReadOnlyCollection<ProductRelease>> GetReleasesAsync(string path)
         {
-            using TextReader reader = File.OpenText(path);
+            using FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
 
-            return await GetReleasesAsync(reader, null).ConfigureAwait(false);
+            return await GetReleasesAsync(stream, null).ConfigureAwait(false);
         }
 
-        private static async Task<ReadOnlyCollection<ProductRelease>> GetReleasesAsync(TextReader reader, Product product)
+        private static async Task<ReadOnlyCollection<ProductRelease>> GetReleasesAsync(Stream stream, Product product)
         {
-            if (reader == null)
+            if (stream == null)
             {
-                throw new ArgumentNullException(nameof(reader));
+                throw new ArgumentNullException(nameof(stream));
             }
 
-            using var releasesDocument = JsonDocument.Parse(await reader.ReadToEndAsync().ConfigureAwait(false));
+            using var releasesDocument = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
             JsonElement root = releasesDocument.RootElement;
             var releases = new List<ProductRelease>();
             var enumerator = root.GetProperty("releases").EnumerateArray();

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ProductCollection.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ProductCollection.cs
@@ -79,9 +79,8 @@ namespace Microsoft.Deployment.DotNet.Releases
             }
 
             using var stream = new MemoryStream(await Utils.s_httpClient.GetByteArrayAsync(releasesIndexUrl).ConfigureAwait(false));
-            using var reader = new StreamReader(stream);
 
-            return await GetAsync(reader).ConfigureAwait(false);
+            return await GetAsync(stream).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -101,19 +100,19 @@ namespace Microsoft.Deployment.DotNet.Releases
         {
             await Utils.GetLatestFileAsync(path, downloadLatest, ReleasesIndexDefaultUrl).ConfigureAwait(false);
 
-            using TextReader reader = File.OpenText(path);
+            using FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
 
-            return await GetAsync(reader).ConfigureAwait(false);
+            return await GetAsync(stream).ConfigureAwait(false);
         }
 
-        private static async Task<ProductCollection> GetAsync(TextReader reader)
+        private static async Task<ProductCollection> GetAsync(Stream stream)
         {
-            if (reader == null)
+            if (stream == null)
             {
-                throw new ArgumentNullException(nameof(reader));
+                throw new ArgumentNullException(nameof(stream));
             }
 
-            using var releasesIndexDocument = JsonDocument.Parse(await reader.ReadToEndAsync().ConfigureAwait(false));
+            using var releasesIndexDocument = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
             var root = releasesIndexDocument.RootElement.GetProperty("releases-index");
             var products = new List<Product>();
 

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseFile.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseFile.cs
@@ -16,13 +16,20 @@ namespace Microsoft.Deployment.DotNet.Releases
     {
         private static readonly SHA512 s_defaultHashAlgorithm = SHA512.Create();
 
+        private Uri _address;
+        private string _addressString;
+
         /// <summary>
         /// The URL from where to download the file.
         /// </summary>
         public Uri Address
         {
-            get;
-            private set;
+            get => _address ??= _addressString != null ? new Uri(_addressString) : null;
+            private set
+            {
+                _address = value;
+                _addressString = value?.OriginalString;
+            }
         }
 
         /// <summary>
@@ -63,7 +70,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// <param name="fileElement">The <see cref="JsonElement"/> to deserialize.</param>
         internal ReleaseFile(JsonElement fileElement)
         {
-            Address = fileElement.GetUriOrDefault("url");
+            _addressString = fileElement.GetStringOrDefault("url");
             Hash = fileElement.GetStringOrDefault("hash");
             Name = fileElement.GetStringOrDefault("name");
             Rid = fileElement.GetStringOrDefault("rid");
@@ -149,7 +156,7 @@ namespace Microsoft.Deployment.DotNet.Releases
                 Name == other.Name &&
                 Rid == other.Rid &&
                 Hash == other.Hash &&
-                Address == other.Address;
+                _addressString == other._addressString;
         }
 
         /// <summary>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseFile.cs
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/ReleaseFile.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Deployment.DotNet.Releases
         /// </summary>
         /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode() =>
-            Hash.GetHashCode() ^ Name.GetHashCode() ^ Rid.GetHashCode() ^ Address.GetHashCode();
+            Hash.GetHashCode();
 
         internal static ReleaseFile Create(string hash, string name, string rid, string address) =>
             new ReleaseFile(new Uri(address), hash, name, rid);


### PR DESCRIPTION
Porting changes from #545 to 10.0. To flow to Visual Studio, the updated assemblies need to go into the SDK template locator and MSBuild resolver.

## Customer Impact

- [X] Found internally

Reduces allocations in Visual Studio when process releases JSON data, improving performance. The library is used by both the SDK resolver and template locator. Additionally, the New Project Dialog also uses it to provide information related to EOL versions of .NET.

## Regression

- [ ] Yes
- [X] No

## Testing

Manual testing.

## Risk

Low
