### PR TITLE
Fix CodeQL Python database finalize failure

### DIFF
--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -34,6 +34,7 @@ jobs:
     ${{ else }}:
       InternalMSBuildArgs: ''
     Codeql.Enabled: ${{ parameters.codeql }}
+    Codeql.Language: csharp,cpp
   steps:
   - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
     displayName: Clear NuGet http cache (if exists)

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -27,6 +27,7 @@ jobs:
     ${{ else }}:
       InternalMSBuildArgs: ''
     Codeql.Enabled: ${{ parameters.codeql }}
+    Codeql.Language: csharp,cpp
   templateContext:
     outputs:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true'), eq(variables['_BuildConfig'], 'Release')) }}:


### PR DESCRIPTION
## Summary

Fixes #519

CodeQL auto-detects Python as a scannable language due to `eng/common/cross/install-debs.py`, then fails during the Finalize step because there is no meaningful Python source to build a database from:

```
|python |database finalize failed |Database failed to finalize or no source code was built!
```

## Fix

Set `Codeql.Language: csharp,cpp` in both `eng/jobs/windows-build.yml` and `eng/jobs/windows-build-PR.yml` to restrict CodeQL to only scan the actual source languages in this repo.

This is consistent with how other dotnet repos handle this — notably `dotnet/dotnet-monitor` uses the same `Codeql.Language: csharp,cpp` pattern for the same reason.
