### PR TITLE
Upgrade to V4 Arcade publishing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.46" />
 
     <!-- Runtime dependencies -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.4" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" /> <!-- Pin transitive dependency to avoid vulnerable 8.0.0 version. -->
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ extends:
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:
-            publishUsingPipelines: true
+            publishingVersion: 4
             publishAssetsImmediately: true
             dependsOn:
             - win_x64
@@ -97,6 +97,7 @@ extends:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
+          publishingInfraVersion: 4
           enableSymbolValidation: false
           enableSigningValidation: false
           enableNugetValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- This avoids creating VS.*.symbols.nupkg packages that are identical to the original package. -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
+    <PublishingVersion>4</PublishingVersion>
   </PropertyGroup>
   
   <!-- Update all Artifacts with Kind=Package to have additional metadata item Category="ToolingPackage".

--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -30,7 +30,7 @@ jobs:
       -c $(_BuildConfig) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:DotNetSignType=$(_SignType)
     ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       InternalMSBuildArgs: >-
-        /p:OfficialBuildId=$(Build.BuildNumber) /p:DotNetPublishUsingPipelines=true /p:Test=false
+        /p:OfficialBuildId=$(Build.BuildNumber) /p:Test=false
     ${{ else }}:
       InternalMSBuildArgs: ''
     Codeql.Enabled: ${{ parameters.codeql }}

--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -51,10 +51,6 @@ jobs:
   - script: >-
       eng\common\cibuild.cmd $(CommonMSBuildArgs) $(InternalMSBuildArgs)
     displayName: Build
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/steps/generate-sbom.yml@self
-      parameters:
-        name: Generate_SBOM_${{ parameters.name }}
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true')) }}:
     - task: NuGetAuthenticate@1
       displayName: 'Authenticate to DevDiv VS feed (WIF)'

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -71,10 +71,6 @@ jobs:
     - script: >-
         eng\common\cibuild.cmd $(CommonMSBuildArgs) $(InternalMSBuildArgs)
       displayName: Build
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: /eng/common/templates-official/steps/generate-sbom.yml@self
-        parameters:
-          name: Generate_SBOM_${{ parameters.name }}
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true')) }}:
       - task: NuGetAuthenticate@1
         displayName: 'Authenticate to DevDiv VS feed (WIF)'

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -45,15 +45,7 @@ jobs:
     - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
       displayName: Clear NuGet http cache (if exists)
     - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        condition: eq(variables['Agent.OS'], 'Windows_NT')
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config******
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      - task: NuGetAuthenticate@1
+      - template: /eng/common/templates-official/steps/enable-internal-sources.yml@self
     - script: >-
         eng\common\cibuild.cmd $(CommonMSBuildArgs) $(InternalMSBuildArgs)
       displayName: Build

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -6,139 +6,167 @@ parameters:
   timeoutInMinutes: 120
   codeql: false
 jobs:
-- job: ${{ parameters.name }}
-  displayName: ${{ parameters.displayName }}
-  timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
-  strategy:
-    matrix:
-      release:
-        _BuildConfig: Release
-      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-        debug:
-          _BuildConfig: Debug
-  workspace:
-    clean: all
-  variables:
-    CommonMSBuildArgs: >-
-      -c $(_BuildConfig) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:DotNetSignType=$(_SignType)
-    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      InternalMSBuildArgs: >-
-        /p:OfficialBuildId=$(Build.BuildNumber) /p:DotNetPublishUsingPipelines=true /p:Test=false
-    ${{ else }}:
-      InternalMSBuildArgs: ''
-    Codeql.Enabled: ${{ parameters.codeql }}
-    Codeql.Language: csharp,cpp
-  templateContext:
-    outputs:
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Release'), eq(variables['StagingArtifactsFolderExist'], True)) }}:
+- template: /eng/common/templates-official/job/job.yml@self
+  parameters:
+    name: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    publishingVersion: 4
+    enablePublishing: ${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
+    enableMicrobuild: true
+    microbuildUseESRP: true
+    workspace:
+      clean: all
+    strategy:
+      matrix:
+        release:
+          _BuildConfig: Release
+        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          debug:
+            _BuildConfig: Debug
+    variables:
+    - CommonMSBuildArgs: >-
+        -c $(_BuildConfig) /p:TargetArchitecture=${{ parameters.targetArchitecture }} /p:DotNetSignType=$(_SignType)
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - InternalMSBuildArgs: >-
+          /p:OfficialBuildId=$(Build.BuildNumber) /p:Test=false
+    - ${{ else }}:
+      - InternalMSBuildArgs: ''
+    - Codeql.Enabled: ${{ parameters.codeql }}
+    - Codeql.Language: csharp,cpp
+    templateContext:
+      outputs:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Release'), eq(variables['StagingArtifactsFolderExist'], True)) }}:
+        - output: pipelineArtifact
+          displayName: 'Publish Artifacts'
+          condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
+          targetPath: '$(Build.StagingDirectory)/Artifacts'
+          artifactName: IntermediateUnsignedArtifacts
+          artifactType: container
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Release')) }}:
+        - output: pipelineArtifact
+          displayName: 'Publish PdbArtifacts'
+          condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+          targetPath: '$(Build.StagingDirectory)/PdbArtifacts'
+          artifactName: PdbArtifacts-${{ parameters.name }}
+          artifactType: container
       - output: pipelineArtifact
-        displayName: 'Publish Artifacts'
-        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
-        targetPath: '$(Build.StagingDirectory)/Artifacts'
-        artifactName: IntermediateUnsignedArtifacts
-        artifactType: container
-    - output: pipelineArtifact
-      displayName: 'Publish BuildLogs'
-      condition: succeededOrFailed()
-      targetPath: '$(Build.StagingDirectory)/BuildLogs'
-      artifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
-  steps:
-  - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
-    displayName: Clear NuGet http cache (if exists)
-  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - task: PowerShell@2
-      displayName: Setup Private Feeds Credentials
-      condition: eq(variables['Agent.OS'], 'Windows_NT')
-      inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-      env:
-        Token: $(dn-bot-dnceng-artifact-feeds-rw)
-    - task: NuGetAuthenticate@1
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/core-templates/steps/install-microbuild.yml
-      parameters:
-        enableMicrobuild: true
-        microbuildUseESRP: true
-        continueOnError: false
-  - script: >-
-      eng\common\cibuild.cmd $(CommonMSBuildArgs) $(InternalMSBuildArgs)
-    displayName: Build
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates-official/steps/generate-sbom.yml@self
-      parameters:
-        name: Generate_SBOM_${{ parameters.name }}
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true')) }}:
-    - task: NuGetAuthenticate@1
-      displayName: 'Authenticate to DevDiv VS feed (WIF)'
-      inputs:
-        azureDevOpsServiceConnection: 'dnceng-devdiv-vs-feed-push'
-        feedUrl: 'https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json'
-    - powershell: |
-        $packages = Get-ChildItem "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.NETCoreCheck.*.nupkg"
-        foreach ($pkg in $packages) {
-          Write-Host "Pushing $($pkg.Name)..."
-          dotnet nuget push $pkg.FullName --source "https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json" --api-key AzureDevOps --skip-duplicate
-        }
-      displayName: 'Push NETCoreCheck NuPkgs to DevDiv VS feed'
-      condition: succeeded()
-    - ${{ if eq(parameters.targetArchitecture, 'x64') }}:
+        displayName: 'Publish BuildLogs'
+        condition: succeededOrFailed()
+        targetPath: '$(Build.StagingDirectory)/BuildLogs'
+        artifactName: Logs-${{ parameters.name }}-$(_BuildConfig)
+    steps:
+    - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
+      displayName: Clear NuGet http cache (if exists)
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      - task: PowerShell@2
+        displayName: Setup Private Feeds Credentials
+        condition: eq(variables['Agent.OS'], 'Windows_NT')
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config******
+        env:
+          Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - task: NuGetAuthenticate@1
+    - script: >-
+        eng\common\cibuild.cmd $(CommonMSBuildArgs) $(InternalMSBuildArgs)
+      displayName: Build
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+        parameters:
+          name: Generate_SBOM_${{ parameters.name }}
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['DisableVSPublish'], 'true')) }}:
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate to DevDiv VS feed (WIF)'
+        inputs:
+          azureDevOpsServiceConnection: 'dnceng-devdiv-vs-feed-push'
+          feedUrl: 'https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json'
       - powershell: |
-          $packages = Get-ChildItem "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.NetCore.Launcher.*.nupkg"
+          $packages = Get-ChildItem "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.NETCoreCheck.*.nupkg"
           foreach ($pkg in $packages) {
             Write-Host "Pushing $($pkg.Name)..."
             dotnet nuget push $pkg.FullName --source "https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json" --api-key AzureDevOps --skip-duplicate
           }
-        displayName: 'Push NetCore.Launcher NuPkgs to DevDiv VS feed'
+        displayName: 'Push NETCoreCheck NuPkgs to DevDiv VS feed'
         condition: succeeded()
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - powershell: |
-        $folderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
-        Write-Output "##vso[task.setvariable variable=ArtifactsPackagesFolderExists]$folderExists"
-      displayName: Detect Packages subdirectory
+      - ${{ if eq(parameters.targetArchitecture, 'x64') }}:
+        - powershell: |
+            $packages = Get-ChildItem "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/*/VS.Redist.Common.NetCore.Launcher.*.nupkg"
+            foreach ($pkg in $packages) {
+              Write-Host "Pushing $($pkg.Name)..."
+              dotnet nuget push $pkg.FullName --source "https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json" --api-key AzureDevOps --skip-duplicate
+            }
+          displayName: 'Push NetCore.Launcher NuPkgs to DevDiv VS feed'
+          condition: succeeded()
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - powershell: |
+          $folderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
+          Write-Output "##vso[task.setvariable variable=ArtifactsPackagesFolderExists]$folderExists"
+        displayName: Detect Packages subdirectory
+      - task: CopyFiles@2
+        displayName: Prepare job-specific Artifacts subdirectory
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+          Contents: |
+            Shipping/**/*
+            NonShipping/**/*
+          TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
+          CleanTargetFolder: true
+        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsPackagesFolderExists'], True))
+      - powershell: |
+          $folderExists = Test-Path -Path "$(Build.StagingDirectory)/Artifacts"
+          Write-Output "##vso[task.setvariable variable=StagingArtifactsFolderExist]$folderExists"
+        displayName: Detect Staged Artifacts subdirectory
+      - powershell: |
+          $packagesRoot = "$(Build.ArtifactStagingDirectory)/artifacts/packages"
+          Remove-Item -Recurse -Force -ErrorAction Ignore $packagesRoot
+
+          foreach ($packageKind in @("Shipping", "NonShipping")) {
+            $source = "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/$packageKind"
+            if (Test-Path $source) {
+              $destination = Join-Path $packagesRoot $packageKind.ToLowerInvariant()
+              New-Item -ItemType Directory -Force $destination | Out-Null
+              Copy-Item -Path (Join-Path $source "*") -Destination $destination -Recurse -Force
+            }
+          }
+        displayName: Stage V4 packages for Arcade wrapper publishing
+        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsPackagesFolderExists'], True))
+      - task: CopyFiles@2
+        displayName: Stage V4 asset manifests for Arcade wrapper publishing
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/AssetManifest'
+          Contents: '*.xml'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/manifests'
+          CleanTargetFolder: true
+        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+      - task: CopyFiles@2
+        displayName: Prepare job-specific PdbArtifacts subdirectory
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/artifacts/SymStore/$(_BuildConfig)'
+          Contents: |
+            **/*
+          TargetFolder: '$(Build.StagingDirectory)/PdbArtifacts/${{ parameters.name }}'
+          CleanTargetFolder: true
+        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+    - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: PublishTestResults@2
+        displayName: Publish Test Results
+        inputs:
+          testResultsFormat: 'xUnit'
+          testResultsFiles: '*.xml'
+          searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+          mergeTestResults: true
+          testRunTitle: ${{ parameters.name }}-$(_BuildConfig)
+        continueOnError: true
+        condition: always()
     - task: CopyFiles@2
-      displayName: Prepare job-specific Artifacts subdirectory
+      displayName: Prepare BuildLogs staging directory
       inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+        SourceFolder: '$(Build.SourcesDirectory)'
         Contents: |
-          Shipping/**/*
-          NonShipping/**/*
-        TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
+          **/*.log
+          **/*.binlog
+        TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
         CleanTargetFolder: true
-      condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsPackagesFolderExists'], True))
-    - powershell: |
-        $folderExists = Test-Path -Path "$(Build.StagingDirectory)/Artifacts"
-        Write-Output "##vso[task.setvariable variable=StagingArtifactsFolderExist]$folderExists"
-      displayName: Detect Staged Artifacts subdirectory
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - task: CopyFiles@2
-      displayName: Prepare job-specific PdbArtifacts subdirectory
-      inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/artifacts/SymStore/$(_BuildConfig)'
-        Contents: |
-          **/*
-        TargetFolder: '$(Build.StagingDirectory)/PdbArtifacts/${{ parameters.name }}'
-        CleanTargetFolder: true
-      condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - task: PublishTestResults@2
-      displayName: Publish Test Results
-      inputs:
-        testResultsFormat: 'xUnit'
-        testResultsFiles: '*.xml'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        mergeTestResults: true
-        testRunTitle: ${{ parameters.name }}-$(_BuildConfig)
       continueOnError: true
-      condition: always()
-  - task: CopyFiles@2
-    displayName: Prepare BuildLogs staging directory
-    inputs:
-      SourceFolder: '$(Build.SourcesDirectory)'
-      Contents: |
-        **/*.log
-        **/*.binlog
-      TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
-      CleanTargetFolder: true
-    continueOnError: true
-    condition: succeededOrFailed()
+      condition: succeededOrFailed()

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -36,20 +36,6 @@ jobs:
     - Codeql.Language: csharp,cpp
     templateContext:
       outputs:
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Release'), eq(variables['StagingArtifactsFolderExist'], True)) }}:
-        - output: pipelineArtifact
-          displayName: 'Publish Artifacts'
-          condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['StagingArtifactsFolderExist'], True))
-          targetPath: '$(Build.StagingDirectory)/Artifacts'
-          artifactName: IntermediateUnsignedArtifacts
-          artifactType: container
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['_BuildConfig'], 'Release')) }}:
-        - output: pipelineArtifact
-          displayName: 'Publish PdbArtifacts'
-          condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-          targetPath: '$(Build.StagingDirectory)/PdbArtifacts'
-          artifactName: PdbArtifacts-${{ parameters.name }}
-          artifactType: container
       - output: pipelineArtifact
         displayName: 'Publish BuildLogs'
         condition: succeededOrFailed()
@@ -94,56 +80,6 @@ jobs:
             }
           displayName: 'Push NetCore.Launcher NuPkgs to DevDiv VS feed'
           condition: succeeded()
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - powershell: |
-          $folderExists = Test-Path -Path "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)"
-          Write-Output "##vso[task.setvariable variable=ArtifactsPackagesFolderExists]$folderExists"
-        displayName: Detect Packages subdirectory
-      - task: CopyFiles@2
-        displayName: Prepare job-specific Artifacts subdirectory
-        inputs:
-          SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
-          Contents: |
-            Shipping/**/*
-            NonShipping/**/*
-          TargetFolder: '$(Build.StagingDirectory)/Artifacts/${{ parameters.name }}'
-          CleanTargetFolder: true
-        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsPackagesFolderExists'], True))
-      - powershell: |
-          $folderExists = Test-Path -Path "$(Build.StagingDirectory)/Artifacts"
-          Write-Output "##vso[task.setvariable variable=StagingArtifactsFolderExist]$folderExists"
-        displayName: Detect Staged Artifacts subdirectory
-      - powershell: |
-          $packagesRoot = "$(Build.ArtifactStagingDirectory)/artifacts/packages"
-          Remove-Item -Recurse -Force -ErrorAction Ignore $packagesRoot
-
-          foreach ($packageKind in @("Shipping", "NonShipping")) {
-            $source = "$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/$packageKind"
-            if (Test-Path $source) {
-              $destination = Join-Path $packagesRoot $packageKind.ToLowerInvariant()
-              New-Item -ItemType Directory -Force $destination | Out-Null
-              Copy-Item -Path (Join-Path $source "*") -Destination $destination -Recurse -Force
-            }
-          }
-        displayName: Stage V4 packages for Arcade wrapper publishing
-        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), eq(variables['ArtifactsPackagesFolderExists'], True))
-      - task: CopyFiles@2
-        displayName: Stage V4 asset manifests for Arcade wrapper publishing
-        inputs:
-          SourceFolder: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/AssetManifest'
-          Contents: '*.xml'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/manifests'
-          CleanTargetFolder: true
-        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-      - task: CopyFiles@2
-        displayName: Prepare job-specific PdbArtifacts subdirectory
-        inputs:
-          SourceFolder: '$(Build.SourcesDirectory)/artifacts/SymStore/$(_BuildConfig)'
-          Contents: |
-            **/*
-          TargetFolder: '$(Build.StagingDirectory)/PdbArtifacts/${{ parameters.name }}'
-          CleanTargetFolder: true
-        condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
     - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
       - task: PublishTestResults@2
         displayName: Publish Test Results


### PR DESCRIPTION
## Summary
- Upgrade deployment-tools to Arcade V4 publishing.
- Set `PublishingVersion` to 4 and wire official publish-build-assets/post-build templates for V4.
- Route Windows build jobs through `/eng/common/templates-official/job/job.yml@self` so Arcade's wrapper emits the V4 `$(System.PhaseName)_Artifacts` output.
- Retain minimal staging of packages/manifests into `$(Build.ArtifactStagingDirectory)/artifacts` because this repo's build writes them under repo `artifacts/` rather than directly into the wrapper staging directory.
- Update `System.Security.Cryptography.Xml` to 8.0.4 to unblock current official NuGet audit errors.

## Validation tracking
- Official validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=3023306 (succeeded)
- Promotion build: https://dev.azure.com/dnceng/internal/_build/results?buildId=3023338 (partiallySucceeded with only expected V3 fallback artifact warnings)
- Asset comparison: baseline official build 20260709.1 / BAR 322309 vs new build 20260715.2 / BAR 323031 - asset counts matched (13 vs 13) and normalized identities aligned.