### PR TITLE
V11

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- This avoids creating VS.*.symbols.nupkg packages that are identical to the original package. -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
+    <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
   </PropertyGroup>
   
   <!-- Update all Artifacts with Kind=Package to have additional metadata item Category="ToolingPackage".

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,13 +3,14 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <MajorVersion>10</MajorVersion>
+    <MajorVersion>11</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>3</PreReleaseVersionIteration>
-    <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->
-    <DotNetFinalVersionKind></DotNetFinalVersionKind>
+    <PreReleaseVersionIteration>5</PreReleaseVersionIteration>
+    <!-- Enable to remove prerelease label. -->
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -8,6 +8,7 @@
     <!-- Always produce this package in the .NET unified product build so that it may flow to downstream consumers. -->
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
+    <IsShippingPackage>true</IsShippingPackage>
     <PackageId>Microsoft.Deployment.DotNet.Releases</PackageId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableXlfLocalization>true</EnableXlfLocalization>

--- a/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -5,11 +5,6 @@
     <TargetFrameworks>$(NetCurrent);netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
-    <MajorVersion>2</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-
     <!-- Always produce this package in the .NET unified product build so that it may flow to downstream consumers. -->
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>


### PR DESCRIPTION
Fix the versioning for Microsoft.Deployment.DotNet.Releases. Currently, active release branches are all producing some form of a 2.0.0 prerelease package, none of which ship on NuGet. This is causing problems for the VMR when some 2.0.0 packages land on the wrong feed.

Starting with 10.0 and 11.0, we'll produce versioned packages that will flow to the SDK and into other products like Visual Studio (this happens as part of the template locator from the SDK that's inserted into Visual Studio). 