### PR TITLE
Fix NullReferenceException in MageCLI Validate for manifests without entry point

### DIFF
--- a/src/clickonce/MageCLI/Command.cs
+++ b/src/clickonce/MageCLI/Command.cs
@@ -1634,7 +1634,10 @@ namespace Microsoft.Deployment.MageCLI
 
                 manifest.Validate();
 
+                // EntryPoint can be null for manifests that don't reference an entry-point
+                // assembly (e.g. those using customHostRequired), so guard before dereferencing.
                 bool launcherBasedDeployment =
+                    manifest.EntryPoint != null && manifest.EntryPoint.TargetPath != null &&
                     string.Equals(manifest.EntryPoint.TargetPath.ToLower(), LauncherUtil.LauncherFilename.ToLower(), StringComparison.OrdinalIgnoreCase);
 
                 // Prints out all the information.


### PR DESCRIPTION
## Summary

Fixes #313

`Command.Validate` dereferenced `manifest.EntryPoint.TargetPath` without a null check. Manifests that do not reference an entry-point assembly — for example those using [`customHostRequired`](https://learn.microsoft.com/en-us/visualstudio/deployment/entrypoint-element-clickonce-application?view=vs-2022#customhostrequired) — have a `null` `EntryPoint`, which caused a `NullReferenceException` during validation (including when running with `-Update`):

```
Object reference not set to an instance of an object.
   at Microsoft.Deployment.MageCLI.Command.Validate(Manifest manifest) in Command.cs
   at Microsoft.Deployment.MageCLI.Command.ExecuteManifestRelated()
   at Microsoft.Deployment.MageCLI.Command.Execute()
   at Microsoft.Deployment.MageCLI.Application.Main(String[] args)
```

## Fix

Guard `EntryPoint` and `TargetPath` against null before dereferencing, consistent with the null checks already used everywhere else `EntryPoint` is accessed (see `AppMan.cs`). When there is no entry point, the deployment is not launcher-based, so `launcherBasedDeployment` is correctly `false`.

## Testing

Builds cleanly (`build.cmd -restore -build` on the MageCLI project, 0 warnings / 0 errors). There is no existing unit-test project for MageCLI, so no automated test was added.
