### PR TITLE
Update System.Security.Cryptography.Xml to 8.0.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.46" />
 
     <!-- Runtime dependencies -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.4" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" /> <!-- Pin transitive dependency to avoid vulnerable 8.0.0 version. -->
 


### PR DESCRIPTION
Updated System.Security.Cryptography.Xml package version to 8.0.4. We lift this version in the source build but the local repo build doesn't so we need to update it here.