### PR TITLE
Complete Arcade authentication migrations

### DIFF
--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -113,10 +113,13 @@ try {
     $installations = @()
     $page = 1
     do {
-        $pageInstallations = @(Invoke-RestMethod `
+        # Assign the response before wrapping it in @(). PowerShell otherwise
+        # preserves a top-level JSON array as one nested pipeline object.
+        $pageResponse = Invoke-RestMethod `
             -Uri "https://api.github.com/app/installations?per_page=100&page=$page" `
             -Headers $headers `
-            -Method Get)
+            -Method Get
+        $pageInstallations = @($pageResponse)
         $installations += $pageInstallations
         $page++
     } while ($pageInstallations.Count -eq 100)
@@ -125,12 +128,19 @@ catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."
     exit 1
 }
-$installation = $installations | Where-Object { $_.account.login -ieq $InstallationOwner } | Select-Object -First 1
-if (-not $installation) {
+$matchingInstallations = @($installations | Where-Object { $_.account.login -ieq $InstallationOwner })
+if ($matchingInstallations.Count -eq 0) {
     $found = ($installations | ForEach-Object { $_.account.login }) -join ', '
     Write-PipelineTelemetryError -Category 'Build' -Message "No installation found for '$InstallationOwner'. App is installed on: $found"
     exit 1
 }
+if ($matchingInstallations.Count -ne 1) {
+    $matchingIds = ($matchingInstallations | ForEach-Object { $_.id }) -join ', '
+    Write-PipelineTelemetryError -Category 'Build' -Message "Found multiple installations for '$InstallationOwner': $matchingIds"
+    exit 1
+}
+$installation = $matchingInstallations[0]
+Write-Host "Using installation $($installation.id) for '$($installation.account.login)'."
 
 try {
     $tokenResponse = Invoke-RestMethod `

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -173,7 +173,7 @@ if ($disabledSources -ne $null) {
     Write-Host "Checking for any darc-int disabled package sources in the disabledPackageSources node"
     EnableMaestroInternalPackageSources -DisabledPackageSources $disabledSources -Creds $creds -Credential $feedCredential
 }
-$dotnetVersions = @('5','6','7','8','9','10')
+$dotnetVersions = @('5','6','7','8','9','10','11')
 
 foreach ($dotnetVersion in $dotnetVersions) {
     $feedPrefix = "dotnet" + $dotnetVersion;

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -169,7 +169,7 @@ if [ "$?" == "0" ]; then
     EnableMaestroInternalPackageSources
 fi
 
-DotNetVersions=('5' '6' '7' '8' '9' '10')
+DotNetVersions=('5' '6' '7' '8' '9' '10' '11')
 
 for DotNetVersion in ${DotNetVersions[@]} ; do
     FeedPrefix="dotnet${DotNetVersion}";

--- a/eng/jobs/windows-build-PR.yml
+++ b/eng/jobs/windows-build-PR.yml
@@ -44,9 +44,7 @@ jobs:
       condition: eq(variables['Agent.OS'], 'Windows_NT')
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-      env:
-        Token: $(dn-bot-dnceng-artifact-feeds-rw)
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
     - task: NuGetAuthenticate@1
   - script: >-
       eng\common\cibuild.cmd $(CommonMSBuildArgs) $(InternalMSBuildArgs)

--- a/eng/jobs/windows-build.yml
+++ b/eng/jobs/windows-build.yml
@@ -51,9 +51,7 @@ jobs:
       condition: eq(variables['Agent.OS'], 'Windows_NT')
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-      env:
-        Token: $(dn-bot-dnceng-artifact-feeds-rw)
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config
     - task: NuGetAuthenticate@1
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/core-templates/steps/install-microbuild.yml


### PR DESCRIPTION
## Summary
- remove the retired `dn-bot-dnceng-artifact-feeds-rw` PAT from internal Windows builds so `NuGetAuthenticate@1` uses build identity
- apply Arcade's GitHub App installation-selection fix from dotnet/arcade#17312
- recognize .NET 11 internal and transport feeds, matching dotnet/arcade#17375

## Context
PR #570 syncs `main` into `release/releases-json/1.0.2`, but its public validation does not exercise internal feed authentication or the internal OneLoc GitHub App path. These fixes should land in `main` first and then be incorporated by refreshing #570.

The `eng/common` changes are exact copies of fixes already made upstream in Arcade; future source flow will preserve them.

## Validation
- `SetupNugetSources.ps1` added `dotnet11-internal` and `dotnet11-internal-transport` without a PAT
- PowerShell parser validation passed for the modified scripts
- Bash syntax validation passed for `SetupNugetSources.sh`